### PR TITLE
Improve data validation and screener updates

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -17,28 +17,29 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Absolute paths to CSV data files used throughout the dashboard
-trades_log_path = os.path.join(BASE_DIR, 'data', 'trades_log.csv')
-open_positions_path = os.path.join(BASE_DIR, 'data', 'open_positions.csv')
-top_candidates_path = os.path.join(BASE_DIR, 'data', 'top_candidates.csv')
+trades_log_path = os.path.join(BASE_DIR, "data", "trades_log.csv")
+open_positions_path = os.path.join(BASE_DIR, "data", "open_positions.csv")
+top_candidates_path = os.path.join(BASE_DIR, "data", "top_candidates.csv")
+latest_candidates_path = os.path.join(BASE_DIR, "data", "latest_candidates.csv")
 
 # Additional datasets introduced for monitoring
-metrics_summary_path = os.path.join(BASE_DIR, 'data', 'metrics_summary.csv')
-executed_trades_path = os.path.join(BASE_DIR, 'data', 'executed_trades.csv')
-historical_candidates_path = os.path.join(BASE_DIR, 'data', 'historical_candidates.csv')
+metrics_summary_path = os.path.join(BASE_DIR, "data", "metrics_summary.csv")
+executed_trades_path = os.path.join(BASE_DIR, "data", "executed_trades.csv")
+historical_candidates_path = os.path.join(BASE_DIR, "data", "historical_candidates.csv")
 
 # Absolute paths to log files for the Screener tab
-screener_log_dir = os.path.join(BASE_DIR, 'logs')
-pipeline_log_path = os.path.join(screener_log_dir, 'pipeline.log')
-monitor_log_path = os.path.join(screener_log_dir, 'monitor.log')
+screener_log_dir = os.path.join(BASE_DIR, "logs")
+pipeline_log_path = os.path.join(screener_log_dir, "pipeline.log")
+monitor_log_path = os.path.join(screener_log_dir, "monitor.log")
 # Additional logs
-screener_log_path = os.path.join(screener_log_dir, 'screener.log')
-backtest_log_path = os.path.join(screener_log_dir, 'backtest.log')
-execute_trades_log_path = os.path.join(screener_log_dir, 'execute_trades.log')
-error_log_path = os.path.join(screener_log_dir, 'error.log')
+screener_log_path = os.path.join(screener_log_dir, "screener.log")
+backtest_log_path = os.path.join(screener_log_dir, "backtest.log")
+execute_trades_log_path = os.path.join(screener_log_dir, "execute_trades.log")
+error_log_path = os.path.join(screener_log_dir, "error.log")
 
-load_dotenv(os.path.join(BASE_DIR, '.env'))
-API_KEY = os.getenv('APCA_API_KEY_ID')
-API_SECRET = os.getenv('APCA_API_SECRET_KEY')
+load_dotenv(os.path.join(BASE_DIR, ".env"))
+API_KEY = os.getenv("APCA_API_KEY_ID")
+API_SECRET = os.getenv("APCA_API_SECRET_KEY")
 trading_client = TradingClient(API_KEY, API_SECRET, paper=True)
 logger = logging.getLogger(__name__)
 
@@ -47,20 +48,25 @@ def fetch_positions_api():
     """Fetch open positions from Alpaca for fallback."""
     try:
         positions = trading_client.get_all_positions()
-        return pd.DataFrame([
-            {
-                'symbol': p.symbol,
-                'qty': p.qty,
-                'avg_entry_price': p.avg_entry_price,
-                'current_price': p.current_price,
-                'unrealized_pl': p.unrealized_pl,
-                'entry_time': getattr(p, 'created_at', datetime.utcnow()).isoformat(),
-            }
-            for p in positions
-        ])
+        return pd.DataFrame(
+            [
+                {
+                    "symbol": p.symbol,
+                    "qty": p.qty,
+                    "avg_entry_price": p.avg_entry_price,
+                    "current_price": p.current_price,
+                    "unrealized_pl": p.unrealized_pl,
+                    "entry_time": getattr(
+                        p, "created_at", datetime.utcnow()
+                    ).isoformat(),
+                }
+                for p in positions
+            ]
+        )
     except Exception as e:
-        logger.error('open_positions.csv empty; failed Alpaca fallback: %s', e)
+        logger.error("open_positions.csv empty; failed Alpaca fallback: %s", e)
         return pd.DataFrame()
+
 
 def load_csv(filepath, required_columns=None):
     """Load a CSV file from ``filepath`` and validate required columns.
@@ -75,12 +81,14 @@ def load_csv(filepath, required_columns=None):
         return pd.DataFrame(), alert
 
     try:
-        df = pd.read_csv(filepath, sep=',', encoding='utf-8')
+        df = pd.read_csv(filepath, sep=",", encoding="utf-8")
         df.rename(columns=lambda c: c.strip(), inplace=True)
         app.logger.info("Loaded columns: %s", df.columns.tolist())
     except pd.errors.EmptyDataError:
         app.logger.warning("No data in %s", filepath)
-        alert = dbc.Alert(f"No data available in {filename}.", color="warning", className="m-2")
+        alert = dbc.Alert(
+            f"No data available in {filename}.", color="warning", className="m-2"
+        )
         return pd.DataFrame(), alert
     except Exception as e:
         alert = dbc.Alert(
@@ -97,10 +105,13 @@ def load_csv(filepath, required_columns=None):
             return pd.DataFrame(), alert
 
     if df.empty:
-        alert = dbc.Alert(f"No data available in {filename}.", color="warning", className="m-2")
+        alert = dbc.Alert(
+            f"No data available in {filename}.", color="warning", className="m-2"
+        )
         return df, alert
 
     return df, None
+
 
 def read_recent_lines(filepath, num_lines=50):
     """Return the last ``num_lines`` lines of ``filepath``.
@@ -112,29 +123,34 @@ def read_recent_lines(filepath, num_lines=50):
         return [f"{filename} not found.\n"]
 
     try:
-        with open(filepath, 'r') as f:
+        with open(filepath, "r") as f:
             lines = f.readlines()[-num_lines:]
         return lines if lines else [f"No entries in {filename}.\n"]
     except Exception as e:
         return [f"Error reading {filename}: {e}\n"]
 
+
 def format_log_lines(lines):
     """Return a list of HTML spans with coloring for ERROR and WARNING lines."""
     formatted = []
     for line in lines:
-        if '[ERROR]' in line or 'ERROR' in line:
-            formatted.append(html.Span(line, style={'color': '#E57373'}))
-        elif '[WARNING]' in line or 'WARNING' in line:
-            formatted.append(html.Span(line, style={'color': '#FFB74D'}))
+        if "[ERROR]" in line or "ERROR" in line:
+            formatted.append(html.Span(line, style={"color": "#E57373"}))
+        elif "[WARNING]" in line or "WARNING" in line:
+            formatted.append(html.Span(line, style={"color": "#FFB74D"}))
         else:
             formatted.append(html.Span(line))
     return formatted
+
 
 def file_timestamp(path):
     """Return modification time of ``path`` formatted for display."""
     if not os.path.exists(path):
         return "N/A"
-    return datetime.utcfromtimestamp(os.path.getmtime(path)).strftime('%Y-%m-%d %H:%M:%S UTC')
+    return datetime.utcfromtimestamp(os.path.getmtime(path)).strftime(
+        "%Y-%m-%d %H:%M:%S UTC"
+    )
+
 
 def pipeline_status_component():
     """Create status indicators for Screener -> Backtest -> Execution."""
@@ -155,13 +171,14 @@ def pipeline_status_component():
             else:
                 color = "warning"
                 status = "Stale"
-            timestamp = mtime.strftime('%Y-%m-%d %H:%M')
+            timestamp = mtime.strftime("%Y-%m-%d %H:%M")
         else:
             color = "danger"
             status = "Missing"
             timestamp = "N/A"
         items.append(dbc.ListGroupItem(f"{name}: {status} ({timestamp})", color=color))
     return dbc.ListGroup(items, className="mb-3")
