### PR TITLE
Fix import path in backtest module

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -15,7 +15,7 @@ import pandas as pd
 from dotenv import load_dotenv
 
 # Import indicator helpers from screener to keep the scoring consistent
-from .screener import adx, aroon, macd, obv, rsi
+from scripts.screener import adx, aroon, macd, obv, rsi
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.makedirs(os.path.join(BASE_DIR, "logs"), exist_ok=True)


### PR DESCRIPTION
## Summary
- use absolute import in `backtest.py`

## Testing
- `python scripts/backtest.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6873fa0134e8833183a8dbe8af0efdfb