### PR TITLE
Fix pipeline and dashboard data updates

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -949,5 +949,18 @@ def toggle_modal(active_cell, table_data, close_click, is_open):
     return is_open, ""
 
 
+# Periodically refresh screener table
+@app.callback(Output("top-candidates-table", "data"), Input("interval-update", "n_intervals"))
+def update_screener_table(n):
+    if os.path.exists(top_candidates_path):
+        df = pd.read_csv(top_candidates_path)
+        logger.info(
+            "Screener table updated successfully with %d records.", len(df)
+        )
+        return df.to_dict("records")
+    logger.warning("%s not found when updating screener table", top_candidates_path)
+    return []
+
+
 if __name__ == "__main__":
     app.run(debug=False)

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -435,7 +435,11 @@ if __name__ == "__main__":
     try:
         csv_path = os.path.join(BASE_DIR, "data", "top_candidates.csv")
         symbols_df = pd.read_csv(csv_path)
-        symbol_list = symbols_df.iloc[:, 0].tolist()
+        if "symbol" in symbols_df.columns:
+            symbol_list = symbols_df["symbol"].tolist()
+        else:
+            symbol_list = symbols_df.iloc[:, 0].tolist()
+        logging.info("Loaded %d symbols from %s", len(symbol_list), csv_path)
         run_backtest(symbol_list)
         logging.info("Backtest script finished.")
     except Exception as exc:

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -99,13 +99,21 @@ def rank_candidates(df):
 
 # Save top-ranked candidates
 def save_top_candidates(df, top_n=15, output_file='top_candidates.csv'):
-    top_candidates = df.head(top_n)
+    required_columns = ['symbol', 'score', 'win_rate', 'net_pnl']
+    missing_cols = [c for c in required_columns if c not in df.columns]
     csv_path = os.path.join(BASE_DIR, 'data', output_file)
+    if missing_cols:
+        logger.error("Missing columns: %s", missing_cols)
+        return
+
+    top_candidates = df.head(top_n)
     try:
         write_csv_atomic(top_candidates, csv_path)
-        logging.info("Successfully appended data to %s", csv_path)
+        logger.info(
+            "Successfully updated %s with %d records", csv_path, len(top_candidates)
+        )
     except Exception as e:
-        logging.error("Failed appending to %s: %s", csv_path, e)
+        logger.error("Failed appending to %s: %s", csv_path, e)
 
 # Save overall metrics summary
 def save_metrics_summary(metrics_summary, symbols, output_file='metrics_summary.csv'):

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -307,9 +307,20 @@ def main() -> None:
     top15.insert(0, "timestamp", timestamp)
     top15["universe_count"] = len(symbols)
 
+    cols = [
+        "symbol",
+        "score",
+        "timestamp",
+    ] + [c for c in top15.columns if c not in ["symbol", "score", "timestamp"]]
+    top15 = top15[cols]
+
     csv_path = os.path.join(BASE_DIR, "data", "top_candidates.csv")
     write_csv_atomic(top15, csv_path)
-    logging.info("Top 15 ranked candidates saved to %s", csv_path)
+    logging.info(
+        "Top candidates updated: %d records written to %s",
+        len(top15),
+        csv_path,
+    )
 
 # Append to historical candidates log
     hist_path = os.path.join(BASE_DIR, "data", "historical_candidates.csv")


### PR DESCRIPTION
## Summary
- ensure screener output has `symbol` column first
- read symbol column explicitly in backtest step
- validate columns before writing results in metrics
- periodically reload screener data in dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d76627d588331b14f764dc5c74cbe