### PR TITLE
Fix import in backtest script

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -15,7 +15,7 @@ import pandas as pd
 from dotenv import load_dotenv
 
 # Import indicator helpers from screener to keep the scoring consistent
-from . import screener
+from scripts import screener
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.makedirs(os.path.join(BASE_DIR, "logs"), exist_ok=True)


### PR DESCRIPTION
## Summary
- fix relative import in `backtest.py`

## Testing
- `python scripts/backtest.py` *(fails: ModuleNotFoundError due to missing numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6873f4d015888331ad6ede65cd9d2357