### PR TITLE
Integrate enhanced logging and scoring

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -48,6 +48,8 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
 
+logging.info("Backtest script started.")
+
 dotenv_path = os.path.join(BASE_DIR, ".env")
 load_dotenv(dotenv_path)
 
@@ -399,6 +401,17 @@ def run_backtest(symbols: List[str]) -> None:
             columns=["symbol", "trades", "wins", "losses", "net_pnl", "win_rate"]
         )
 
+    summary_df["timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M")
+    summary_df["symbols_tested"] = len(symbols)
+
+    for _, row in summary_df.iterrows():
+        logging.info(
+            "Backtest %s win_rate=%.2f%% net_pnl=%.2f",
+            row.symbol,
+            row.win_rate,
+            row.net_pnl,
+        )
+
     trades_path = os.path.join(BASE_DIR, "data", "trades_log.csv")
     equity_path = os.path.join(BASE_DIR, "data", "equity_curve.csv")
     metrics_path = os.path.join(BASE_DIR, "data", "backtest_results.csv")
@@ -416,6 +429,7 @@ if __name__ == "__main__":
         symbols_df = pd.read_csv(csv_path)
         symbol_list = symbols_df.iloc[:, 0].tolist()
         run_backtest(symbol_list)
+        logging.info("Backtest script finished.")
     except Exception as exc:
         logging.error("Backtest failed: %s", exc)
 


### PR DESCRIPTION
## Summary
- add start and finish messages to all key scripts
- export indicator breakdown and reasons in screener
- track win rate and PnL per symbol in backtest
- log metrics summary and add timestamps
- display scored candidate data and screener log in dashboard

## Testing
- `python -m py_compile dashboards/dashboard_app.py scripts/backtest.py scripts/metrics.py scripts/execute_trades.py scripts/screener.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687acd06c8788331bd640010e47bdee0