### PR TITLE
Add side column to trade CSVs

### DIFF
--- a/scripts/create_dummy_data.py
+++ b/scripts/create_dummy_data.py
@@ -74,6 +74,7 @@ def populate_dummy_data():
                 'net_pnl': t['pnl'],
                 'pnl': t['pnl'],
                 'order_type': 'sell',
+                'side': 'sell',
             }
         )
     df_trades_log = pd.DataFrame(normalized)

--- a/scripts/fetch_trades_history.py
+++ b/scripts/fetch_trades_history.py
@@ -96,6 +96,7 @@ for order in orders_sorted:
             'net_pnl': pnl,
             'pnl': pnl,
             'order_type': getattr(order, 'order_type', ''),
+            'side': side,
         }
     )
 
@@ -113,6 +114,7 @@ cols = [
     'net_pnl',
     'pnl',
     'order_type',
+    'side',
 ]
 
 df[cols].to_csv(os.path.join(data_dir, 'trades_log.csv'), index=False)

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -113,6 +113,7 @@ TRADE_COLUMNS = [
     "net_pnl",
     "order_type",
     "exit_reason",
+    "side",
 ]
 
 for path in (executed_trades_path, trades_log_path):
@@ -379,6 +380,7 @@ def log_trade_exit(
         "net_pnl": 0.0,
         "order_type": order_type,
         "exit_reason": exit_reason,
+        "side": "sell",
     }
     for path in (executed_trades_path, trades_log_path):
         try:

--- a/scripts/update_dashboard_data.py
+++ b/scripts/update_dashboard_data.py
@@ -113,7 +113,8 @@ def init_db():
                     exit_time TEXT,
                     net_pnl REAL,
                     order_status TEXT,
-                    order_type TEXT
+                    order_type TEXT,
+                    side TEXT
             )"""
         )
         conn.execute(
@@ -129,7 +130,8 @@ def init_db():
                     exit_time TEXT,
                     net_pnl REAL,
                     order_status TEXT,
-                    order_type TEXT
+                    order_type TEXT,
+                    side TEXT
             )"""
         )
 
@@ -272,6 +274,7 @@ def update_order_history():
                     "pnl": pnl,
                     "order_status": order.status.value if order.status else "unknown",
                     "order_type": getattr(order, "order_type", ""),
+                    "side": side,
                 }
             )
 
@@ -289,6 +292,7 @@ def update_order_history():
             "pnl",
             "order_status",
             "order_type",
+            "side",
         ]
         df = pd.DataFrame(records, columns=cols)
 


### PR DESCRIPTION
## Summary
- include `side` column for trade logs
- update executed trade recording and dashboard update logic
- revise dummy data and monitoring scripts to include `side`

## Testing
- `python -m py_compile scripts/*.py`
- `pip install pandas` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68770c87444c8331855e40dbb6ca6985