+
 
 def data_freshness_alert(path, name, threshold_minutes=60):
     """Return a Dash alert if ``path`` was not modified within ``threshold_minutes``."""
@@ -170,110 +187,269 @@ def data_freshness_alert(path, name, threshold_minutes=60):
     mtime = datetime.fromtimestamp(os.path.getmtime(path))
     age = (datetime.now() - mtime).total_seconds() / 60
     if age > threshold_minutes:
-        return dbc.Alert(f"{name} has not updated for {int(age)} minutes", color="warning", className="m-2")
+        return dbc.Alert(
+            f"{name} has not updated for {int(age)} minutes",
+            color="warning",
+            className="m-2",
+        )
     return None
 
-app = Dash(__name__, external_stylesheets=[
-    dbc.themes.DARKLY,
-    "https://cdn.jsdelivr.net/gh/AnnMarieW/dash-bootstrap-templates@V2.1.0/dbc.min.css"
-])
+
+app = Dash(
+    __name__,
+    external_stylesheets=[
+        dbc.themes.DARKLY,
+        "https://cdn.jsdelivr.net/gh/AnnMarieW/dash-bootstrap-templates@V2.1.0/dbc.min.css",
+    ],
+)
 
 # Layout with Tabs and Modals
-app.layout = dbc.Container([
-    dbc.Row(dbc.Col(html.H1('JBravo Swing Trading Dashboard', className="text-center my-4 text-light"))),
+app.layout = dbc.Container(
+    [
+        dbc.Row(
+            dbc.Col(
+                html.H1(
+                    "JBravo Swing Trading Dashboard",
+                    className="text-center my-4 text-light",
+                )
+            )
+        ),
+        dbc.Tabs(
+            id="main-tabs",
+            active_tab="tab-overview",
+            class_name="mb-3",
+            children=[
+                dbc.Tab(
+                    label="Overview",
+                    tab_id="tab-overview",
+                    tab_style={"backgroundColor": "#343a40", "color": "#ccc"},
+                    active_tab_style={"backgroundColor": "#17a2b8", "color": "#fff"},
+                    className="custom-tab",
+                ),
+                dbc.Tab(
+                    label="Screener",
+                    tab_id="tab-screener",
+                    tab_style={"backgroundColor": "#343a40", "color": "#ccc"},
+                    active_tab_style={"backgroundColor": "#17a2b8", "color": "#fff"},
+                    className="custom-tab",
+                ),
+                dbc.Tab(
+                    label="Trade Log",
+                    tab_id="tab-trades",
+                    tab_style={"backgroundColor": "#343a40", "color": "#ccc"},
+                    active_tab_style={"backgroundColor": "#17a2b8", "color": "#fff"},
+                    className="custom-tab",
+                ),
+                dbc.Tab(
+                    label="Open Positions",
+                    tab_id="tab-positions",
+                    tab_style={"backgroundColor": "#343a40", "color": "#ccc"},
+                    active_tab_style={"backgroundColor": "#17a2b8", "color": "#fff"},
+                    className="custom-tab",
+                ),
+                dbc.Tab(
+                    label="Symbol Performance",
+                    tab_id="tab-symbols",
+                    tab_style={"backgroundColor": "#343a40", "color": "#ccc"},
+                    active_tab_style={"backgroundColor": "#17a2b8", "color": "#fff"},
+                    className="custom-tab",
+                ),
+                dbc.Tab(
+                    label="Monitor Log",
+                    tab_id="tab-monitor",
+                    tab_style={"backgroundColor": "#343a40", "color": "#ccc"},
+                    active_tab_style={"backgroundColor": "#17a2b8", "color": "#fff"},
+                    className="custom-tab",
+                ),
+            ],
+        ),
+        html.Div(id="tabs-content", className="mt-4"),
+        dcc.Interval(id="interval-update", interval=600000, n_intervals=0),
+        dcc.Interval(id="log-interval", interval=10000, n_intervals=0),
+        dbc.Modal(
+            id="detail-modal",
+            is_open=False,
+            size="lg",
+            children=[
+                dbc.ModalHeader(dbc.ModalTitle("Details")),
+                dbc.ModalBody(id="modal-content"),
+                dbc.ModalFooter(
+                    dbc.Button("Close", id="close-modal", className="ms-auto")
+                ),
+            ],
+        ),
+    ],
+    fluid=True,
+)
 
-    dbc.Tabs(
-        id='main-tabs',
-        active_tab='tab-overview',
-        class_name='mb-3',
-        children=[
-            dbc.Tab(label='Overview', tab_id='tab-overview', tab_style={'backgroundColor':'#343a40','color':'#ccc'}, active_tab_style={'backgroundColor':'#17a2b8','color':'#fff'}, className='custom-tab'),
-            dbc.Tab(label='Screener', tab_id='tab-screener', tab_style={'backgroundColor':'#343a40','color':'#ccc'}, active_tab_style={'backgroundColor':'#17a2b8','color':'#fff'}, className='custom-tab'),
-            dbc.Tab(label='Trade Log', tab_id='tab-trades', tab_style={'backgroundColor':'#343a40','color':'#ccc'}, active_tab_style={'backgroundColor':'#17a2b8','color':'#fff'}, className='custom-tab'),
-            dbc.Tab(label='Open Positions', tab_id='tab-positions', tab_style={'backgroundColor':'#343a40','color':'#ccc'}, active_tab_style={'backgroundColor':'#17a2b8','color':'#fff'}, className='custom-tab'),
-            dbc.Tab(label='Symbol Performance', tab_id='tab-symbols', tab_style={'backgroundColor':'#343a40','color':'#ccc'}, active_tab_style={'backgroundColor':'#17a2b8','color':'#fff'}, className='custom-tab'),
-            dbc.Tab(label='Monitor Log', tab_id='tab-monitor',
-                    tab_style={'backgroundColor': '#343a40', 'color': '#ccc'},
-                    active_tab_style={'backgroundColor': '#17a2b8', 'color': '#fff'},
-                    className='custom-tab')
-        ]
-    ),
-
-    html.Div(id='tabs-content', className="mt-4"),
-
-    dcc.Interval(id='interval-update', interval=600000, n_intervals=0),
-    dcc.Interval(id='log-interval', interval=10000, n_intervals=0),
-
-    dbc.Modal(id='detail-modal', is_open=False, size="lg", children=[
-        dbc.ModalHeader(dbc.ModalTitle("Details")),
-        dbc.ModalBody(id='modal-content'),
-        dbc.ModalFooter(dbc.Button("Close", id="close-modal", className="ms-auto"))
-    ])
-], fluid=True)
 
 # Callbacks for tabs content
 @app.callback(
-    Output('tabs-content', 'children'),
+    Output("tabs-content", "children"),
     [
-        Input('main-tabs', 'active_tab'),
-        Input('interval-update', 'n_intervals'),
-        Input('log-interval', 'n_intervals')
-    ]
+        Input("main-tabs", "active_tab"),
+        Input("interval-update", "n_intervals"),
+        Input("log-interval", "n_intervals"),
+    ],
 )
 def render_tab(tab, n_intervals, n_log_intervals):
-    if tab == 'tab-overview':
-        trades_df, alert = load_csv(trades_log_path, required_columns=['pnl', 'entry_time'])
-        freshness = data_freshness_alert(trades_log_path, 'Trade log')
+    if tab == "tab-overview":
+        trades_df, alert = load_csv(
+            trades_log_path, required_columns=["pnl", "entry_time"]
+        )
+        freshness = data_freshness_alert(trades_log_path, "Trade log")
         if alert:
             return alert
 
-        trades_df['entry_time'] = pd.to_datetime(trades_df['entry_time'])
-        trades_df['cumulative_pnl'] = trades_df['pnl'].cumsum()
-        trades_df['cummax'] = trades_df['cumulative_pnl'].cummax()
-        trades_df['drawdown'] = trades_df['cumulative_pnl'] - trades_df['cummax']
+        trades_df["entry_time"] = pd.to_datetime(trades_df["entry_time"])
+        trades_df["cumulative_pnl"] = trades_df["pnl"].cumsum()
+        trades_df["cummax"] = trades_df["cumulative_pnl"].cummax()
+        trades_df["drawdown"] = trades_df["cumulative_pnl"] - trades_df["cummax"]
 
