### PR TITLE
Add entry and pnl columns to trade history CSVs

### DIFF
--- a/scripts/fetch_trades_history.py
+++ b/scripts/fetch_trades_history.py
@@ -2,29 +2,96 @@ from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import GetOrdersRequest
 from alpaca.trading.enums import QueryOrderStatus
 from dotenv import load_dotenv
-import pandas as pd, os
+import pandas as pd
+import os
 
 load_dotenv()
-client = TradingClient(os.getenv('APCA_API_KEY_ID'), os.getenv('APCA_API_SECRET_KEY'), paper=True)
+client = TradingClient(
+    os.getenv('APCA_API_KEY_ID'),
+    os.getenv('APCA_API_SECRET_KEY'),
+    paper=True,
+)
 
-all_orders = []
+all_orders: list = []
 end = pd.Timestamp.utcnow().isoformat()
 
 while True:
-    req = GetOrdersRequest(status=QueryOrderStatus.CLOSED, until=end, limit=500, direction='desc')
+    req = GetOrdersRequest(
+        status=QueryOrderStatus.CLOSED,
+        until=end,
+        limit=500,
+        direction='desc',
+    )
     chunk = client.get_orders(filter=req)
-    if not chunk: break
+    if not chunk:
+        break
     all_orders.extend(chunk)
     end = chunk[-1].submitted_at.isoformat()
 
-# ``Order`` objects from alpaca-py used to expose a ``_raw`` attribute. In
-# newer versions this was renamed to ``raw_data``.  With Pydantic v2 the
-# preferred method to obtain a dictionary representation is ``model_dump()``.
-# To remain compatible with older versions we check for ``raw_data`` and fall
-# back to ``model_dump()``.
-records = [getattr(order, "raw_data", order.model_dump()) for order in all_orders]
-df = pd.DataFrame(records).drop_duplicates("id")
+records = []
+for order in all_orders:
+    data = getattr(order, 'raw_data', order.model_dump())
+
+    filled_qty = float(data.get('filled_qty', 0))
+    avg_fill_price = float(data.get('filled_avg_price', 0))
+    limit_price = float(data.get('limit_price') or 0)
+
+    if data['side'] == 'buy':
+        entry_price = avg_fill_price if avg_fill_price else limit_price
+        entry_time = data.get('filled_at') or data.get('submitted_at')
+    else:
+        entry_price = None
+        entry_time = None
+
+    current_price = float(
+        data.get('filled_avg_price') or data.get('limit_price') or 0
+    )
+    pnl = (current_price - entry_price) * filled_qty if entry_price else 0
+
+    records.append(
+        {
+            **data,
+            'entry_price': entry_price,
+            'entry_time': entry_time,
+            'pnl': pnl,
+            'order_status': data['status'],
+        }
+    )
+
+df = pd.DataFrame(records).drop_duplicates('id')
 data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
-df.to_csv(os.path.join(data_dir, 'trades_log.csv'), index=False)
-executed = df[df['filled_qty'].astype(float) > 0]
-executed.to_csv(os.path.join(data_dir, 'executed_trades.csv'), index=False)
+
+trades_log_cols = [
+    'id',
+    'symbol',
+    'side',
+    'filled_qty',
+    'filled_avg_price',
+    'submitted_at',
+    'filled_at',
+    'entry_price',
+    'entry_time',
+    'pnl',
+    'status',
+]
+df[trades_log_cols].to_csv(
+    os.path.join(data_dir, 'trades_log.csv'), index=False
+)
+
+executed_trades = df[df['filled_qty'].astype(float) > 0]
+executed_trades_cols = [
+    'id',
+    'symbol',
+    'side',
+    'filled_qty',
+    'filled_avg_price',
+    'submitted_at',
+    'filled_at',
+    'entry_price',
+    'entry_time',
+    'order_status',
+]
+executed_trades[executed_trades_cols].to_csv(
+    os.path.join(data_dir, 'executed_trades.csv'),
+    index=False,
+)


### PR DESCRIPTION
## Summary
- enhance `fetch_trades_history.py` with entry price/time and pnl calculation
- output new columns to `trades_log.csv` and `executed_trades.csv`

## Testing
- `python scripts/fetch_trades_history.py` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `python scripts/execute_trades.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f2ba160b883318b815e7e2c3bf480