### PR TITLE
Improve trade execution logging and metrics

### DIFF
--- a/scripts/exit_signals.py
+++ b/scripts/exit_signals.py
@@ -64,10 +64,10 @@ def should_exit_early(symbol: str, data_client, cache_dir: str, lookback: int = 
     """
     try:
         df = cache_bars(symbol, data_client, cache_dir)
-        # Focus on the most recent ``lookback`` bars
-        if len(df) < 25:
-            # Not enough data to compute the indicators
+        if df is None or len(df) < 25:
+            # Not enough data available to compute the indicators
             return False
+        # Focus on the most recent ``lookback`` bars
         df = df.sort_index().iloc[-lookback:].copy()
 
         # Compute 20‑period EMA, RSI and MACD histogram


### PR DESCRIPTION
## Summary
- tweak `cache_bars` to support intraday bars and add error handling
- track order execution metrics in `execute_trades.py`
- persist metrics to `execute_metrics.json`
- display new metrics and execution log in dashboard
- handle missing data in `exit_signals`

## Testing
- `python -m py_compile scripts/execute_trades.py dashboards/dashboard_app.py scripts/utils.py scripts/exit_signals.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687d940518a48331b9495e012c731d84