-        equity_fig = px.line(trades_df, x='entry_time', y='cumulative_pnl', template='plotly_dark', title='Equity Curve')
-        hist_fig = px.histogram(trades_df, x='pnl', nbins=20, template='plotly_dark', title='Distribution of Trade PnL')
-        pie_fig = px.pie(trades_df, names=trades_df['pnl']>0, title='Win vs Loss', template='plotly_dark')
+        equity_fig = px.line(
+            trades_df,
+            x="entry_time",
+            y="cumulative_pnl",
+            template="plotly_dark",
+            title="Equity Curve",
+        )
+        hist_fig = px.histogram(
+            trades_df,
+            x="pnl",
+            nbins=20,
+            template="plotly_dark",
+            title="Distribution of Trade PnL",
+        )
+        pie_fig = px.pie(
+            trades_df,
+            names=trades_df["pnl"] > 0,
+            title="Win vs Loss",
+            template="plotly_dark",
+        )
 
-        daily = trades_df.groupby(trades_df['entry_time'].dt.date)['pnl'].sum().reset_index()
-        daily_fig = px.bar(daily, x='entry_time', y='pnl', template='plotly_dark', title='Daily PnL')
-        monthly = trades_df.groupby(trades_df['entry_time'].dt.to_period('M'))['pnl'].sum().reset_index()
-        monthly['entry_time'] = monthly['entry_time'].astype(str)
-        monthly_fig = px.bar(monthly, x='entry_time', y='pnl', template='plotly_dark', title='Monthly PnL')
-        dd_fig = px.area(trades_df, x='entry_time', y='drawdown', template='plotly_dark', title='Drawdown Over Time')
+        daily = (
+            trades_df.groupby(trades_df["entry_time"].dt.date)["pnl"]
+            .sum()
+            .reset_index()
+        )
+        daily_fig = px.bar(
+            daily, x="entry_time", y="pnl", template="plotly_dark", title="Daily PnL"
+        )
+        monthly = (
+            trades_df.groupby(trades_df["entry_time"].dt.to_period("M"))["pnl"]
+            .sum()
+            .reset_index()
+        )
+        monthly["entry_time"] = monthly["entry_time"].astype(str)
+        monthly_fig = px.bar(
+            monthly,
+            x="entry_time",
+            y="pnl",
+            template="plotly_dark",
+            title="Monthly PnL",
+        )
+        dd_fig = px.area(
+            trades_df,
+            x="entry_time",
+            y="drawdown",
+            template="plotly_dark",
+            title="Drawdown Over Time",
+        )
 
         metrics_df, _ = load_csv(metrics_summary_path)
         if not metrics_df.empty:
-            total_trades = int(metrics_df['Total Trades'][0])
-            total_pnl = metrics_df['Total Net PnL'][0]
+            total_trades = int(metrics_df["Total Trades"][0])
+            total_pnl = metrics_df["Total Net PnL"][0]
         else:
             total_trades = len(trades_df)
-            total_pnl = trades_df['pnl'].sum()
+            total_pnl = trades_df["pnl"].sum()
 
-        kpis = dbc.Row([
-            dbc.Col(dbc.Card([dbc.CardHeader("Total Trades"), dbc.CardBody(html.H4(f"{total_trades}"))]), width=2),
-            dbc.Col(dbc.Card([dbc.CardHeader("Total Net PnL"), dbc.CardBody(html.H4(f"${total_pnl:.2f}"))]), width=2),
-            dbc.Col(dbc.Card([dbc.CardHeader("Win Rate"), dbc.CardBody(html.H4(f"{(trades_df['pnl'] > 0).mean()*100:.2f}%"))]), width=2),
-            dbc.Col(dbc.Card([dbc.CardHeader("Expectancy"), dbc.CardBody(html.H4(f"${trades_df['pnl'].mean():.2f}"))]), width=2),
-            dbc.Col(dbc.Card([dbc.CardHeader("Profit Factor"), dbc.CardBody(html.H4(f"{trades_df[trades_df['pnl']>0]['pnl'].sum()/abs(trades_df[trades_df['pnl']<0]['pnl'].sum()):.2f}"))]), width=2),
-            dbc.Col(dbc.Card([dbc.CardHeader("Max Drawdown"), dbc.CardBody(html.H4(f"${trades_df['drawdown'].min():.2f}"))]), width=2)
-        ], className='mb-4')
+        kpis = dbc.Row(
+            [
+                dbc.Col(
+                    dbc.Card(
+                        [
+                            dbc.CardHeader("Total Trades"),
+                            dbc.CardBody(html.H4(f"{total_trades}")),
+                        ]
+                    ),
+                    width=2,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        [
+                            dbc.CardHeader("Total Net PnL"),
+                            dbc.CardBody(html.H4(f"${total_pnl:.2f}")),
+                        ]
+                    ),
+                    width=2,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        [
+                            dbc.CardHeader("Win Rate"),
+                            dbc.CardBody(
+                                html.H4(f"{(trades_df['pnl'] > 0).mean()*100:.2f}%")
+                            ),
+                        ]
+                    ),
+                    width=2,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        [
+                            dbc.CardHeader("Expectancy"),
+                            dbc.CardBody(html.H4(f"${trades_df['pnl'].mean():.2f}")),
+                        ]
+                    ),
+                    width=2,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        [
+                            dbc.CardHeader("Profit Factor"),
+                            dbc.CardBody(
+                                html.H4(
+                                    f"{trades_df[trades_df['pnl']>0]['pnl'].sum()/abs(trades_df[trades_df['pnl']<0]['pnl'].sum()):.2f}"
+                                )
+                            ),
+                        ]
+                    ),
+                    width=2,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        [
+                            dbc.CardHeader("Max Drawdown"),
+                            dbc.CardBody(
+                                html.H4(f"${trades_df['drawdown'].min():.2f}")
+                            ),
+                        ]
+                    ),
+                    width=2,
+                ),
+            ],
+            className="mb-4",
+        )
 
-        graphs = dbc.Row([
-            dbc.Col(dcc.Graph(figure=equity_fig), md=6),
-            dbc.Col(dcc.Graph(figure=hist_fig), md=6),
-            dbc.Col(dcc.Graph(figure=pie_fig), md=4),
-            dbc.Col(dcc.Graph(figure=daily_fig), md=4),
-            dbc.Col(dcc.Graph(figure=monthly_fig), md=4),
-            dbc.Col(dcc.Graph(figure=dd_fig), md=12)
-        ])
+        graphs = dbc.Row(
+            [
+                dbc.Col(dcc.Graph(figure=equity_fig), md=6),
+                dbc.Col(dcc.Graph(figure=hist_fig), md=6),
+                dbc.Col(dcc.Graph(figure=pie_fig), md=4),
+                dbc.Col(dcc.Graph(figure=daily_fig), md=4),
+                dbc.Col(dcc.Graph(figure=monthly_fig), md=4),
+                dbc.Col(dcc.Graph(figure=dd_fig), md=12),
+            ]
+        )
         latest_file = trades_log_path
-        if os.path.exists(executed_trades_path) and os.path.getmtime(executed_trades_path) > os.path.getmtime(trades_log_path):
+        if os.path.exists(executed_trades_path) and os.path.getmtime(
+            executed_trades_path
+        ) > os.path.getmtime(trades_log_path):
             latest_file = executed_trades_path
         timestamp = html.Div(
             f"Data last refreshed: {file_timestamp(latest_file)}",
-            className='text-muted mb-2'
+            className="text-muted mb-2",
         )
 
         components = [timestamp]
@@ -282,23 +458,34 @@ def render_tab(tab, n_intervals, n_log_intervals):
         components.extend([kpis, graphs])
         return dbc.Container(components, fluid=True)
 
