### PR TITLE
Improve screener configuration and logging

### DIFF
--- a/screener.py
+++ b/screener.py
@@ -1,5 +1,6 @@
 # screener.py with debugging and robust scoring
 import os
+import logging
 import pandas as pd
 from alpaca.trading.client import TradingClient
 from alpaca.data.historical import StockHistoricalDataClient
@@ -8,12 +9,28 @@ from alpaca.data.timeframe import TimeFrame
 from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s"
+)
+
 # Load environment variables
-dotenv_path = os.path.expanduser('/home/RasPatrick/jbravo_screener/.env')
-load_dotenv(dotenv_path)
+env_path = os.environ.get("BRAVO_ENV_PATH")
+if not env_path:
+    cwd_env = os.path.join(os.getcwd(), ".env")
+    default_env = os.path.expanduser("~/jbravo_screener/.env")
+    env_path = cwd_env if os.path.exists(cwd_env) else default_env
+
+logging.info("Loading environment variables from %s", env_path)
+load_dotenv(env_path)
 
 API_KEY = os.getenv("APCA_API_KEY_ID")
 API_SECRET = os.getenv("APCA_API_SECRET_KEY")
+
+if not API_KEY or not API_SECRET:
+    logging.error("Missing API credentials. Please set APCA_API_KEY_ID and APCA_API_SECRET_KEY in the .env file.")
+    raise SystemExit(1)
 
 # Initialize Alpaca clients
 trading_client = TradingClient(API_KEY, API_SECRET)
@@ -27,7 +44,7 @@ ranked_candidates = []
 
 # Screening and ranking criteria
 for symbol in symbols:
-    print(f"[INFO] Processing {symbol}...")
+    logging.info("Processing %s...", symbol)
     try:
         request_params = StockBarsRequest(
             symbol_or_symbols=symbol,
@@ -38,7 +55,7 @@ for symbol in symbols:
         bars = data_client.get_stock_bars(request_params).df
 
         if len(bars) < 200:
-            print(f"[WARN] Skipping {symbol}: insufficient data ({len(bars)} bars)")
+            logging.warning("Skipping %s: insufficient data (%d bars)", symbol, len(bars))
             continue
 
         df = bars.copy().sort_index()
@@ -70,12 +87,14 @@ for symbol in symbols:
             })
 
     except Exception as e:
-        print(f"[ERROR] {symbol} failed: {e}")
+        logging.error("%s failed: %s", symbol, e)
 
 # Convert to DataFrame and rank
 ranked_df = pd.DataFrame(ranked_candidates)
-ranked_df.sort_values(by='total_score', ascending=False, inplace=True)
+ranked_df.sort_values(by="total_score", ascending=False, inplace=True)
 
-# Output top 15 candidates
-ranked_df.head(15).to_csv("top_candidates.csv", index=False)
-print("[INFO] Top 15 ranked candidates saved to top_candidates.csv")
+if ranked_df.empty:
+    logging.warning("No candidates met the screening criteria. CSV file not created.")
+else:
+    ranked_df.head(15).to_csv("top_candidates.csv", index=False)
+    logging.info("Top 15 ranked candidates saved to top_candidates.csv")


### PR DESCRIPTION
## Summary
- load `.env` from configurable path using `BRAVO_ENV_PATH`
- add logging and validation for API credentials
- switch from print statements to the `logging` module
- warn if no candidates meet criteria instead of writing an empty CSV

## Testing
- `python -m py_compile screener.py`

------
https://chatgpt.com/codex/tasks/task_e_686b37e467a48331830d3e03482e3191