### PR TITLE
Add order_status column for executed trades

### DIFF
--- a/data/executed_trades.csv
+++ b/data/executed_trades.csv
@@ -1,3 +1,3 @@
-symbol,entry_price,entry_time,order_status
-AAPL,171.0,2025-07-07 09:35:00,Filled
-AMZN,125.5,2025-07-07 10:15:00,Rejected
+id,symbol,side,filled_qty,entry_price,exit_price,entry_time,exit_time,order_status,pnl
+1,AAPL,buy,10,171.0,,2025-07-07 09:35:00,,Filled,0
+2,AMZN,buy,20,125.5,,2025-07-07 10:15:00,,Rejected,0

--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -66,7 +66,7 @@ if not os.path.exists(exec_trades_path):
     pd.DataFrame(
         columns=[
             'id', 'symbol', 'side', 'filled_qty', 'entry_price',
-            'exit_price', 'entry_time', 'exit_time', 'status', 'pnl'
+            'exit_price', 'entry_time', 'exit_time', 'order_status', 'pnl'
         ]
     ).to_csv(exec_trades_path, index=False)
 
@@ -164,7 +164,7 @@ def record_executed_trade(symbol, entry_price, status):
         'exit_price': '',
         'entry_time': datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
         'exit_time': '',
-        'status': status,
+        'order_status': status,
         'pnl': 0.0,
     }
     pd.DataFrame([row]).to_csv(csv_path, mode='a', header=False, index=False)

--- a/scripts/fetch_trades_history.py
+++ b/scripts/fetch_trades_history.py
@@ -94,7 +94,7 @@ for order in orders_sorted:
             'exit_price': exit_price,
             'entry_time': entry_time,
             'exit_time': exit_time,
-            'status': order.status.value,
+            'order_status': order.status.value if order.status else 'unknown',
             'pnl': pnl,
         }
     )
@@ -111,7 +111,7 @@ cols = [
     'exit_price',
     'entry_time',
     'exit_time',
-    'status',
+    'order_status',
     'pnl',
 ]
 


### PR DESCRIPTION
## Summary
- include `order_status` when fetching trade history
- track `order_status` in execute_trades
- update sample executed_trades.csv data

## Testing
- `python -m py_compile scripts/fetch_trades_history.py scripts/execute_trades.py`

------
https://chatgpt.com/codex/tasks/task_e_686f39c8f2c48331a3cda2af0915faf0