### PR TITLE
Fix timezone aware Timestamp

### DIFF
--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -86,7 +86,8 @@ def parse_execution_log(log_name: str = "execute_trades.log") -> dict:
 
 def calculate_weekly_summary() -> dict:
     """Compute weekly trading metrics from CSV files."""
-    today = pd.Timestamp.utcnow().tz_localize("UTC")
+    # Use timezone-aware timestamp directly to avoid localization errors
+    today = pd.Timestamp.now(tz="UTC")
     one_week_ago = today - pd.Timedelta(days=7)
 
     executed_trades = load_csv("executed_trades.csv")


### PR DESCRIPTION
## Summary
- avoid TypeError when localizing today's timestamp in `weekly_summary.py`

## Testing
- `python -m py_compile scripts/weekly_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_6873d5c7545883319cb96c4bf2ffc721