### PR TITLE
Improve dashboard and open positions handling

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -14,9 +14,36 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 def data_path(filename):
     return os.path.join(BASE_DIR, 'data', filename)
 
-def load_csv(filename):
+def load_csv(filename, required_columns=None):
+    """Load a CSV file and validate required columns.
+
+    Returns a tuple of (DataFrame, alert_component). If the file is missing
+    or columns are absent, an empty DataFrame and a Dash alert component are
+    returned so the UI can gracefully inform the user.
+    """
     filepath = data_path(filename)
-    return pd.read_csv(filepath) if os.path.exists(filepath) else pd.DataFrame()
+    if not os.path.exists(filepath):
+        alert = dbc.Alert(f"{filename} not found.", color="warning", className="m-2")
+        return pd.DataFrame(), alert
+
+    try:
+        df = pd.read_csv(filepath)
+    except Exception as e:
+        alert = dbc.Alert(f"Error reading {filename}: {e}", color="danger", className="m-2")
+        return pd.DataFrame(), alert
+
+    if required_columns:
+        missing = [c for c in required_columns if c not in df.columns]
+        if missing:
+            msg = f"{filename} missing columns: {', '.join(missing)}"
+            alert = dbc.Alert(msg, color="warning", className="m-2")
+            return pd.DataFrame(), alert
+
+    if df.empty:
+        alert = dbc.Alert(f"No data available in {filename}.", color="warning", className="m-2")
+        return df, alert
+
+    return df, None
 
 app = Dash(__name__, external_stylesheets=[
     dbc.themes.DARKLY,
@@ -52,7 +79,9 @@ app.layout = dbc.Container([
 )
 def render_tab(tab):
     if tab == 'tab-overview':
-        trades_df = load_csv('trades_log.csv')
+        trades_df, alert = load_csv('trades_log.csv', required_columns=['pnl', 'entry_time'])
+        if alert:
+            return alert
         trades_df['cumulative_pnl'] = trades_df['pnl'].cumsum()
         equity_fig = px.line(trades_df, x='entry_time', y='cumulative_pnl', template='plotly_dark', title='Equity Curve')
 
@@ -66,20 +95,31 @@ def render_tab(tab):
         return dbc.Container([kpis, dcc.Graph(figure=equity_fig)], fluid=True)
 
     elif tab == 'tab-trades':
-        trades_df = load_csv('trades_log.csv')
+        trades_df, alert = load_csv('trades_log.csv', required_columns=['symbol', 'entry_time'])
+        if alert:
+            return alert
+        if 'pnl' not in trades_df.columns:
+            trades_df['pnl'] = 0.0
         trades_df['entry_time'] = pd.to_datetime(trades_df['entry_time']).dt.strftime('%Y-%m-%d %H:%M')
         columns = [{'name': c.replace('_',' ').title(), 'id': c} for c in trades_df.columns]
         return dash_table.DataTable(data=trades_df.to_dict('records'), columns=columns, page_size=20, filter_action="native", sort_action="native",
                                     style_table={'overflowX':'auto'}, style_cell={'backgroundColor':'#212529','color':'#E0E0E0'})
 
     elif tab == 'tab-positions':
-        positions_df = load_csv('open_positions.csv')
+        positions_df, alert = load_csv('open_positions.csv', required_columns=['symbol'])
+        if alert:
+            return alert
+        pnl_col = 'unrealized_pl' if 'unrealized_pl' in positions_df.columns else 'pnl' if 'pnl' in positions_df.columns else None
+        if pnl_col is None:
+            return dbc.Alert("open_positions.csv missing unrealized P/L data.", color="warning", className="m-2")
         columns = [{'name': c.replace('_',' ').title(), 'id': c} for c in positions_df.columns]
-        positions_fig = px.bar(positions_df, x='symbol', y='pnl', color=positions_df['pnl']>0, color_discrete_map={True:'#4DB6AC',False:'#E57373'}, template='plotly_dark', title='Open Positions P/L')
+        positions_fig = px.bar(positions_df, x='symbol', y=pnl_col, color=positions_df[pnl_col]>0, color_discrete_map={True:'#4DB6AC',False:'#E57373'}, template='plotly_dark', title='Open Positions P/L')
         return dbc.Container([dcc.Graph(figure=positions_fig), dash_table.DataTable(data=positions_df.to_dict('records'), columns=columns, style_table={'overflowX':'auto'}, style_cell={'backgroundColor':'#212529','color':'#E0E0E0'})])
 
     elif tab == 'tab-symbols':
-        trades_df = load_csv('trades_log.csv')
+        trades_df, alert = load_csv('trades_log.csv', required_columns=['symbol', 'pnl'])
+        if alert:
+            return alert
         symbol_perf = trades_df.groupby('symbol').agg({'pnl':['count','mean','sum']}).reset_index()
         symbol_perf.columns = ['Symbol','Trades','Avg P/L','Total P/L']
         symbol_fig = px.bar(symbol_perf, x='Symbol', y='Total P/L', color='Total P/L', template='plotly_dark', title='Performance by Symbol')

--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -48,6 +48,30 @@ def get_open_positions():
     positions = alpaca.list_positions()
     return {p.symbol: p for p in positions}
 
+def save_open_positions_csv():
+    """Fetch current open positions from Alpaca and save to CSV."""
+    try:
+        positions = alpaca.list_positions()
+        data = []
+        for p in positions:
+            data.append({
+                'symbol': p.symbol,
+                'qty': p.qty,
+                'avg_entry_price': p.avg_entry_price,
+                'current_price': p.current_price,
+                'unrealized_pl': p.unrealized_pl
+            })
+
+        df = pd.DataFrame(data, columns=['symbol', 'qty', 'avg_entry_price', 'current_price', 'unrealized_pl'])
+        if df.empty:
+            df = pd.DataFrame(columns=['symbol', 'qty', 'avg_entry_price', 'current_price', 'unrealized_pl'])
+
+        csv_path = os.path.join(BASE_DIR, 'data', 'open_positions.csv')
+        df.to_csv(csv_path, index=False)
+        logging.info("Saved open positions to %s", csv_path)
+    except Exception as e:
+        logging.error("Failed to save open positions: %s", e)
+
 def allocate_position(symbol):
     open_positions = get_open_positions()
     if symbol in open_positions or len(open_positions) >= MAX_OPEN_TRADES:
@@ -150,5 +174,6 @@ if __name__ == '__main__':
     submit_trades()
     attach_trailing_stops()
     daily_exit_check()
+    save_open_positions_csv()
     logging.info("Pre-market trade execution script complete")
 


### PR DESCRIPTION
## Summary
- handle missing files/columns gracefully in dashboard
- fetch open positions after executing trades
- store Alpaca positions to `open_positions.csv`

## Testing
- `python scripts/run_pipeline.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python scripts/execute_trades.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d3842f40c83319f168a76c6aa6b31