### PR TITLE
Fix pipeline path and DB schema

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -2,6 +2,10 @@
 import os
 import sys
 
+# Ensure the script runs from the repository root regardless of where it is
+# invoked from.
+os.chdir(os.path.dirname(__file__))
+
 # Add project root to sys.path so that sibling packages (like scripts) can be imported
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -47,7 +51,11 @@ def send_alert(msg: str) -> None:
 def run_step(step_name, command):
     logging.info("Starting %s...", step_name)
     try:
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(
+            command,
+            cwd=os.path.dirname(__file__),
+            capture_output=True,
+        )
         logging.info("%s stdout:\n%s", step_name, result.stdout.decode())
         logging.info("%s stderr:\n%s", step_name, result.stderr.decode())
         if result.returncode != 0:
@@ -65,15 +73,15 @@ if __name__ == "__main__":
     steps = [
         (
             "Screener",
-            ["python", "scripts/screener.py"],
+            [sys.executable, "scripts/screener.py"],
         ),
         (
             "Backtest",
-            ["python", "/home/RasPatrick/jbravo_screener/scripts/backtest.py"],
+            [sys.executable, "scripts/backtest.py"],
         ),
         (
             "Metrics Calculation",
-            ["python", "/home/RasPatrick/jbravo_screener/scripts/metrics.py"],
+            [sys.executable, "scripts/metrics.py"],
         ),
     ]
     for name, cmd in steps:

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -83,6 +83,11 @@ def init_db() -> None:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS historical_candidates (date TEXT, symbol TEXT, score REAL)"
         )
+        columns = [row[1] for row in conn.execute("PRAGMA table_info(historical_candidates)")]
+        if "timestamp" not in columns:
+            conn.execute("PRAGMA foreign_keys=off;")
+            conn.execute("ALTER TABLE historical_candidates ADD COLUMN timestamp TEXT;")
+            conn.execute("PRAGMA foreign_keys=on;")
 
 
 init_db()


### PR DESCRIPTION
## Summary
- ensure run_pipeline.py runs from repo root and uses relative paths
- add timestamp column to historical_candidates SQLite table when missing

## Testing
- `python -m py_compile scripts/run_pipeline.py scripts/screener.py`

------
https://chatgpt.com/codex/tasks/task_e_687d1f3c6e50833190bc083277a6051e