### PR TITLE
Add missing score_breakdown column to DB schema

### DIFF
--- a/scripts/ensure_db_indicators.py
+++ b/scripts/ensure_db_indicators.py
@@ -19,6 +19,7 @@ REQUIRED_COLUMNS = [
     "adx",
     "aroon_up",
     "aroon_down",
+    "score_breakdown",
     "win_rate",
     "net_pnl",
     "trades",


### PR DESCRIPTION
## Summary
- include `score_breakdown` in database schema sync list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d531e54288331892d6a08646b9239