### PR TITLE
Swap write_csv_atomic arguments

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -407,9 +407,9 @@ def run_backtest(symbols: List[str]) -> dict:
     equity_path = os.path.join(BASE_DIR, "data", "equity_curve.csv")
     metrics_path = os.path.join(BASE_DIR, "data", "backtest_results.csv")
 
-    write_csv_atomic(trades_df, trades_path)
-    write_csv_atomic(equity_df.reset_index(), equity_path)
-    write_csv_atomic(summary_df, metrics_path)
+    write_csv_atomic(trades_path, trades_df)
+    write_csv_atomic(equity_path, equity_df.reset_index())
+    write_csv_atomic(metrics_path, summary_df)
 
     processed = len(valid_symbols)
     tested = len(data)

--- a/scripts/enhanced_screener.py
+++ b/scripts/enhanced_screener.py
@@ -115,11 +115,11 @@ init_db()
 # Prepare initial CSVs if they do not already exist
 hist_init_path = os.path.join(BASE_DIR, 'data', 'historical_candidates.csv')
 if not os.path.exists(hist_init_path):
-    write_csv_atomic(pd.DataFrame(columns=['date', 'symbol', 'score']), hist_init_path)
+    write_csv_atomic(hist_init_path, pd.DataFrame(columns=['date', 'symbol', 'score']))
 
 top_init_path = os.path.join(BASE_DIR, 'data', 'top_candidates.csv')
 if not os.path.exists(top_init_path):
-    write_csv_atomic(pd.DataFrame(columns=["symbol", "score"]), top_init_path)
+    write_csv_atomic(top_init_path, pd.DataFrame(columns=["symbol", "score"]))
 
 
 # Gather all tradable tickers via Alpaca.  We defer the Alpaca imports
@@ -340,13 +340,13 @@ def main() -> None:
     if ranked_df.empty:
         logging.warning("No candidates met the screening criteria.")
         ranked_df = pd.DataFrame(columns=["symbol", "score"])
-    write_csv_atomic(ranked_df.head(15), csv_path)
+    write_csv_atomic(csv_path, ranked_df.head(15))
     logging.info("Top 15 ranked candidates saved to %s", csv_path)
     # Append to historical candidates log
     hist_path = os.path.join(BASE_DIR, 'data', 'historical_candidates.csv')
     append_df = ranked_df.head(15).copy()
     append_df.insert(0, 'date', datetime.now().strftime('%Y-%m-%d'))
-    write_csv_atomic(append_df, hist_path)
+    write_csv_atomic(hist_path, append_df)
     logging.info("Historical candidates updated at %s", hist_path)
     with sqlite3.connect(DB_PATH) as conn:
         append_df.to_sql("historical_candidates", conn, if_exists="append", index=False)

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -3,8 +3,7 @@ import os
 import pandas as pd
 import logging
 from utils import logger_utils
-import shutil
-from tempfile import NamedTemporaryFile
+from utils import write_csv_atomic
 from datetime import datetime
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -13,12 +12,6 @@ logger = logger_utils.init_logging(__name__, "metrics.log")
 start_time = datetime.utcnow()
 logger.info("Script started")
 
-
-def write_csv_atomic(df: pd.DataFrame, dest: str):
-    tmp = NamedTemporaryFile('w', delete=False, dir=os.path.dirname(dest), newline='')
-    df.to_csv(tmp.name, index=False)
-    tmp.close()
-    shutil.move(tmp.name, dest)
 
 # Load backtest results
 def load_results(csv_file='backtest_results.csv'):
@@ -99,7 +92,7 @@ def save_top_candidates(df, top_n=15, output_file='top_candidates.csv'):
         cols = required_cols + [c for c in df.columns if c not in required_cols]
         top_candidates = df[cols].head(top_n)
         try:
-            write_csv_atomic(top_candidates, csv_path)
+            write_csv_atomic(csv_path, top_candidates)
             logger.info(
                 "Successfully updated %s with %d records", csv_path, len(top_candidates)
             )
