### PR TITLE
Fix screener scoring crash

### DIFF
--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -192,6 +192,13 @@ for fut in futures:
 
 # Convert to DataFrame and rank
 ranked_df = pd.DataFrame(ranked_candidates)
+if "score" not in ranked_df.columns:
+    logging.error(
+        "Screener output missing 'score'. DataFrame columns: %s",
+        ranked_df.columns.tolist(),
+    )
+    # Optional: send webhook alert for failure
+    sys.exit(1)
 ranked_df.sort_values(by="score", ascending=False, inplace=True)
 
 csv_path = os.path.join(BASE_DIR, 'data', 'top_candidates.csv')


### PR DESCRIPTION
## Summary
- guard screener ranking if score column missing

## Testing
- `python -m py_compile scripts/screener.py`

------
https://chatgpt.com/codex/tasks/task_e_68746017e0148331bd923a5f0750fdba