-    elif tab == 'tab-screener':
-        candidates_df, alert = load_csv(top_candidates_path)
-        backtest_df, _ = load_csv(os.path.join(os.path.dirname(top_candidates_path), 'backtest_results.csv'))
+    elif tab == "tab-screener":
+        candidates_df, alert = load_csv(latest_candidates_path)
+        backtest_df, _ = load_csv(
+            os.path.join(
+                os.path.dirname(latest_candidates_path), "backtest_results.csv"
+            )
+        )
         if alert:
             table = alert
         else:
-            merged = pd.merge(candidates_df, backtest_df[['symbol','win_rate','net_pnl']], on='symbol', how='left')
-            columns = [{'name': c.replace('_',' ').title(), 'id': c} for c in merged.columns]
+            merged = pd.merge(
+                candidates_df,
+                backtest_df[["symbol", "win_rate", "net_pnl"]],
+                on="symbol",
+                how="left",
+            )
+            columns = [
+                {"name": c.replace("_", " ").title(), "id": c} for c in merged.columns
+            ]
             table = dash_table.DataTable(
-                id='top-candidates-table',
-                data=merged.to_dict('records'),
+                id="top-candidates-table",
+                data=merged.to_dict("records"),
                 columns=columns,
                 page_size=20,
-                filter_action='native',
-                sort_action='native',
-                style_table={'overflowX':'auto'},
-                style_cell={'backgroundColor':'#212529','color':'#E0E0E0'}
+                filter_action="native",
+                sort_action="native",
+                style_table={"overflowX": "auto"},
+                style_cell={"backgroundColor": "#212529", "color": "#E0E0E0"},
             )
 
         pipeline_lines = read_recent_lines(pipeline_log_path)[::-1]
@@ -306,29 +493,68 @@ def render_tab(tab, n_intervals, n_log_intervals):
         backtest_lines = read_recent_lines(backtest_log_path)[::-1]
 
         def format_lines(lines):
-            return [html.Span(l, style={'color':'#E57373'} if 'ERROR' in l else {}) for l in lines]
+            return [
+                html.Span(l, style={"color": "#E57373"} if "ERROR" in l else {})
+                for l in lines
+            ]
 
-        pipeline_log = html.Div([
-            html.H5('Pipeline Log', className='text-light'),
-            html.Pre(format_lines(pipeline_lines), style={'maxHeight':'200px','overflowY':'auto','backgroundColor':'#272B30','color':'#E0E0E0','padding':'0.5rem'})
-        ], className='mb-3')
+        pipeline_log = html.Div(
+            [
+                html.H5("Pipeline Log", className="text-light"),
+                html.Pre(
+                    format_lines(pipeline_lines),
+                    style={
+                        "maxHeight": "200px",
+                        "overflowY": "auto",
+                        "backgroundColor": "#272B30",
+                        "color": "#E0E0E0",
+                        "padding": "0.5rem",
+                    },
+                ),
+            ],
+            className="mb-3",
+        )
 
-        screener_log = html.Div([
-            html.H5('Screener Log', className='text-light'),
-            html.Pre(format_lines(screener_lines), style={'maxHeight':'200px','overflowY':'auto','backgroundColor':'#272B30','color':'#E0E0E0','padding':'0.5rem'})
-        ], className='mb-3')
+        screener_log = html.Div(
+            [
+                html.H5("Screener Log", className="text-light"),
+                html.Pre(
+                    format_lines(screener_lines),
+                    style={
+                        "maxHeight": "200px",
+                        "overflowY": "auto",
+                        "backgroundColor": "#272B30",
+                        "color": "#E0E0E0",
+                        "padding": "0.5rem",
+                    },
+                ),
+            ],
+            className="mb-3",
+        )
 
-        backtest_log = html.Div([
-            html.H5('Backtest Log', className='text-light'),
-            html.Pre(format_lines(backtest_lines), style={'maxHeight':'200px','overflowY':'auto','backgroundColor':'#272B30','color':'#E0E0E0','padding':'0.5rem'})
-        ], className='mb-3')
+        backtest_log = html.Div(
+            [
+                html.H5("Backtest Log", className="text-light"),
+                html.Pre(
+                    format_lines(backtest_lines),
+                    style={
+                        "maxHeight": "200px",
+                        "overflowY": "auto",
+                        "backgroundColor": "#272B30",
+                        "color": "#E0E0E0",
+                        "padding": "0.5rem",
+                    },
+                ),
+            ],
+            className="mb-3",
+        )
 
         status = pipeline_status_component()
-        freshness = data_freshness_alert(top_candidates_path, 'Top candidates')
+        freshness = data_freshness_alert(latest_candidates_path, "Latest candidates")
 
         timestamp = html.Div(
-            f"Data last refreshed: {file_timestamp(top_candidates_path)}",
-            className='text-muted mb-2'
+            f"Data last refreshed: {file_timestamp(latest_candidates_path)}",
+            className="text-muted mb-2",
         )
 
         components = [timestamp, table, status]
@@ -338,161 +564,248 @@ def render_tab(tab, n_intervals, n_log_intervals):
 
         return dbc.Container(components, fluid=True)
 
-    elif tab == 'tab-trades':
-        executed_df, exec_alert = load_csv(executed_trades_path, required_columns=['symbol','entry_price','entry_time','order_status'])
-        trades_df, alert = load_csv(trades_log_path, required_columns=['symbol', 'entry_time', 'pnl'])
-        freshness = data_freshness_alert(trades_log_path, 'Trade log')
-        exec_fresh = data_freshness_alert(executed_trades_path, 'Executed trades')
+    elif tab == "tab-trades":
+        executed_df, exec_alert = load_csv(
+            executed_trades_path,
+            required_columns=["symbol", "entry_price", "entry_time", "order_status"],
+        )
+        trades_df, alert = load_csv(
+            trades_log_path, required_columns=["symbol", "entry_time", "pnl"]
+        )
+        freshness = data_freshness_alert(trades_log_path, "Trade log")
+        exec_fresh = data_freshness_alert(executed_trades_path, "Executed trades")
         if alert:
             trades_table = alert
         else:
-            trades_df['entry_time'] = pd.to_datetime(trades_df['entry_time'])
-            trades_df.sort_values('entry_time', ascending=False, inplace=True)
-            trades_df['entry_time'] = trades_df['entry_time'].dt.strftime('%Y-%m-%d %H:%M')
-            columns = [{'name': c.replace('_',' ').title(), 'id': c} for c in trades_df.columns]
+            trades_df["entry_time"] = pd.to_datetime(trades_df["entry_time"])
+            trades_df.sort_values("entry_time", ascending=False, inplace=True)
+            trades_df["entry_time"] = trades_df["entry_time"].dt.strftime(
+                "%Y-%m-%d %H:%M"
+            )
+            columns = [
+                {"name": c.replace("_", " ").title(), "id": c}
+                for c in trades_df.columns
+            ]
             trades_table = dash_table.DataTable(
-                data=trades_df.to_dict('records'),
+                data=trades_df.to_dict("records"),
                 columns=columns,
                 page_size=20,
                 filter_action="native",
                 sort_action="native",
-                style_table={'overflowX':'auto'},
-                style_cell={'backgroundColor':'#212529','color':'#E0E0E0'},
+                style_table={"overflowX": "auto"},
+                style_cell={"backgroundColor": "#212529", "color": "#E0E0E0"},
                 style_data_conditional=[
-                    {'if':{'filter_query':'{pnl} < 0','column_id':'pnl'},'color':'#E57373'},
-                    {'if':{'filter_query':'{pnl} > 0','column_id':'pnl'},'color':'#4DB6AC'},
-                ]
+                    {
+                        "if": {"filter_query": "{pnl} < 0", "column_id": "pnl"},
+                        "color": "#E57373",
+                    },
+                    {
+                        "if": {"filter_query": "{pnl} > 0", "column_id": "pnl"},
+                        "color": "#4DB6AC",
+                    },
+                ],
             )
 
         if exec_alert:
             executed_table = exec_alert
         else:
