### PR TITLE
Fix open_positions.csv columns

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -68,12 +68,20 @@ def save_open_positions_csv():
                 'qty': p.qty,
                 'avg_entry_price': p.avg_entry_price,
                 'current_price': p.current_price,
-                'unrealized_pl': p.unrealized_pl
+                'unrealized_pl': p.unrealized_pl,
+                'entry_price': p.avg_entry_price,
+                'entry_time': getattr(p, 'created_at', datetime.utcnow()).isoformat()
             })
 
-        df = pd.DataFrame(data, columns=['symbol', 'qty', 'avg_entry_price', 'current_price', 'unrealized_pl'])
+        df = pd.DataFrame(data, columns=[
+            'symbol', 'qty', 'avg_entry_price', 'current_price',
+            'unrealized_pl', 'entry_price', 'entry_time']
+        )
         if df.empty:
-            df = pd.DataFrame(columns=['symbol', 'qty', 'avg_entry_price', 'current_price', 'unrealized_pl'])
+            df = pd.DataFrame(columns=[
+                'symbol', 'qty', 'avg_entry_price', 'current_price',
+                'unrealized_pl', 'entry_price', 'entry_time'
+            ])
 
         csv_path = os.path.join(BASE_DIR, 'data', 'open_positions.csv')
         df.to_csv(csv_path, index=False)

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -61,12 +61,27 @@ def save_positions_csv(positions):
             {
                 'symbol': p.symbol,
                 'qty': p.qty,
+                'avg_entry_price': p.avg_entry_price,
                 'current_price': p.current_price,
                 'unrealized_pl': p.unrealized_pl,
+                'entry_price': p.avg_entry_price,
+                'entry_time': getattr(p, 'created_at', datetime.utcnow()).isoformat(),
             }
             for p in positions
         ]
-        pd.DataFrame(data).to_csv(csv_path, index=False)
+        df = pd.DataFrame(
+            data,
+            columns=[
+                'symbol', 'qty', 'avg_entry_price', 'current_price',
+                'unrealized_pl', 'entry_price', 'entry_time'
+            ]
+        )
+        if df.empty:
+            df = pd.DataFrame(columns=[
+                'symbol', 'qty', 'avg_entry_price', 'current_price',
+                'unrealized_pl', 'entry_price', 'entry_time'
+            ])
+        df.to_csv(csv_path, index=False)
         logging.debug("Saved open positions to %s", csv_path)
     except Exception as e:
         logging.error("Failed to save positions CSV: %s", e)


### PR DESCRIPTION
## Summary
- add entry_price and entry_time columns in execute_trades save function
- include entry details in monitor_positions save function

## Testing
- `python scripts/execute_trades.py` *(fails: No module named 'pandas')*
- `python dashboards/dashboard_app.py` *(fails: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686ed5de95bc83319d632a96b830081c