### PR TITLE
Fix script paths in pipeline

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -39,9 +39,18 @@ def run_step(step_name, command):
 if __name__ == "__main__":
     logging.info("Pipeline execution started.")
     steps = [
-        ("Screener", ["python", "scripts/screener.py"]),
-        ("Backtest", ["python", "scripts/backtest.py"]),
-        ("Metrics Calculation", ["python", "scripts/metrics.py"]),
+        (
+            "Screener",
+            ["python", "/home/RasPatrick/jbravo_screener/scripts/screener.py"],
+        ),
+        (
+            "Backtest",
+            ["python", "/home/RasPatrick/jbravo_screener/scripts/backtest.py"],
+        ),
+        (
+            "Metrics Calculation",
+            ["python", "/home/RasPatrick/jbravo_screener/scripts/metrics.py"],
+        ),
     ]
     for name, cmd in steps:
         try:


### PR DESCRIPTION
## Summary
- adjust `run_pipeline.py` to invoke scripts with their full absolute paths

## Testing
- `python -m py_compile scripts/run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_687193da4f0883319ffb25d9e4f183a2