### PR TITLE
Add DB schema sync for indicators

### DIFF
--- a/scripts/enhanced_screener.py
+++ b/scripts/enhanced_screener.py
@@ -102,15 +102,12 @@ def send_alert(message: str) -> None:
         logging.error("Failed to send alert: %s", exc)
 
 
+from scripts.ensure_db_indicators import ensure_columns, REQUIRED_COLUMNS
+
+
 def init_db() -> None:
-    """Ensure the SQLite table for historical candidates exists."""
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS historical_candidates (date TEXT, symbol TEXT, score REAL)"
-        )
-        columns = [row[1] for row in conn.execute("PRAGMA table_info(historical_candidates)")]
-        if "rsi" not in columns:
-            conn.execute("ALTER TABLE historical_candidates ADD COLUMN rsi REAL;")
+    """Ensure the SQLite table has all required columns."""
+    ensure_columns(DB_PATH, REQUIRED_COLUMNS)
 
 
 init_db()

--- a/scripts/ensure_db_indicators.py
+++ b/scripts/ensure_db_indicators.py
@@ -4,10 +4,30 @@ import sqlite3
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DB_PATH = os.path.join(BASE_DIR, 'data', 'pipeline.db')
 
-INDICATORS = ['rsi', 'macd', 'ema20', 'sma9']
+REQUIRED_COLUMNS = [
+    'date',
+    'symbol',
+    'score',
+    'timestamp',
+    'rsi',
+    'macd',
+    'ema20',
+    'sma9',
+    'sma180',
+    'macd_hist',
+    'adx',
+    'aroon_up',
+    'aroon_down',
+    'win_rate',
+    'net_pnl',
+    'trades',
+    'wins',
+    'losses',
+    'avg_return',
+]
 
-def ensure_columns(db_path: str = DB_PATH, indicators: list[str] = INDICATORS) -> None:
-    """Ensure indicator columns exist in the historical_candidates table."""
+def ensure_columns(db_path: str = DB_PATH, indicators: list[str] = REQUIRED_COLUMNS) -> None:
+    """Ensure required columns exist in the historical_candidates table."""
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     cur.execute(
@@ -29,3 +49,4 @@ def ensure_columns(db_path: str = DB_PATH, indicators: list[str] = INDICATORS) -
 
 if __name__ == "__main__":
     ensure_columns()
+

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -78,18 +78,12 @@ def send_alert(message: str) -> None:
         logging.error("Failed to send alert: %s", exc)
 
 
+from scripts.ensure_db_indicators import ensure_columns, REQUIRED_COLUMNS
+
+
 def init_db() -> None:
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS historical_candidates (date TEXT, symbol TEXT, score REAL)"
-        )
-        columns = [row[1] for row in conn.execute("PRAGMA table_info(historical_candidates)")]
-        if "timestamp" not in columns:
-            conn.execute("PRAGMA foreign_keys=off;")
-            conn.execute("ALTER TABLE historical_candidates ADD COLUMN timestamp TEXT;")
-            conn.execute("PRAGMA foreign_keys=on;")
-        if "rsi" not in columns:
-            conn.execute("ALTER TABLE historical_candidates ADD COLUMN rsi REAL;")
+    """Ensure all required columns exist in the database."""
+    ensure_columns(DB_PATH, REQUIRED_COLUMNS)
 
 
 init_db()

--- a/tests/test_ensure_db.py
+++ b/tests/test_ensure_db.py
@@ -1,0 +1,27 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.ensure_db_indicators import ensure_columns, REQUIRED_COLUMNS
+
+class TestEnsureDBIndicators(unittest.TestCase):
+    def test_columns_created(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            ensure_columns(path, REQUIRED_COLUMNS)
+            conn = sqlite3.connect(path)
+            cur = conn.execute("PRAGMA table_info(historical_candidates);")
+            cols = [row[1] for row in cur.fetchall()]
+            for col in REQUIRED_COLUMNS:
+                self.assertIn(col, cols)
+            conn.close()
+        finally:
+            os.remove(path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- sync historical_candidates schema with required indicators
- reuse schema sync in screener scripts
- test that schema sync works

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d4c0a77b48331959a9f1a6091cc70