-            executed_df['entry_time'] = pd.to_datetime(executed_df['entry_time'])
-            executed_df.sort_values('entry_time', ascending=False, inplace=True)
-            executed_df['entry_time'] = executed_df['entry_time'].dt.strftime('%Y-%m-%d %H:%M')
-            e_cols = [{'name': c.replace('_',' ').title(), 'id': c} for c in executed_df.columns]
+            executed_df["entry_time"] = pd.to_datetime(executed_df["entry_time"])
+            executed_df.sort_values("entry_time", ascending=False, inplace=True)
+            executed_df["entry_time"] = executed_df["entry_time"].dt.strftime(
+                "%Y-%m-%d %H:%M"
+            )
+            e_cols = [
+                {"name": c.replace("_", " ").title(), "id": c}
+                for c in executed_df.columns
+            ]
             executed_table = dash_table.DataTable(
-                data=executed_df.to_dict('records'),
+                data=executed_df.to_dict("records"),
                 columns=e_cols,
                 page_size=10,
-                style_table={'overflowX':'auto'},
-                style_cell={'backgroundColor':'#212529','color':'#E0E0E0'}
+                style_table={"overflowX": "auto"},
+                style_cell={"backgroundColor": "#212529", "color": "#E0E0E0"},
             )
 
         latest_file = trades_log_path
-        if os.path.exists(executed_trades_path) and os.path.getmtime(executed_trades_path) > os.path.getmtime(trades_log_path):
+        if os.path.exists(executed_trades_path) and os.path.getmtime(
+            executed_trades_path
+        ) > os.path.getmtime(trades_log_path):
             latest_file = executed_trades_path
         timestamp = html.Div(
             f"Data last refreshed: {file_timestamp(latest_file)}",
-            className='text-muted mb-2'
+            className="text-muted mb-2",
         )
         components = [timestamp]
         if freshness:
             components.append(freshness)
         if exec_fresh:
             components.append(exec_fresh)
-        components.extend([
-            html.H5('Executed Trades', className='text-light'),
-            executed_table,
-            html.Hr(),
-            html.H5('Trade Log', className='text-light'),
-            trades_table
-        ])
+        components.extend(
+            [
+                html.H5("Executed Trades", className="text-light"),
+                executed_table,
+                html.Hr(),
+                html.H5("Trade Log", className="text-light"),
+                trades_table,
+            ]
+        )
         return dbc.Container(components, fluid=True)
 
-    elif tab == 'tab-positions':
-        positions_df, alert = load_csv(open_positions_path, required_columns=['symbol','entry_price','entry_time'])
-        freshness = data_freshness_alert(open_positions_path, 'Open positions')
-        exec_fresh = data_freshness_alert(executed_trades_path, 'Executed trades')
+    elif tab == "tab-positions":
+        positions_df, alert = load_csv(
+            open_positions_path,
+            required_columns=["symbol", "entry_price", "entry_time"],
+        )
+        freshness = data_freshness_alert(open_positions_path, "Open positions")
+        exec_fresh = data_freshness_alert(executed_trades_path, "Executed trades")
         if positions_df.empty:
             fallback_df = fetch_positions_api()
             if not fallback_df.empty:
                 positions_df = fallback_df
-                alert = dbc.Alert('open_positions.csv empty; loaded positions from Alpaca API as fallback.', color='warning', className='m-2')
-                logger.info('open_positions.csv empty; loaded positions from Alpaca API as fallback.')
+                alert = dbc.Alert(
+                    "open_positions.csv empty; loaded positions from Alpaca API as fallback.",
+                    color="warning",
+                    className="m-2",
+                )
+                logger.info(
+                    "open_positions.csv empty; loaded positions from Alpaca API as fallback."
+                )
             elif alert:
                 return alert
         if alert and not positions_df.empty:
             alert = None
-        pnl_col = 'unrealized_pl' if 'unrealized_pl' in positions_df.columns else 'pnl' if 'pnl' in positions_df.columns else None
+        pnl_col = (
+            "unrealized_pl"
+            if "unrealized_pl" in positions_df.columns
+            else "pnl" if "pnl" in positions_df.columns else None
+        )
         if pnl_col is None:
-            return dbc.Alert("open_positions.csv missing unrealized P/L data.", color="warning", className="m-2")
-        positions_df['entry_time'] = pd.to_datetime(positions_df['entry_time']).dt.strftime('%Y-%m-%d %H:%M')
-        columns = [{'name': c.replace('_',' ').title(), 'id': c} for c in positions_df.columns]
+            return dbc.Alert(
+                "open_positions.csv missing unrealized P/L data.",
+                color="warning",
+                className="m-2",
+            )
+        positions_df["entry_time"] = pd.to_datetime(
+            positions_df["entry_time"]
+        ).dt.strftime("%Y-%m-%d %H:%M")
+        columns = [
+            {"name": c.replace("_", " ").title(), "id": c} for c in positions_df.columns
+        ]
         positions_fig = px.bar(
-            positions_df, x='symbol', y=pnl_col,
+            positions_df,
+            x="symbol",
+            y=pnl_col,
             color=positions_df[pnl_col] > 0,
-            color_discrete_map={True:'#4DB6AC', False:'#E57373'},
-            template='plotly_dark', title='Open Positions P/L'
+            color_discrete_map={True: "#4DB6AC", False: "#E57373"},
+            template="plotly_dark",
+            title="Open Positions P/L",
         )
         table = dash_table.DataTable(
-            data=positions_df.to_dict('records'),
+            data=positions_df.to_dict("records"),
             columns=columns,
-            style_table={'overflowX':'auto'},
-            style_cell={'backgroundColor':'#212529','color':'#E0E0E0'},
+            style_table={"overflowX": "auto"},
+            style_cell={"backgroundColor": "#212529", "color": "#E0E0E0"},
             style_data_conditional=[
-                {'if':{'filter_query':f'{{{pnl_col}}} < 0','column_id':pnl_col},'color':'#E57373'},
-                {'if':{'filter_query':f'{{{pnl_col}}} > 0','column_id':pnl_col},'color':'#4DB6AC'},
-            ]
+                {
+                    "if": {"filter_query": f"{{{pnl_col}}} < 0", "column_id": pnl_col},
+                    "color": "#E57373",
+                },
+                {
+                    "if": {"filter_query": f"{{{pnl_col}}} > 0", "column_id": pnl_col},
+                    "color": "#4DB6AC",
+                },
+            ],
         )
-        exec_df, exec_alert = load_csv(executed_trades_path, required_columns=['symbol','order_status','entry_time'])
+        exec_df, exec_alert = load_csv(
+            executed_trades_path,
+            required_columns=["symbol", "order_status", "entry_time"],
+        )
         if exec_alert:
             exec_table = exec_alert
         else:
-            exec_df['entry_time'] = pd.to_datetime(exec_df['entry_time']).dt.strftime('%Y-%m-%d %H:%M')
-            e_cols = [{'name': c.replace('_',' ').title(), 'id': c} for c in ['symbol','side','order_status','entry_time'] if c in exec_df.columns]
+            exec_df["entry_time"] = pd.to_datetime(exec_df["entry_time"]).dt.strftime(
+                "%Y-%m-%d %H:%M"
+            )
+            e_cols = [
+                {"name": c.replace("_", " ").title(), "id": c}
+                for c in ["symbol", "side", "order_status", "entry_time"]
+                if c in exec_df.columns
+            ]
             exec_table = dash_table.DataTable(
-                data=exec_df[['symbol','side','order_status','entry_time']].to_dict('records'),
+                data=exec_df[["symbol", "side", "order_status", "entry_time"]].to_dict(
+                    "records"
+                ),
                 columns=e_cols,
                 page_size=10,
-                style_table={'overflowX':'auto'},
-                style_cell={'backgroundColor':'#212529','color':'#E0E0E0'}
+                style_table={"overflowX": "auto"},
+                style_cell={"backgroundColor": "#212529", "color": "#E0E0E0"},
             )
         latest_file = open_positions_path
