### PR TITLE
Remove explicit end parameters

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -310,7 +310,7 @@ def allocate_position(symbol):
             symbol_or_symbols=symbol,
             timeframe=TimeFrame.Minute,
             start=start,
-            end=end,
+            feed="iex",
         )
         bars = data_client.get_stock_bars(request).df
         if bars.empty:

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -261,9 +261,7 @@ def fetch_indicators(symbol):
             start=(datetime.now(timezone.utc) - timedelta(days=750)).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             ),
-            end=(datetime.now(timezone.utc) - timedelta(minutes=16)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            feed="iex",
         )
         bars = data_client.get_stock_bars(request).df
     except Exception as e:

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -243,7 +243,7 @@ def main() -> None:
             symbol_or_symbols=symbol,
             timeframe=TimeFrame.Day,
             start=datetime.now(timezone.utc) - timedelta(days=1500),
-            end=datetime.now(timezone.utc),
+            feed="iex",
         )
         bars = data_client.get_stock_bars(request_params)
         cache_bars(symbol, bars, DATA_CACHE_DIR)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -79,7 +79,7 @@ def cache_bars(
                 symbol_or_symbols=symbol,
                 timeframe=TimeFrame.Minute,
                 start=start,
-                end=end,
+                feed="iex",
             )
             df = data_client.get_stock_bars(request).df
             if df.empty:
@@ -119,7 +119,12 @@ def cache_bars(
     if start >= end:
         return df
 
-    request_params = StockBarsRequest(symbol_or_symbols=symbol, timeframe=TimeFrame.Day, start=start, end=end)
+    request_params = StockBarsRequest(
+        symbol_or_symbols=symbol,
+        timeframe=TimeFrame.Day,
+        start=start,
+        feed="iex",
+    )
     try:
         new_df = data_client.get_stock_bars(request_params).df
     except APIError as exc:
@@ -207,7 +212,12 @@ def cache_bars_batch(symbols: list[str], data_client, cache_dir: str, days: int 
 
         end = get_last_trading_day_end()
         min_start = min(start_map.values())
-        request_params = StockBarsRequest(symbol_or_symbols=batch, timeframe=TimeFrame.Day, start=min_start, end=end)
+        request_params = StockBarsRequest(
+            symbol_or_symbols=batch,
+            timeframe=TimeFrame.Day,
+            start=min_start,
+            feed="iex",
+        )
 
         attempt = 0
         bars_df = pd.DataFrame()
@@ -268,7 +278,6 @@ def fetch_daily_bars(symbol: str, trade_date: str, data_client) -> pd.DataFrame:
         symbol_or_symbols=symbol,
         timeframe=TimeFrame.Day,
         start=trade_date,
-        end=trade_date,
         feed="iex",
     )
     bars = data_client.get_stock_bars(request).df
@@ -293,7 +302,6 @@ def fetch_extended_hours_bars(symbol: str, trade_date: str, data_client) -> tupl
         symbol_or_symbols=symbol,
         timeframe=TimeFrame.Minute,
         start=start,
-        end=end,
         feed="iex",
     )
     bars = data_client.get_stock_bars(request).df


### PR DESCRIPTION
## Summary
- follow Alpaca guidance to let API decide cutoff
- always request IEX feed when fetching data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ed2afd2f08331a173701af8b6dff1