### PR TITLE
Fix timezone aware filter

### DIFF
--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -56,7 +56,7 @@ def parse_execution_log(log_name: str = "execute_trades.log") -> dict:
         logger.warning("Execution log not found: %s", path)
         return stats
 
-    one_week_ago = pd.Timestamp.utcnow().tz_localize("UTC") - pd.Timedelta(days=7)
+    one_week_ago = pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=7)
     ts_pattern = re.compile(r"^(\d{4}-\d{2}-\d{2})\s(\d{2}:\d{2}:\d{2})")
     with open(path, "r") as fh:
         for line in fh:


### PR DESCRIPTION
## Summary
- avoid localizing an already aware timestamp in weekly_summary

## Testing
- `python -m py_compile scripts/weekly_summary.py`
- `pip install pandas` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873d32d512483319059511007307858