-        if os.path.exists(executed_trades_path) and os.path.getmtime(executed_trades_path) > os.path.getmtime(open_positions_path):
+        if os.path.exists(executed_trades_path) and os.path.getmtime(
+            executed_trades_path
+        ) > os.path.getmtime(open_positions_path):
             latest_file = executed_trades_path
         timestamp = html.Div(
             f"Data last refreshed: {file_timestamp(latest_file)}",
-            className='text-muted mb-2'
+            className="text-muted mb-2",
         )
         components = [timestamp]
         if freshness:
             components.append(freshness)
         if alert:
             components.append(alert)
-        components.extend([
-            dcc.Graph(figure=positions_fig),
-            table,
-            html.Hr(),
-            html.H5('Recent Order Status', className='text-light'),
-            exec_table
-        ])
+        components.extend(
+            [
+                dcc.Graph(figure=positions_fig),
+                table,
+                html.Hr(),
+                html.H5("Recent Order Status", className="text-light"),
+                exec_table,
+            ]
+        )
         if exec_fresh:
             components.append(exec_fresh)
         return dbc.Container(components, fluid=True)
 
-    elif tab == 'tab-symbols':
-        trades_df, alert = load_csv(trades_log_path, required_columns=['symbol', 'pnl'])
-        freshness = data_freshness_alert(trades_log_path, 'Trade log')
+    elif tab == "tab-symbols":
+        trades_df, alert = load_csv(trades_log_path, required_columns=["symbol", "pnl"])
+        freshness = data_freshness_alert(trades_log_path, "Trade log")
         if alert:
             return alert
-        symbol_perf = trades_df.groupby('symbol').agg({'pnl':['count','mean','sum']}).reset_index()
-        symbol_perf.columns = ['Symbol','Trades','Avg P/L','Total P/L']
-        symbol_fig = px.bar(symbol_perf, x='Symbol', y='Total P/L', color='Total P/L', template='plotly_dark', title='Performance by Symbol')
-        columns = [{'name': c, 'id': c} for c in symbol_perf.columns]
+        symbol_perf = (
+            trades_df.groupby("symbol")
+            .agg({"pnl": ["count", "mean", "sum"]})
+            .reset_index()
+        )
+        symbol_perf.columns = ["Symbol", "Trades", "Avg P/L", "Total P/L"]
+        symbol_fig = px.bar(
+            symbol_perf,
+            x="Symbol",
+            y="Total P/L",
+            color="Total P/L",
+            template="plotly_dark",
+            title="Performance by Symbol",
+        )
+        columns = [{"name": c, "id": c} for c in symbol_perf.columns]
         table = dash_table.DataTable(
-            data=symbol_perf.to_dict('records'),
+            data=symbol_perf.to_dict("records"),
             columns=columns,
-            style_table={'overflowX':'auto'},
-            style_cell={'backgroundColor':'#212529','color':'#E0E0E0'},
+            style_table={"overflowX": "auto"},
+            style_cell={"backgroundColor": "#212529", "color": "#E0E0E0"},
             style_data_conditional=[
-                {'if':{'filter_query':'{Total P/L} < 0','column_id':'Total P/L'},'color':'#E57373'},
-                {'if':{'filter_query':'{Total P/L} > 0','column_id':'Total P/L'},'color':'#4DB6AC'},
-            ]
+                {
+                    "if": {"filter_query": "{Total P/L} < 0", "column_id": "Total P/L"},
+                    "color": "#E57373",
+                },
+                {
+                    "if": {"filter_query": "{Total P/L} > 0", "column_id": "Total P/L"},
+                    "color": "#4DB6AC",
+                },
+            ],
         )
         timestamp = html.Div(
             f"Data last refreshed: {file_timestamp(trades_log_path)}",
-            className='text-muted mb-2'
+            className="text-muted mb-2",
         )
         components = [timestamp]
         if freshness:
@@ -500,24 +813,29 @@ def render_tab(tab, n_intervals, n_log_intervals):
         components.extend([dcc.Graph(figure=symbol_fig), table])
         return dbc.Container(components, fluid=True)
 
-    elif tab == 'tab-monitor':
-        closed_df, alert = load_csv(trades_log_path, required_columns=['symbol', 'exit_time', 'pnl'])
-        freshness = data_freshness_alert(trades_log_path, 'Trade log')
+    elif tab == "tab-monitor":
+        closed_df, alert = load_csv(
+            trades_log_path, required_columns=["symbol", "exit_time", "pnl"]
+        )
+        freshness = data_freshness_alert(trades_log_path, "Trade log")
         if alert:
             closed_table = alert
         else:
-            closed_df['exit_time'] = pd.to_datetime(closed_df['exit_time'])
-            closed_df.sort_values('exit_time', ascending=False, inplace=True)
+            closed_df["exit_time"] = pd.to_datetime(closed_df["exit_time"])
+            closed_df.sort_values("exit_time", ascending=False, inplace=True)
             recent_trades = closed_df.head(10)
-            columns = [{'name': c.replace('_',' ').title(), 'id': c} for c in recent_trades.columns]
+            columns = [
+                {"name": c.replace("_", " ").title(), "id": c}
+                for c in recent_trades.columns
+            ]
             closed_table = dash_table.DataTable(
-                data=recent_trades.to_dict('records'),
+                data=recent_trades.to_dict("records"),
                 columns=columns,
                 page_size=10,
-                filter_action='native',
-                sort_action='native',
-                style_table={'overflowX': 'auto'},
-                style_cell={'backgroundColor': '#212529', 'color': '#E0E0E0'}
+                filter_action="native",
+                sort_action="native",
+                style_table={"overflowX": "auto"},
+                style_cell={"backgroundColor": "#212529", "color": "#E0E0E0"},
             )
 
         monitor_lines = read_recent_lines(monitor_log_path, num_lines=100)[::-1]
@@ -525,53 +843,71 @@ def render_tab(tab, n_intervals, n_log_intervals):
         error_lines = read_recent_lines(error_log_path, num_lines=50)[::-1]
 
         def log_box(title, lines):
-            return html.Div([
-                html.H5(title, className='text-light'),
-                html.Pre(
-                    format_log_lines(lines),
-                    style={'maxHeight':'200px','overflowY':'auto','backgroundColor':'#272B30','color':'#E0E0E0','padding':'0.5rem'}
-                )
-            ], className='mb-3')
+            return html.Div(
+                [
+                    html.H5(title, className="text-light"),
+                    html.Pre(
+                        format_log_lines(lines),
+                        style={
+                            "maxHeight": "200px",
+                            "overflowY": "auto",
+                            "backgroundColor": "#272B30",
+                            "color": "#E0E0E0",
+                            "padding": "0.5rem",
+                        },
+                    ),
+                ],
+                className="mb-3",
+            )
 
         heartbeat = html.Div(
             [
-                html.Span(f"Last pipeline run: {file_timestamp(pipeline_log_path)}", className='me-3'),
-                html.Span(f"Last monitor update: {file_timestamp(monitor_log_path)}")
-            ], className='text-muted'
+                html.Span(
+                    f"Last pipeline run: {file_timestamp(pipeline_log_path)}",
+                    className="me-3",
+                ),
+                html.Span(f"Last monitor update: {file_timestamp(monitor_log_path)}"),
+            ],
+            className="text-muted",
         )
 
         timestamp = html.Div(
             f"Data last refreshed: {file_timestamp(trades_log_path)}",
-            className='text-muted mb-2'
+            className="text-muted mb-2",
         )
 
         components = [timestamp]
         if freshness:
             components.append(freshness)
-        components.extend([
-            html.H5('Recently Closed Positions', className='text-light'),
-            closed_table,
-            html.Hr(),
-            log_box('Monitor Log', monitor_lines),
-            log_box('Execution Log', exec_lines),
-            log_box('Errors', error_lines),
-            heartbeat
-        ])
+        components.extend(
+            [
+                html.H5("Recently Closed Positions", className="text-light"),
+                closed_table,
+                html.Hr(),
+                log_box("Monitor Log", monitor_lines),
+                log_box("Execution Log", exec_lines),
+                log_box("Errors", error_lines),
+                heartbeat,
+            ]
+        )
         return dbc.Container(components, fluid=True)
