### PR TITLE
Fix script imports for execute_trades

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -3,6 +3,11 @@
 # Trailing stops and max hold logic manage risk on open trades.
 
 import os
+import sys
+
+# Ensure project root is first in Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import subprocess
 import logging
 import pandas as pd
@@ -21,8 +26,9 @@ except Exception:  # pragma: no cover - fallback import
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.timeframe import TimeFrame
 from dotenv import load_dotenv
-from utils import logger_utils, fetch_bars_with_cutoff
-from exit_signals import should_exit_early
+from utils import logger_utils  # from top-level utils package
+from scripts.utils import fetch_bars_with_cutoff, cache_bars  # explicitly from scripts directory
+from scripts.exit_signals import should_exit_early
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.makedirs(os.path.join(BASE_DIR, 'data'), exist_ok=True)

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -1,21 +1,19 @@
 # metrics.py (enhanced with comprehensive metrics)
 import os
+import sys
+
+# Ensure project root is first in Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import pandas as pd
 import logging
-import sys
-from pathlib import Path
 
-# Adjust sys.path to ensure utils package is correctly found
-project_root = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(project_root))
-
-from utils.logger_utils import init_logging
-from utils import write_csv_atomic
+from utils import logger_utils, write_csv_atomic
 from datetime import datetime
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-logger = init_logging(__name__, "metrics.log")
+logger = logger_utils.init_logging(__name__, "metrics.log")
 start_time = datetime.utcnow()
 logger.info("Script started")
 


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` at script start
- import `logger_utils` and helpers from explicit modules
- make metrics script use same pattern

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68805032e74483319b7e1b84a0d605cc