@@ -116,7 +109,7 @@ def save_metrics_summary(metrics_summary, symbols, output_file='metrics_summary.
     summary_df['symbols'] = ';'.join(symbols)
     csv_path = os.path.join(BASE_DIR, 'data', output_file)
     try:
-        write_csv_atomic(summary_df, csv_path)
+        write_csv_atomic(csv_path, summary_df)
         logger.info("Successfully appended data to %s", csv_path)
     except Exception as e:
         logger.error("Failed appending to %s: %s", csv_path, e)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     if os.path.exists(source_path):
         try:
             df = pd.read_csv(source_path)
-            write_csv_atomic(df, target_path)
+            write_csv_atomic(target_path, df)
             logger.info(
                 "Updated latest_candidates.csv at %s",
                 datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),

--- a/scripts/run_pipeline_enhanced.py
+++ b/scripts/run_pipeline_enhanced.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     if os.path.exists(source_path):
         try:
             df = pd.read_csv(source_path)
-            write_csv_atomic(df, target_path)
+            write_csv_atomic(target_path, df)
             logging.info(
                 "Updated latest_candidates.csv at %s",
                 datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -82,12 +82,12 @@ init_db()
 # Ensure historical candidates file exists
 hist_init_path = os.path.join(BASE_DIR, 'data', 'historical_candidates.csv')
 if not os.path.exists(hist_init_path):
-    write_csv_atomic(pd.DataFrame(columns=['date', 'symbol', 'score']), hist_init_path)
+    write_csv_atomic(hist_init_path, pd.DataFrame(columns=['date', 'symbol', 'score']))
 
 # Ensure top candidates file exists
 top_init_path = os.path.join(BASE_DIR, 'data', 'top_candidates.csv')
 if not os.path.exists(top_init_path):
-    write_csv_atomic(pd.DataFrame(columns=["symbol", "score"]), top_init_path)
+    write_csv_atomic(top_init_path, pd.DataFrame(columns=["symbol", "score"]))
 
 API_KEY = os.getenv("APCA_API_KEY_ID")
 API_SECRET = os.getenv("APCA_API_SECRET_KEY")
@@ -289,7 +289,7 @@ def main() -> None:
 
 # Save full scored list
     scored_path = os.path.join(BASE_DIR, "data", "scored_candidates.csv")
-    write_csv_atomic(ranked_df, scored_path)
+    write_csv_atomic(scored_path, ranked_df)
     logger.info("All scored candidates saved to %s", scored_path)
 
 # Log details for top symbols
@@ -310,7 +310,7 @@ def main() -> None:
     top15 = top15[cols]
 
     csv_path = os.path.join(BASE_DIR, "data", "top_candidates.csv")
-    write_csv_atomic(top15, csv_path)
+    write_csv_atomic(csv_path, top15)
     logger.info(
         "Top candidates updated: %d records written to %s",
         len(top15),
@@ -321,7 +321,7 @@ def main() -> None:
     hist_path = os.path.join(BASE_DIR, "data", "historical_candidates.csv")
     append_df = top15.copy()
     append_df.insert(0, "date", datetime.now().strftime("%Y-%m-%d"))
-    write_csv_atomic(append_df, hist_path)
+    write_csv_atomic(hist_path, append_df)
     logger.info("Historical candidates updated at %s", hist_path)
     # Synchronize SQLite schema to match the DataFrame before insertion
     sync_columns_from_dataframe(append_df, DB_PATH)
@@ -342,7 +342,7 @@ def main() -> None:
         columns=["date", "time", "summary"],
     )
     summary_df = pd.concat([summary_df, new_row], ignore_index=True)
-    write_csv_atomic(summary_df, summary_path)
+    write_csv_atomic(summary_path, summary_df)
     logger.info("Screener script finished.")
 
 

--- a/scripts/update_dashboard_data.py
+++ b/scripts/update_dashboard_data.py
@@ -136,11 +136,11 @@ def init_db():
         )
 
 
-def write_csv_atomic(df: pd.DataFrame, dest: str):
+def write_csv_atomic(path: str, df: pd.DataFrame):
     tmp = NamedTemporaryFile("w", delete=False, dir=DATA_DIR, newline="")
     df.to_csv(tmp.name, index=False)
     tmp.close()
-    shutil.move(tmp.name, dest)
+    shutil.move(tmp.name, path)
 
 
 def update_open_positions():
@@ -194,7 +194,7 @@ def update_open_positions():
         df['pnl'] = df['net_pnl']
         df['order_type'] = df.get('order_type', 'limit')
         df = df[columns]
-        write_csv_atomic(df, OPEN_POSITIONS_CSV)
+        write_csv_atomic(OPEN_POSITIONS_CSV, df)
         with sqlite3.connect(DB_PATH) as conn:
             df.to_sql("open_positions", conn, if_exists="replace", index=False)
         logger.info("Updated open_positions.csv successfully.")
@@ -299,9 +299,9 @@ def update_order_history():
         if df.empty:
             df = pd.DataFrame(columns=cols)
 
-        write_csv_atomic(df, TRADES_LOG_CSV)
+        write_csv_atomic(TRADES_LOG_CSV, df)
         executed_df = df[df["qty"] > 0][cols]
-        write_csv_atomic(executed_df, EXECUTED_TRADES_CSV)
+        write_csv_atomic(EXECUTED_TRADES_CSV, executed_df)
 
         with sqlite3.connect(DB_PATH) as conn:
             df.to_sql("trades_log", conn, if_exists="replace", index=False)
@@ -359,7 +359,7 @@ def update_metrics_summary():
                 ]
             )
 
