### PR TITLE
Add DB indicator column updater

### DIFF
--- a/scripts/ensure_db_indicators.py
+++ b/scripts/ensure_db_indicators.py
@@ -1,0 +1,31 @@
+import os
+import sqlite3
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DB_PATH = os.path.join(BASE_DIR, 'data', 'pipeline.db')
+
+INDICATORS = ['rsi', 'macd', 'ema20', 'sma9']
+
+def ensure_columns(db_path: str = DB_PATH, indicators: list[str] = INDICATORS) -> None:
+    """Ensure indicator columns exist in the historical_candidates table."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS historical_candidates (date TEXT, symbol TEXT, score REAL)"
+    )
+    cur.execute("PRAGMA table_info(historical_candidates);")
+    existing = [row[1] for row in cur.fetchall()]
+
+    for col in indicators:
+        if col not in existing:
+            cur.execute(f"ALTER TABLE historical_candidates ADD COLUMN {col} REAL;")
+            print(f"\u2714 Added column: {col}")
+        else:
+            print(f"\u23E9 Column already exists: {col}")
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    ensure_columns()


### PR DESCRIPTION
## Summary
- add script to ensure indicator columns exist in `pipeline.db`

## Testing
- `python scripts/ensure_db_indicators.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d462526308331bd8bd8d1097859af