### PR TITLE
Improve trailing stop logging for ARQQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ assets_backup/
 
 # Ignore runtime data and logs
 data/*.csv
-logs/*.log
+logs/*.log*
 


### PR DESCRIPTION
## Summary
- lower log rotation threshold to trigger frequent rotation
- improve indicator fetching logs when data is insufficient
- add explicit ARQQ trailing stop log messages
- log when skipping trailing stop creation and when managing trailing stops
- ignore rotated log files

## Testing
- `python3 -m py_compile scripts/monitor_positions.py`
- `python3 - <<'EOF'
import logging
from logging.handlers import RotatingFileHandler
import os
path=os.path.join('logs','monitor.log')
logger=logging.getLogger('rotation_test')
logger.setLevel(logging.INFO)
logger.propagate=False
handler=RotatingFileHandler(path,maxBytes=50000,backupCount=5)
formatter=logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
handler.setFormatter(formatter)
logger.addHandler(handler)
for i in range(1000):
    logger.info('rotation test line %d', i)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68701cc9fc1083319e9f4b09f53c89e2