-        write_csv_atomic(summary_df, os.path.join(DATA_DIR, "metrics_summary.csv"))
+        write_csv_atomic(os.path.join(DATA_DIR, "metrics_summary.csv"), summary_df)
         with sqlite3.connect(DB_PATH) as conn:
             summary_df.to_sql("metrics_summary", conn, if_exists="replace", index=False)
         logger.info("Updated metrics_summary.csv successfully.")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -18,11 +18,11 @@ def has_datetime_index(idx) -> bool:
     return hasattr(idx, "dtype") and pd.api.types.is_datetime64_any_dtype(idx.dtype)
 
 
-def write_csv_atomic(df: pd.DataFrame, dest: str) -> None:
-    tmp = NamedTemporaryFile("w", delete=False, dir=os.path.dirname(dest), newline="")
+def write_csv_atomic(path: str, df: pd.DataFrame) -> None:
+    tmp = NamedTemporaryFile("w", delete=False, dir=os.path.dirname(path), newline="")
     df.to_csv(tmp.name, index=False)
     tmp.close()
-    shutil.move(tmp.name, dest)
+    shutil.move(tmp.name, path)
 
 
 def get_last_trading_day_end(now: datetime | None = None) -> datetime:
@@ -250,7 +250,7 @@ def cache_bars_batch(symbols: list[str], data_client, cache_dir: str, days: int 
             df_sym = df_sym[~df_sym.index.duplicated(keep="last")].tail(days)
             os.makedirs(cache_dir, exist_ok=True)
             path = os.path.join(cache_dir, f"{sym}.csv")
-            write_csv_atomic(df_sym.reset_index(), path)
+            write_csv_atomic(path, df_sym.reset_index())
             results[sym] = df_sym
 
     return results

--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -25,12 +25,12 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-def write_csv_atomic(df: pd.DataFrame, dest: str) -> None:
-    """Write DataFrame to ``dest`` atomically."""
-    tmp = NamedTemporaryFile("w", delete=False, dir=os.path.dirname(dest), newline="")
+def write_csv_atomic(path: str, df: pd.DataFrame) -> None:
+    """Write DataFrame to ``path`` atomically."""
+    tmp = NamedTemporaryFile("w", delete=False, dir=os.path.dirname(path), newline="")
     df.to_csv(tmp.name, index=False)
     tmp.close()
-    shutil.move(tmp.name, dest)
+    shutil.move(tmp.name, path)
 
 
 def load_csv(filename: str) -> pd.DataFrame:
@@ -205,7 +205,7 @@ def save_weekly_summary(summary: dict, filename: str = "weekly_summary.csv") -> 
     """Write ``summary`` to a CSV in the data directory."""
     dest = os.path.join(DATA_DIR, filename)
     df = pd.DataFrame([summary])
-    write_csv_atomic(df, dest)
+    write_csv_atomic(dest, df)
     logger.info("Weekly summary saved to %s", dest)
 
 

--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -1,17 +1,25 @@
 import os
 import csv
+from typing import Union
+
+import pandas as pd
 from atomicwrites import atomic_write
 
 
-def write_csv_atomic(path: str, rows: list[dict], fieldnames: list[str] | None = None) -> None:
+def write_csv_atomic(path: str, rows: Union[pd.DataFrame, list[dict]], fieldnames: list[str] | None = None) -> None:
     """Atomically writes rows (list of dicts) to a CSV file.
 
     Parameters:
     - path (str): Full path to the CSV file.
-    - rows (list[dict]): List of rows, each row being a dictionary.
+    - rows (list[dict] | pandas.DataFrame): Data to write.
     - fieldnames (list[str], optional): List of CSV headers. If None, inferred from rows[0].
     """
     os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+
+    if isinstance(rows, pd.DataFrame):
+        if fieldnames is None:
+            fieldnames = list(rows.columns)
+        rows = rows.to_dict("records")
 
     if not rows:
         if fieldnames is None:


### PR DESCRIPTION
## Summary
- update `write_csv_atomic` to accept path first
- refactor calls across pipeline, screener and metrics
- adjust helper functions to new signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ede33cc70833184bddac59a8aa092