### PR TITLE
Add automatic migration for RSI column

### DIFF
--- a/scripts/enhanced_screener.py
+++ b/scripts/enhanced_screener.py
@@ -108,6 +108,9 @@ def init_db() -> None:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS historical_candidates (date TEXT, symbol TEXT, score REAL)"
         )
+        columns = [row[1] for row in conn.execute("PRAGMA table_info(historical_candidates)")]
+        if "rsi" not in columns:
+            conn.execute("ALTER TABLE historical_candidates ADD COLUMN rsi REAL;")
 
 
 init_db()

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -88,6 +88,8 @@ def init_db() -> None:
             conn.execute("PRAGMA foreign_keys=off;")
             conn.execute("ALTER TABLE historical_candidates ADD COLUMN timestamp TEXT;")
             conn.execute("PRAGMA foreign_keys=on;")
+        if "rsi" not in columns:
+            conn.execute("ALTER TABLE historical_candidates ADD COLUMN rsi REAL;")
 
 
 init_db()


### PR DESCRIPTION
## Summary
- ensure `screener.py` migrates `historical_candidates` table to include `rsi`
- ensure `enhanced_screener.py` also checks for the `rsi` column

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d42f9a32c8331b9f7d2ad2635b4fe