### PR TITLE
Fix backtest import path

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import os
+import sys
+
+# Insert the project root directory into Python's module search path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import logging
 import math
-import os
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List


### PR DESCRIPTION
## Summary
- update `scripts/backtest.py` to insert project root on `sys.path`

## Testing
- `python scripts/backtest.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6873fb61f1ec8331ba5b9e9c1bc8e7f6