### PR TITLE
Fix entry order sorting with missing filled times

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -328,7 +328,11 @@ def daily_exit_check():
             logging.warning("No entry order found for %s, skipping.", symbol)
             continue
 
-        entry_order = sorted(entry_orders, key=lambda o: o.filled_at, reverse=True)[0]
+        valid_entries = [o for o in entry_orders if o.filled_at is not None]
+        if not valid_entries:
+            logging.warning(f"No filled entry orders found for symbol {symbol}. Skipping exit check.")
+            continue
+        entry_order = max(valid_entries, key=lambda o: o.filled_at)
         entry_date = entry_order.filled_at.date()
         days_held = (datetime.now(timezone.utc).date() - entry_date).days
 


### PR DESCRIPTION
## Summary
- guard against missing `filled_at` timestamps when checking exit conditions

## Testing
- `python -m py_compile scripts/execute_trades.py`


------
https://chatgpt.com/codex/tasks/task_e_68767c5bce488331a56d2d9d5208caa3