### PR TITLE
Refine pipeline execution order and logging

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,4 +1,6 @@
 # run_pipeline.py
+# Scheduled to run nightly around 9:00 PM Central Standard Time
+# after market close to process the most recent data.
 import os
 import sys
 
@@ -12,18 +14,23 @@ sys.path.insert(0, BASE_DIR)
 
 import subprocess
 import logging
+from logging.handlers import RotatingFileHandler
 from datetime import datetime, timezone
 import requests
 import pandas as pd
 
 from utils import write_csv_atomic
 
-os.makedirs(os.path.join(BASE_DIR, 'logs'), exist_ok=True)
+os.makedirs(os.path.join(BASE_DIR, "logs"), exist_ok=True)
 
-log_path = os.path.join(BASE_DIR, 'logs', 'pipeline.log')
+log_path = os.path.join(BASE_DIR, "logs", "pipeline.log")
+error_log_path = os.path.join(BASE_DIR, "logs", "error.log")
+
+error_handler = RotatingFileHandler(error_log_path, maxBytes=2_000_000, backupCount=5)
+error_handler.setLevel(logging.ERROR)
 
 logging.basicConfig(
-    filename=log_path,
+    handlers=[RotatingFileHandler(log_path, maxBytes=2_000_000, backupCount=5), error_handler],
     level=logging.INFO,
     format="%(asctime)s UTC [%(levelname)s] %(message)s",
 )
@@ -40,23 +47,37 @@ def send_alert(msg: str) -> None:
         logging.error("Failed to send alert: %s", exc)
 
 def run_step(step_name, command):
-    logging.info("Starting %s...", step_name)
+    start_time = datetime.utcnow()
+    logging.info("Starting %s at %s", step_name, start_time.isoformat())
     try:
         result = subprocess.run(
             command,
             cwd=BASE_DIR,
             capture_output=True,
             text=True,
+            check=True,
         )
+        end_time = datetime.utcnow()
+        duration = end_time - start_time
         logging.info("%s stdout:\n%s", step_name, result.stdout)
         logging.info("%s stderr:\n%s", step_name, result.stderr)
-        if result.returncode != 0:
-            logging.error("%s returned non-zero exit %d", step_name, result.returncode)
-            send_alert(f"Pipeline step {step_name} failed: exit {result.returncode}")
-            sys.exit(result.returncode)
-        logging.info("Completed %s successfully.", step_name)
+        logging.info("Completed %s successfully in %s", step_name, duration)
+    except subprocess.CalledProcessError as e:
+        end_time = datetime.utcnow()
+        duration = end_time - start_time
+        logging.error("%s failed with exit %d after %s", step_name, e.returncode, duration)
+        logging.error("%s stdout:\n%s", step_name, e.stdout)
+        logging.error("%s stderr:\n%s", step_name, e.stderr)
+        with open(error_log_path, "a") as error_file:
+            error_file.write(f"{end_time.isoformat()} {step_name} error: {e}\n")
+        send_alert(f"Pipeline step {step_name} failed: {e}")
+        raise
     except Exception as e:
-        logging.error("Unexpected failure in %s: %s", step_name, e)
+        end_time = datetime.utcnow()
+        duration = end_time - start_time
+        logging.error("Unexpected failure in %s after %s: %s", step_name, duration, e)
+        with open(error_log_path, "a") as error_file:
+            error_file.write(f"{end_time.isoformat()} {step_name} exception: {e}\n")
         send_alert(f"Pipeline step {step_name} exception: {e}")
         raise
 
@@ -71,22 +92,24 @@ if __name__ == "__main__":
 
     steps = [
         (
+            "Backtest",
+            [sys.executable, "scripts/backtest.py"],
+        ),
+        (
             "Metrics Calculation",
             [sys.executable, "scripts/metrics.py"],
-        ),
-        (
-            "Execute Trades",
-            [sys.executable, "scripts/execute_trades.py"],
-        ),
-        (
-            "Weekly Summary",
-            [sys.executable, "scripts/weekly_summary.py"],
         ),
     ]
 
     for name, cmd in steps:
         try:
             run_step(name, cmd)
+            if name == "Backtest":
+                backtest_path = os.path.join(BASE_DIR, "data", "backtest_results.csv")
+                if os.path.exists(backtest_path):
+                    logging.info("Backtest results written to %s", backtest_path)
+                else:
+                    logging.error("Expected backtest results at %s not found", backtest_path)
         except Exception:
             logging.error("Step %s failed", name)
             send_alert(f"Pipeline halted at step {name}")


### PR DESCRIPTION
## Summary
- schedule nightly pipeline
- add rotating log handlers
- record timing and results for each pipeline step
- run backtest before metrics and remove trade execution/weekly summary

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d62cf71408331a91697e697544066