### PR TITLE
Fix metrics and screener imports

### DIFF
--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -2,13 +2,20 @@
 import os
 import pandas as pd
 import logging
-from utils import logger_utils
+import sys
+from pathlib import Path
+
+# Adjust sys.path to ensure utils package is correctly found
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+from utils.logger_utils import init_logging
 from utils import write_csv_atomic
 from datetime import datetime
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-logger = logger_utils.init_logging(__name__, "metrics.log")
+logger = init_logging(__name__, "metrics.log")
 start_time = datetime.utcnow()
 logger.info("Script started")
 

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -24,7 +24,8 @@ from dotenv import load_dotenv
 import requests
 
 from indicators import adx, aroon, macd, obv, rsi
-from utils import write_csv_atomic, cache_bars, fetch_bars_with_cutoff
+from utils import write_csv_atomic
+from scripts.utils import fetch_bars_with_cutoff, cache_bars
 
 
 
@@ -240,7 +241,7 @@ def main() -> None:
         logger.info("Processing %s...", symbol)
         start = datetime.now(timezone.utc) - timedelta(days=1500)
         bars = fetch_bars_with_cutoff(symbol, start, TimeFrame.Day, data_client)
-        cache_bars(symbol, bars, DATA_CACHE_DIR)
+        cache_bars(symbol, data_client, DATA_CACHE_DIR)
         df = bars.df.reset_index()
         logger.debug("%s has %d bars", symbol, len(df))
         try:


### PR DESCRIPTION
## Summary
- resolve logger_utils import for metrics
- import market data helpers from scripts.utils
- update screener caching call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687fb03303008331843c82c482b81272