### PR TITLE
Implement cache bars util

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,2 @@
 from .csv_utils import write_csv_atomic
+from .bar_cache import cache_bars

--- a/utils/bar_cache.py
+++ b/utils/bar_cache.py
@@ -1,0 +1,15 @@
+import os
+import pandas as pd
+
+
+def cache_bars(symbol: str, df: pd.DataFrame, cache_dir: str = "cache") -> None:
+    """Cache OHLC bar data for a stock symbol to CSV.
+
+    Parameters:
+    - symbol (str): Stock ticker symbol (e.g., 'AAPL').
+    - df (pd.DataFrame): DataFrame containing bar data (open, high, low, close, indicators).
+    - cache_dir (str): Directory to store cached CSV files.
+    """
+    os.makedirs(cache_dir, exist_ok=True)
+    filepath = os.path.join(cache_dir, f"{symbol}_bars.csv")
+    df.to_csv(filepath, index=False)


### PR DESCRIPTION
## Summary
- add a simple utility to cache DataFrame bars to CSV
- export new cache function from utils package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_687e972e806c8331b24dfc8d8e66e38d