### PR TITLE
Improve cache_bars logic with weekend handling and TradingView fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ urllib3==2.5.0
 Werkzeug==3.1.3
 zipp==3.23.0
 alpaca-py>=0.42.0
+tvdatafeed==3.3.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+from unittest.mock import MagicMock
+from datetime import datetime
+import pandas as pd
+import pytz
+
+from scripts.utils import cache_bars, get_last_trading_day_end
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.cache_dir = 'data/test_cache'
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+    def tearDown(self):
+        for f in os.listdir(self.cache_dir):
+            os.remove(os.path.join(self.cache_dir, f))
+
+    def test_last_trading_day_weekend(self):
+        dt = pytz.timezone('America/New_York').localize(datetime(2024, 8, 10, 12))
+        end = get_last_trading_day_end(dt)
+        self.assertEqual(end.weekday(), 4)
+
+    def test_cache_bars_handles_empty(self):
+        client = MagicMock()
+        client.get_stock_bars.return_value.df = pd.DataFrame()
+        df = cache_bars('FAKE', client, self.cache_dir, days=10)
+        self.assertIsInstance(df, pd.DataFrame)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve date logic for historical bar requests
- better handle Alpaca API errors and integrate TradingView fallback
- add batch bar fetching utility
- add tvdatafeed requirement
- add unit tests for new helpers

## Testing
- `python3 -m unittest tests.test_utils -v` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d3620d0dc83318169413ebef528ac