### PR TITLE
Fix cache_bars import and BarSet handling

### DIFF
--- a/utils/bar_cache.py
+++ b/utils/bar_cache.py
@@ -1,31 +1,22 @@
 import os
 import pandas as pd
-from alpaca.data.historical import StockBars
+from alpaca.data.requests import StockBarsRequest
+from alpaca.data.models.bars import BarSet
 
 
 def cache_bars(symbol: str, bars_or_df, cache_dir: str = "cache") -> None:
-    """Cache historical bar data for ``symbol``.
+    """Save historical bar data for ``symbol`` to disk.
 
-    Parameters
-    ----------
-    symbol: str
-        Stock ticker symbol (e.g., ``"AAPL"``).
-    bars_or_df: pandas.DataFrame | StockBars
-        The data to cache.  Can be a DataFrame directly or an Alpaca
-        ``StockBars`` object.
-    cache_dir: str, optional
-        Directory to store cached CSV files.
+    Accepts either an Alpaca ``BarSet`` or a ``pandas.DataFrame`` and writes
+    the underlying data to ``cache_dir``.
     """
 
-    # Auto-detect input type and extract DataFrame
-    if hasattr(bars_or_df, "df"):
+    if isinstance(bars_or_df, BarSet):
         df = bars_or_df.df.reset_index()
     elif isinstance(bars_or_df, pd.DataFrame):
         df = bars_or_df
     else:
-        raise TypeError(
-            f"Unsupported type: {type(bars_or_df)} provided. Expecting DataFrame or Bars object."
-        )
+        raise TypeError(f"Expected BarSet or DataFrame, got {type(bars_or_df)}")
 
     os.makedirs(cache_dir, exist_ok=True)
     filepath = os.path.join(cache_dir, f"{symbol}_bars.csv")


### PR DESCRIPTION
## Summary
- update utils `cache_bars` to use the correct Alpaca BarSet class
- simplify dataframe extraction logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687eab636c588331894d177adb45b587