### PR TITLE
Add screener dashboard tab and improve styling

### DIFF
--- a/assets/typography.css
+++ b/assets/typography.css
@@ -34,3 +34,16 @@ h1, h2, h3, h4, h5, h6 {
     box-shadow: 0 4px 10px rgba(0,0,0,0.3);
     border-top: 3px solid #4DB6AC;
 }
+
+/* Styling for dashboard tabs */
+.custom-tab {
+    background-color: #343a40;
+    color: #ccc;
+    padding: 8px 12px;
+    border-radius: 0.25rem;
+    margin-right: 4px;
+}
+.custom-tab.active {
+    background-color: #17a2b8;
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- style main dashboard tabs using Bootstrap components
- add screener tab with table of top candidates
- display recent pipeline and monitor logs
- tweak CSS for custom tab styling

## Testing
- `python -m py_compile dashboards/dashboard_app.py`
- `python dashboards/dashboard_app.py` *(fails: ModuleNotFoundError: No module named 'dash')*


------
https://chatgpt.com/codex/tasks/task_e_686db74a832c83318b3b1db4a94346af