### PR TITLE
Fix log path and Alpaca method usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ automatically:
 ```bash
 python scripts/run_pipeline.py
 ```
+
+When creating a scheduled task for `execute_trades.py` on PythonAnywhere make
+sure the working directory is set to the project root so logs and CSV files are
+written in the correct location:
+
+```bash
+cd /home/RasPatrick/jbravo_screener && /home/RasPatrick/.virtualenvs/jbravo-env/bin/python scripts/execute_trades.py
+```

--- a/scripts/enhanced_execute_trades.py
+++ b/scripts/enhanced_execute_trades.py
@@ -174,7 +174,13 @@ def submit_trades() -> None:
     logging.info("Buying power: %s, allocation per trade: %s", buying_power, alloc_dollars)
     for _, row in candidates.iterrows():
         sym = row["symbol"]
-        last_price = trading_client.get_latest_trade(sym).price
+        try:
+            last_price = trading_client.get_stock_latest_trade(sym).price
+        except AttributeError:
+            logging.warning(
+                "Method get_stock_latest_trade not available for %s", sym
+            )
+            continue
         qty = max(int(alloc_dollars / last_price), 1)
         entry_price = last_price  # You can adjust limit pricing here
         logging.info("Submitting buy order for %s: qty=%s @ %s", sym, qty, entry_price)

--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -324,7 +324,14 @@ def allocate_position(symbol):
                 start,
                 (datetime.now(timezone.utc) - timedelta(minutes=16)).isoformat(),
             )
-            prev_close = trading_client.get_latest_trade(symbol).price
+            try:
+                latest_trade = trading_client.get_stock_latest_trade(symbol)
+                prev_close = latest_trade.price
+            except AttributeError:
+                logger.warning(
+                    "Method get_stock_latest_trade not available for %s", symbol
+                )
+                return None, "market data error"
             bars = pd.DataFrame([{"close": prev_close}])
             logger.info("Using previous close price for %s: %s", symbol, prev_close)
     except Exception as e:

--- a/utils/logger_utils.py
+++ b/utils/logger_utils.py
@@ -1,16 +1,21 @@
 import logging
-import os
+from pathlib import Path
 from logging.handlers import RotatingFileHandler
 
 
 def init_logging(module_name: str, log_filename: str) -> logging.Logger:
-    os.makedirs("logs", exist_ok=True)
+    """Initialize a module level logger writing to the project ``logs`` folder."""
+    base_dir = Path(__file__).resolve().parent.parent
+    log_dir = base_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / log_filename
+
     log_formatter = logging.Formatter(
         "%(asctime)s [%(levelname)s] [%(name)s]: %(message)s"
     )
 
     file_handler = RotatingFileHandler(
-        f"logs/{log_filename}", maxBytes=2 * 1024 * 1024, backupCount=5
+        log_path, maxBytes=2 * 1024 * 1024, backupCount=5
     )
     file_handler.setFormatter(log_formatter)
 
@@ -19,7 +24,7 @@ def init_logging(module_name: str, log_filename: str) -> logging.Logger:
     logger.addHandler(file_handler)
 
     error_handler = RotatingFileHandler(
-        "logs/error.log", maxBytes=2 * 1024 * 1024, backupCount=5
+        log_dir / "error.log", maxBytes=2 * 1024 * 1024, backupCount=5
     )
     error_handler.setFormatter(log_formatter)
     error_handler.setLevel(logging.ERROR)


### PR DESCRIPTION
## Summary
- ensure logs directory resolves relative to project root
- document the correct PythonAnywhere scheduled task path
- update Alpaca latest trade call with a fallback handler
- update enhanced trader for new latest trade method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6881078c715c8331ac75b90f2fff9f3c