### PR TITLE
Fix open_positions csv columns

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -174,9 +174,16 @@ def save_open_positions_csv():
             'order_type',
         ]
 
-        df = pd.DataFrame(data, columns=columns)
+        df = pd.DataFrame(data)
         if df.empty:
             df = pd.DataFrame(columns=columns)
+
+        df['side'] = df.get('side', 'long')
+        df['order_status'] = df.get('order_status', 'open')
+        df['net_pnl'] = df.get('unrealized_pl', 0.0)
+        df['pnl'] = df['net_pnl']
+        df['order_type'] = df.get('order_type', 'limit')
+        df = df[columns]
 
         csv_path = os.path.join(BASE_DIR, 'data', 'open_positions.csv')
         df.to_csv(csv_path, index=False)

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -220,7 +220,14 @@ def save_positions_csv(positions):
             "order_type",
         ]
 
-        df = pd.DataFrame(rows, columns=columns)
+        df = pd.DataFrame(rows)
+
+        df['side'] = df.get('side', 'long')
+        df['order_status'] = df.get('order_status', 'open')
+        df['net_pnl'] = df.get('unrealized_pl', 0.0)
+        df['pnl'] = df['net_pnl']
+        df['order_type'] = df.get('order_type', 'limit')
+        df = df[columns]
 
         removed = []
         if not existing.empty and "symbol" in existing.columns:

--- a/scripts/update_dashboard_data.py
+++ b/scripts/update_dashboard_data.py
@@ -175,7 +175,7 @@ def update_open_positions():
                         "order_status": "open",
                         "net_pnl": float(p.unrealized_pl),
                         "pnl": float(p.unrealized_pl),
-                        "order_type": getattr(p, "order_type", "market"),
+                        "order_type": getattr(p, "order_type", "limit"),
                     }
                 )
             except Exception as exc:
@@ -190,7 +190,7 @@ def update_open_positions():
         df['order_status'] = df.get('order_status', 'open')
         df['net_pnl'] = df.get('unrealized_pl', 0.0)
         df['pnl'] = df['net_pnl']
-        df['order_type'] = df.get('order_type', 'market')
+        df['order_type'] = df.get('order_type', 'limit')
         df = df[columns]
         write_csv_atomic(df, OPEN_POSITIONS_CSV)
         with sqlite3.connect(DB_PATH) as conn:


### PR DESCRIPTION
## Summary
- ensure execute_trades saves open positions with side, order_status, net_pnl, pnl, order_type
- ensure monitor_positions saves the same columns
- default order_type to `limit` in update_dashboard_data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6877051bf06c8331af7818cd99266823