+
 
 # Callback for modal interaction
 @app.callback(
-    [Output('detail-modal', 'is_open'), Output('modal-content', 'children')],
-    [Input('top-candidates-table', 'active_cell'), Input('close-modal', 'n_clicks')],
-    [State('detail-modal', 'is_open')]
+    [Output("detail-modal", "is_open"), Output("modal-content", "children")],
+    [Input("top-candidates-table", "active_cell"), Input("close-modal", "n_clicks")],
+    [State("detail-modal", "is_open")],
 )
 def toggle_modal(active_cell, close_click, is_open):
     if active_cell and not is_open:
-        return True, html.Div("Detailed information would appear here (charts, additional stats, etc.)")
+        return True, html.Div(
+            "Detailed information would appear here (charts, additional stats, etc.)"
+        )
     if close_click and is_open:
         return False, ""
     return is_open, ""
 
-if __name__ == '__main__':
-    app.run(debug=False)
 
+if __name__ == "__main__":
+    app.run(debug=False)

--- a/scripts/update_dashboard_data.py
+++ b/scripts/update_dashboard_data.py
@@ -3,7 +3,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 import shutil
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timedelta
 from tempfile import NamedTemporaryFile
 
 import pandas as pd
@@ -11,29 +11,60 @@ from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import GetOrdersRequest
 from alpaca.trading.enums import QueryOrderStatus
 from dotenv import load_dotenv
+import requests
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join(BASE_DIR, 'data')
-LOG_DIR = os.path.join(BASE_DIR, 'logs')
+DATA_DIR = os.path.join(BASE_DIR, "data")
+LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(DATA_DIR, exist_ok=True)
 os.makedirs(LOG_DIR, exist_ok=True)
 
-load_dotenv(os.path.join(BASE_DIR, '.env'))
+load_dotenv(os.path.join(BASE_DIR, ".env"))
 
-logger = logging.getLogger('update_dashboard_data')
+ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
+
+logger = logging.getLogger("update_dashboard_data")
 logger.setLevel(logging.INFO)
 handler = RotatingFileHandler(
-    os.path.join(LOG_DIR, 'data_update.log'), maxBytes=2_000_000, backupCount=5
+    os.path.join(LOG_DIR, "data_update.log"), maxBytes=2_000_000, backupCount=5
 )
-formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
+formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
-API_KEY = os.getenv('APCA_API_KEY_ID')
-API_SECRET = os.getenv('APCA_API_SECRET_KEY')
+API_KEY = os.getenv("APCA_API_KEY_ID")
+API_SECRET = os.getenv("APCA_API_SECRET_KEY")
 
 trading_client = TradingClient(API_KEY, API_SECRET, paper=True)
-DB_PATH = os.path.join(DATA_DIR, 'dashboard.db')
+DB_PATH = os.path.join(DATA_DIR, "dashboard.db")
+
+OPEN_POSITIONS_CSV = os.path.join(DATA_DIR, "open_positions.csv")
+TRADES_LOG_CSV = os.path.join(DATA_DIR, "trades_log.csv")
+EXECUTED_TRADES_CSV = os.path.join(DATA_DIR, "executed_trades.csv")
+
+
+def send_alert(message: str):
+    """Send alert via webhook if configured."""
+    if not ALERT_WEBHOOK_URL:
+        return
+    try:
+        requests.post(ALERT_WEBHOOK_URL, json={"text": message}, timeout=5)
+    except Exception as exc:
+        logger.error("Failed to send alert: %s", exc)
+
+
+def log_if_stale(file_path: str, name: str, threshold_minutes: int = 15):
+    """Log a warning if ``file_path`` is older than ``threshold_minutes``."""
+    if not os.path.exists(file_path):
+        logger.warning("%s missing: %s", name, file_path)
+        send_alert(f"{name} missing: {file_path}")
+        return
+    age = datetime.utcnow() - datetime.utcfromtimestamp(os.path.getmtime(file_path))
+    if age > timedelta(minutes=threshold_minutes):
+        minutes = age.total_seconds() / 60
+        msg = f"{name} is stale ({minutes:.1f} minutes old)"
+        logger.warning(msg)
+        send_alert(msg)
 
 
 def init_db():
@@ -74,7 +105,7 @@ def init_db():
 
 
 def write_csv_atomic(df: pd.DataFrame, dest: str):
-    tmp = NamedTemporaryFile('w', delete=False, dir=DATA_DIR, newline='')
+    tmp = NamedTemporaryFile("w", delete=False, dir=DATA_DIR, newline="")
     df.to_csv(tmp.name, index=False)
     tmp.close()
     shutil.move(tmp.name, dest)
@@ -85,25 +116,33 @@ def update_open_positions():
         positions = trading_client.get_all_positions()
         rows = [
             {
-                'symbol': p.symbol,
-                'qty': float(p.qty),
-                'avg_entry_price': float(p.avg_entry_price),
-                'current_price': float(p.current_price),
-                'unrealized_pl': float(p.unrealized_pl),
-                'entry_time': getattr(p, 'created_at', datetime.utcnow()).isoformat(),
+                "symbol": p.symbol,
+                "qty": float(p.qty),
+                "avg_entry_price": float(p.avg_entry_price),
+                "current_price": float(p.current_price),
+                "unrealized_pl": float(p.unrealized_pl),
+                "entry_time": getattr(p, "created_at", datetime.utcnow()).isoformat(),
             }
             for p in positions
         ]
         df = pd.DataFrame(rows)
         if df.empty:
-            df = pd.DataFrame(columns=['symbol', 'qty', 'avg_entry_price', 'current_price', 'unrealized_pl', 'entry_time'])
-        path = os.path.join(DATA_DIR, 'open_positions.csv')
-        write_csv_atomic(df, path)
+            df = pd.DataFrame(
+                columns=[
+                    "symbol",
+                    "qty",
+                    "avg_entry_price",
+                    "current_price",
+                    "unrealized_pl",
+                    "entry_time",
+                ]
+            )
+        write_csv_atomic(df, OPEN_POSITIONS_CSV)
         with sqlite3.connect(DB_PATH) as conn:
-            df.to_sql('open_positions', conn, if_exists='replace', index=False)
-        logger.info('Updated open_positions.csv successfully.')
+            df.to_sql("open_positions", conn, if_exists="replace", index=False)
+        logger.info("Updated open_positions.csv successfully.")
     except Exception as e:
-        logger.exception('Failed to update open_positions.csv due to %s', e)
+        logger.exception("Failed to update open_positions.csv due to %s", e)
 
 
 def fetch_all_orders(limit=500):
@@ -111,7 +150,9 @@ def fetch_all_orders(limit=500):
     orders = []
     end = None
     while True:
-        req = GetOrdersRequest(status=QueryOrderStatus.ALL, limit=limit, until=end, direction='desc')
+        req = GetOrdersRequest(
+            status=QueryOrderStatus.ALL, limit=limit, until=end, direction="desc"
+        )
         chunk = trading_client.get_orders(filter=req)
         if not chunk:
             break
@@ -137,106 +178,161 @@ def update_order_history():
             qty = float(order.filled_qty or 0)
             price = float(order.filled_avg_price or 0)
 
-            entry_price = ''
-            exit_price = ''
-            entry_time = ''
-            exit_time = ''
+            entry_price = ""
+            exit_price = ""
+            entry_time = ""
+            exit_time = ""
             pnl = 0.0
 
-            if side == 'buy':
+            if side == "buy":
                 entry_price = price
                 entry_time = order.filled_at.isoformat()
-                open_positions[symbol] = {'price': price, 'qty': qty, 'time': entry_time}
-            elif side == 'sell':
+                open_positions[symbol] = {
+                    "price": price,
+                    "qty": qty,
+                    "time": entry_time,
+                }
+            elif side == "sell":
                 exit_price = price
                 exit_time = order.filled_at.isoformat()
                 if symbol in open_positions:
                     info = open_positions.pop(symbol)
