### PR TITLE
Fix pnl column in trade logs

### DIFF
--- a/scripts/create_dummy_data.py
+++ b/scripts/create_dummy_data.py
@@ -72,6 +72,7 @@ def populate_dummy_data():
                 'exit_time': t['exit_time'].strftime('%Y-%m-%d %H:%M:%S'),
                 'order_status': 'Filled',
                 'net_pnl': t['pnl'],
+                'pnl': t['pnl'],
                 'order_type': 'sell',
             }
         )

--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -191,6 +191,7 @@ def update_trades_log():
                 'exit_time': exit_time,
                 'order_status': order.status.value,
                 'net_pnl': pnl,
+                'pnl': pnl,
                 'order_type': getattr(order, 'order_type', ''),
             })
 
@@ -203,6 +204,7 @@ def update_trades_log():
             'exit_time',
             'order_status',
             'net_pnl',
+            'pnl',
             'order_type',
         ])
         csv_path = os.path.join(BASE_DIR, 'data', 'trades_log.csv')

--- a/scripts/fetch_trades_history.py
+++ b/scripts/fetch_trades_history.py
@@ -94,6 +94,7 @@ for order in orders_sorted:
             'exit_time': exit_time,
             'order_status': order.status.value if order.status else 'unknown',
             'net_pnl': pnl,
+            'pnl': pnl,
             'order_type': getattr(order, 'order_type', ''),
         }
     )
@@ -110,6 +111,7 @@ cols = [
     'exit_time',
     'order_status',
     'net_pnl',
+    'pnl',
     'order_type',
 ]
 


### PR DESCRIPTION
## Summary
- add `pnl` when saving trades in `execute_trades.py`
- extend dashboard update scripts to always include a `pnl` column
- store `pnl` in dummy data and fetched trade history

## Testing
- `python scripts/execute_trades.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python scripts/update_dashboard_data.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6875c52f03688331bd688c0919670c32