### PR TITLE
Fix cache_bars tuple index handling

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -36,9 +36,11 @@ def cache_bars(symbol: str, data_client, cache_dir: str, days: int = 800) -> pd.
         return df
 
     if not new_df.empty:
-        first_idx = new_df.index.tolist()[0]
-        if isinstance(first_idx, tuple):
-            idx_df = pd.DataFrame(new_df.index.tolist(), columns=["year", "month", "day"])
+        idx_list = new_df.index.tolist()
+        if idx_list and isinstance(idx_list[0], tuple):
+            n = len(idx_list[0])
+            col_names = ["year", "month", "day"][:n]
+            idx_df = pd.DataFrame(idx_list, columns=col_names)
             new_df.index = pd.to_datetime(idx_df)
         else:
             new_df.index = pd.to_datetime(new_df.index)


### PR DESCRIPTION
## Summary
- handle variable-length tuple indexes in `cache_bars`

## Testing
- `python -m py_compile scripts/utils.py`
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687453e8b3dc8331812c76650288f002