### PR TITLE
Add dynamic DB schema sync

### DIFF
--- a/scripts/ensure_db_indicators.py
+++ b/scripts/ensure_db_indicators.py
@@ -1,5 +1,7 @@
 import os
 import sqlite3
+from typing import Iterable
+import pandas as pd
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DB_PATH = os.path.join(BASE_DIR, 'data', 'pipeline.db')
@@ -61,6 +63,17 @@ def ensure_columns(db_path: str = DB_PATH, indicators: list[str] = REQUIRED_COLU
         print("All required columns verified.")
 
     conn.close()
+
+
+def sync_columns_from_dataframe(df: pd.DataFrame, db_path: str = DB_PATH) -> None:
+    """Ensure DB schema matches the columns in ``df``.
+
+    Any columns present in ``df`` but missing from the
+    ``historical_candidates`` table will be added automatically.
+    """
+
+    columns = list(df.columns)
+    ensure_columns(db_path, columns)
 
 
 if __name__ == "__main__":

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -78,7 +78,11 @@ def send_alert(message: str) -> None:
         logging.error("Failed to send alert: %s", exc)
 
 
-from scripts.ensure_db_indicators import ensure_columns, REQUIRED_COLUMNS
+from scripts.ensure_db_indicators import (
+    ensure_columns,
+    sync_columns_from_dataframe,
+    REQUIRED_COLUMNS,
+)
 
 
 def init_db() -> None:
@@ -313,6 +317,8 @@ def main() -> None:
     append_df.insert(0, "date", datetime.now().strftime("%Y-%m-%d"))
     write_csv_atomic(append_df, hist_path)
     logging.info("Historical candidates updated at %s", hist_path)
+    # Synchronize SQLite schema to match the DataFrame before insertion
+    sync_columns_from_dataframe(append_df, DB_PATH)
     with sqlite3.connect(DB_PATH) as conn:
         append_df.to_sql("historical_candidates", conn, if_exists="append", index=False)
 

--- a/tests/test_ensure_db.py
+++ b/tests/test_ensure_db.py
@@ -3,10 +3,15 @@ import sqlite3
 import tempfile
 import unittest
 import sys
+import pandas as pd
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from scripts.ensure_db_indicators import ensure_columns, REQUIRED_COLUMNS
+from scripts.ensure_db_indicators import (
+    ensure_columns,
+    sync_columns_from_dataframe,
+    REQUIRED_COLUMNS,
+)
 
 class TestEnsureDBIndicators(unittest.TestCase):
     def test_columns_created(self):
@@ -18,6 +23,21 @@ class TestEnsureDBIndicators(unittest.TestCase):
             cur = conn.execute("PRAGMA table_info(historical_candidates);")
             cols = [row[1] for row in cur.fetchall()]
             for col in REQUIRED_COLUMNS:
+                self.assertIn(col, cols)
+            conn.close()
+        finally:
+            os.remove(path)
+
+    def test_sync_columns_from_dataframe(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            df = pd.DataFrame(columns=["date", "symbol", "score", "dynamic_col"])
+            sync_columns_from_dataframe(df, path)
+            conn = sqlite3.connect(path)
+            cur = conn.execute("PRAGMA table_info(historical_candidates);")
+            cols = [row[1] for row in cur.fetchall()]
+            for col in df.columns:
                 self.assertIn(col, cols)
             conn.close()
         finally:


### PR DESCRIPTION
## Summary
- add `sync_columns_from_dataframe` helper for schema sync
- call helper in screener before inserting to SQLite
- extend tests for dynamic schema updates

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d570049f08331ac126df3f98de10c