### PR TITLE
Add schema sync and pipeline order

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ correctly.
 
 ## Scheduled Pipeline and Trading Tasks
 
-Set up PythonAnywhere scheduled tasks (or cron jobs) to execute the main pipeline
-and trading script automatically:
+Set up PythonAnywhere scheduled tasks (or cron jobs) to execute the full pipeline
+automatically:
 
 ```bash
 python scripts/run_pipeline.py
-python scripts/execute_trades.py
 ```

--- a/scripts/ensure_db_indicators.py
+++ b/scripts/ensure_db_indicators.py
@@ -5,34 +5,39 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DB_PATH = os.path.join(BASE_DIR, 'data', 'pipeline.db')
 
 REQUIRED_COLUMNS = [
-    'date',
-    'symbol',
-    'score',
-    'timestamp',
-    'rsi',
-    'macd',
-    'ema20',
-    'sma9',
-    'sma180',
-    'macd_hist',
-    'adx',
-    'aroon_up',
-    'aroon_down',
-    'win_rate',
-    'net_pnl',
-    'trades',
-    'wins',
-    'losses',
-    'avg_return',
+    "date",
+    "symbol",
+    "score",
+    "timestamp",
+    "rsi",
+    "macd",
+    "macd_hist",
+    "ema20",
+    "sma9",
+    "sma180",
+    "atr",
+    "adx",
+    "aroon_up",
+    "aroon_down",
+    "win_rate",
+    "net_pnl",
+    "trades",
+    "wins",
+    "losses",
+    "avg_return",
 ]
 
 def ensure_columns(db_path: str = DB_PATH, indicators: list[str] = REQUIRED_COLUMNS) -> None:
-    """Ensure required columns exist in the historical_candidates table."""
+    """Ensure required columns exist in the ``historical_candidates`` table."""
+
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
+
+    # Create the table if it does not yet exist
     cur.execute(
         "CREATE TABLE IF NOT EXISTS historical_candidates (date TEXT, symbol TEXT, score REAL)"
     )
+
     cur.execute("PRAGMA table_info(historical_candidates);")
     existing = [row[1] for row in cur.fetchall()]
 
@@ -44,6 +49,16 @@ def ensure_columns(db_path: str = DB_PATH, indicators: list[str] = REQUIRED_COLU
             print(f"\u23E9 Column already exists: {col}")
 
     conn.commit()
+
+    # Verify final schema contains all required columns
+    cur.execute("PRAGMA table_info(historical_candidates);")
+    final_cols = [row[1] for row in cur.fetchall()]
+    missing = [c for c in indicators if c not in final_cols]
+    if missing:
+        raise RuntimeError(f"Schema synchronization failed, missing columns: {missing}")
+    else:
+        print("All required columns verified.")
+
     conn.close()
 
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -71,12 +71,16 @@ if __name__ == "__main__":
 
     steps = [
         (
-            "Backtest",
-            [sys.executable, "scripts/backtest.py"],
-        ),
-        (
             "Metrics Calculation",
             [sys.executable, "scripts/metrics.py"],
+        ),
+        (
+            "Execute Trades",
+            [sys.executable, "scripts/execute_trades.py"],
+        ),
+        (
+            "Weekly Summary",
+            [sys.executable, "scripts/weekly_summary.py"],
         ),
     ]
 


### PR DESCRIPTION
## Summary
- enforce required columns via `ensure_db_indicators.ensure_columns`
- include ATR in schema
- execute metrics, trades and weekly summary in pipeline
- streamline scheduled task docs

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `python scripts/screener.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python scripts/metrics.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python scripts/execute_trades.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python scripts/weekly_summary.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d4f6d032c8331ac9c9f1f54b58691