### PR TITLE
Fix logging handlers import in backtest

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -9,6 +9,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import logging
+import logging.handlers
 import math
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary
- import `logging.handlers` in the backtest script for RotatingFileHandler

## Testing
- `python -m py_compile scripts/backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_68746e819eac8331b7ce74aef26a35f4