### PR TITLE
Implement atomic CSV writer utility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ Werkzeug==3.1.3
 zipp==3.23.0
 alpaca-py>=0.42.0
 tvdatafeed==3.3.1
+atomicwrites==1.4.1

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,0 +1,29 @@
+import os
+import csv
+import tempfile
+import unittest
+
+from utils import write_csv_atomic
+
+
+class TestWriteCsvAtomic(unittest.TestCase):
+    def test_write_and_read(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'out.csv')
+            rows = [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+            write_csv_atomic(path, rows)
+            with open(path, newline="") as f:
+                reader = list(csv.reader(f))
+            self.assertEqual(reader, [["a", "b"], ["1", "2"], ["3", "4"]])
+
+    def test_empty_rows_with_header(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'empty.csv')
+            write_csv_atomic(path, [], fieldnames=["x", "y"])
+            with open(path, newline="") as f:
+                reader = list(csv.reader(f))
+            self.assertEqual(reader, [["x", "y"]])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .csv_utils import write_csv_atomic

--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -1,0 +1,30 @@
+import os
+import csv
+from atomicwrites import atomic_write
+
+
+def write_csv_atomic(path: str, rows: list[dict], fieldnames: list[str] | None = None) -> None:
+    """Atomically writes rows (list of dicts) to a CSV file.
+
+    Parameters:
+    - path (str): Full path to the CSV file.
+    - rows (list[dict]): List of rows, each row being a dictionary.
+    - fieldnames (list[str], optional): List of CSV headers. If None, inferred from rows[0].
+    """
+    os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+
+    if not rows:
+        if fieldnames is None:
+            raise ValueError("fieldnames must be provided when rows is empty")
+        with atomic_write(path, newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+        return
+
+    if fieldnames is None:
+        fieldnames = list(rows[0].keys())
+
+    with atomic_write(path, newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)


### PR DESCRIPTION
## Summary
- add `write_csv_atomic` helper using `atomicwrites`
- expose helper via utils package
- include dependency in requirements
- test CSV writer behavior

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687e7ef14f888331a874c72ea32bbe7d