-                    entry_price = info['price']
-                    entry_time = info['time']
-                    pnl = (price - info['price']) * info['qty']
+                    entry_price = info["price"]
+                    entry_time = info["time"]
+                    pnl = (price - info["price"]) * info["qty"]
 
-            records.append({
-                'id': order.id,
-                'symbol': symbol,
-                'side': side,
-                'filled_qty': qty,
-                'entry_price': entry_price,
-                'exit_price': exit_price,
-                'entry_time': entry_time,
-                'exit_time': exit_time,
-                'order_status': order.status.value if order.status else 'unknown',
-                'pnl': pnl,
-            })
+            records.append(
+                {
+                    "id": order.id,
+                    "symbol": symbol,
+                    "side": side,
+                    "filled_qty": qty,
+                    "entry_price": entry_price,
+                    "exit_price": exit_price,
+                    "entry_time": entry_time,
+                    "exit_time": exit_time,
+                    "order_status": order.status.value if order.status else "unknown",
+                    "pnl": pnl,
+                }
+            )
 
-        df = pd.DataFrame(records).drop_duplicates('id')
-        cols = ['id','symbol','side','filled_qty','entry_price','exit_price','entry_time','exit_time','order_status','pnl']
+        df = pd.DataFrame(records).drop_duplicates("id")
+        cols = [
+            "id",
+            "symbol",
+            "side",
+            "filled_qty",
+            "entry_price",
+            "exit_price",
+            "entry_time",
+            "exit_time",
+            "order_status",
+            "pnl",
+        ]
         if df.empty:
             df = pd.DataFrame(columns=cols)
 
-        write_csv_atomic(df, os.path.join(DATA_DIR, 'trades_log.csv'))
-        executed_df = df[df['filled_qty'] > 0]
-        write_csv_atomic(executed_df, os.path.join(DATA_DIR, 'executed_trades.csv'))
+        write_csv_atomic(df, TRADES_LOG_CSV)
+        executed_df = df[df["filled_qty"] > 0]
+        write_csv_atomic(executed_df, EXECUTED_TRADES_CSV)
 
         with sqlite3.connect(DB_PATH) as conn:
-            df.to_sql('trades_log', conn, if_exists='replace', index=False)
-            executed_df.to_sql('executed_trades', conn, if_exists='replace', index=False)
+            df.to_sql("trades_log", conn, if_exists="replace", index=False)
+            executed_df.to_sql(
+                "executed_trades", conn, if_exists="replace", index=False
+            )
 
-        logger.info('Updated trades_log.csv and executed_trades.csv successfully.')
+        logger.info("Updated trades_log.csv and executed_trades.csv successfully.")
     except Exception as e:
-        logger.exception('Failed to update order history due to %s', e)
+        logger.exception("Failed to update order history due to %s", e)
 
 
 def update_metrics_summary():
     """Compute and persist summary trading metrics."""
     try:
-        trades_path = os.path.join(DATA_DIR, 'trades_log.csv')
-        if not os.path.exists(trades_path):
+        if not os.path.exists(TRADES_LOG_CSV):
             df = pd.DataFrame()
         else:
-            df = pd.read_csv(trades_path)
+            df = pd.read_csv(TRADES_LOG_CSV)
 
-        if df.empty or 'pnl' not in df.columns:
-            summary_df = pd.DataFrame([
-                {
-                    'Total Trades': 0,
-                    'Total Wins': 0,
-                    'Total Losses': 0,
-                    'Win Rate (%)': 0.0,
-                    'Total Net PnL': 0.0,
-                    'Average Return per Trade': 0.0,
-                }
-            ])
+        if df.empty or "pnl" not in df.columns:
+            summary_df = pd.DataFrame(
+                [
+                    {
+                        "Total Trades": 0,
+                        "Total Wins": 0,
+                        "Total Losses": 0,
+                        "Win Rate (%)": 0.0,
+                        "Total Net PnL": 0.0,
+                        "Average Return per Trade": 0.0,
+                    }
+                ]
+            )
         else:
             total_trades = len(df)
-            wins = len(df[df['pnl'] > 0])
+            wins = len(df[df["pnl"] > 0])
             losses = total_trades - wins
             win_rate = (wins / total_trades) * 100 if total_trades else 0.0
-            total_pnl = df['pnl'].sum()
-            avg_return = df['pnl'].mean()
-            summary_df = pd.DataFrame([
-                {
-                    'Total Trades': total_trades,
-                    'Total Wins': wins,
-                    'Total Losses': losses,
-                    'Win Rate (%)': round(win_rate, 2),
-                    'Total Net PnL': round(total_pnl, 2),
-                    'Average Return per Trade': round(avg_return, 2),
-                }
-            ])
+            total_pnl = df["pnl"].sum()
+            avg_return = df["pnl"].mean()
+            summary_df = pd.DataFrame(
+                [
+                    {
+                        "Total Trades": total_trades,
+                        "Total Wins": wins,
+                        "Total Losses": losses,
+                        "Win Rate (%)": round(win_rate, 2),
+                        "Total Net PnL": round(total_pnl, 2),
+                        "Average Return per Trade": round(avg_return, 2),
+                    }
+                ]
+            )
 
-        write_csv_atomic(summary_df, os.path.join(DATA_DIR, 'metrics_summary.csv'))
+        write_csv_atomic(summary_df, os.path.join(DATA_DIR, "metrics_summary.csv"))
         with sqlite3.connect(DB_PATH) as conn:
-            summary_df.to_sql('metrics_summary', conn, if_exists='replace', index=False)
-        logger.info('Updated metrics_summary.csv successfully.')
+            summary_df.to_sql("metrics_summary", conn, if_exists="replace", index=False)
+        logger.info("Updated metrics_summary.csv successfully.")
     except Exception as e:
-        logger.exception('Failed to update metrics_summary.csv due to %s', e)
+        logger.exception("Failed to update metrics_summary.csv due to %s", e)
 
 
-if __name__ == '__main__':
+def validate_open_positions():
+    """Cross-check open_positions.csv against live Alpaca positions."""
+    try:
+        live = {p.symbol: float(p.qty) for p in trading_client.get_all_positions()}
+        if not os.path.exists(OPEN_POSITIONS_CSV):
+            logger.warning("open_positions.csv not found for validation")
+            return
+        df = pd.read_csv(OPEN_POSITIONS_CSV)
+        csv_map = {row["symbol"]: float(row["qty"]) for _, row in df.iterrows()}
+        mismatches = []
+        for symbol, qty in csv_map.items():
+            live_qty = live.get(symbol)
+            if live_qty is None:
+                mismatches.append(f"{symbol} not in Alpaca")
+            elif float(live_qty) != float(qty):
+                mismatches.append(f"{symbol} qty csv={qty} live={live_qty}")
+        for symbol, qty in live.items():
+            if symbol not in csv_map:
+                mismatches.append(f"{symbol} missing from CSV")
+        if mismatches:
+            msg = "Open positions discrepancy detected: " + "; ".join(mismatches)
+            logger.warning(msg)
+            send_alert(msg)
+    except Exception as e:
+        logger.exception("Failed to validate open positions: %s", e)
+
+
+if __name__ == "__main__":
     init_db()
     update_open_positions()
     update_order_history()
     update_metrics_summary()
-    logger.info('Dashboard data refresh complete')
-
+    validate_open_positions()
+    for pth, name in [
+        (OPEN_POSITIONS_CSV, "open_positions.csv"),
+        (TRADES_LOG_CSV, "trades_log.csv"),
+        (EXECUTED_TRADES_CSV, "executed_trades.csv"),
+    ]:
+        log_if_stale(pth, name)
+    logger.info("Dashboard data refresh complete")


### PR DESCRIPTION
## Summary
- remove stale open positions in `monitor_positions`
- load screener data from `latest_candidates.csv`
- validate dashboard CSV files against Alpaca positions
- log stale files and send optional alerts

## Testing
- `python -m py_compile scripts/monitor_positions.py scripts/update_dashboard_data.py dashboards/dashboard_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687131d001d083319f0d1958c145f55e