### PR TITLE
Add entry_time to backtest trade logs

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -396,6 +396,12 @@ def run_backtest(symbols: List[str]) -> None:
     bt.run()
 
     trades_df = bt.results()
+    # Add entry_time column for dashboard compatibility
+    if "entry_date" in trades_df.columns and "entry_time" not in trades_df.columns:
+        trades_df["entry_time"] = trades_df["entry_date"]
+    if "exit_date" in trades_df.columns and "exit_time" not in trades_df.columns:
+        trades_df["exit_time"] = trades_df["exit_date"]
+
     equity_df = bt.equity()
     metrics = bt.metrics()
 


### PR DESCRIPTION
## Summary
- ensure the CSV generated from `backtest.py` contains `entry_time`

## Testing
- `python scripts/backtest.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68743767e70c8331b363fee08a1b8cef