### PR TITLE
Fix monitoring logs and dashboard alerts

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -712,6 +712,15 @@ def render_tab(tab, n_intervals, n_log_intervals, refresh_clicks):
             except Exception as exc:  # pragma: no cover - log file errors
                 logger.error("Failed to load execution metrics: %s", exc)
 
+        api_error_alert = (
+            html.Div(
+                f"Recent API Errors: {metrics_data['api_failures']}",
+                style={"color": "orange"},
+            )
+            if metrics_data["api_failures"] > 0
+            else None
+        )
+
         metrics_view = html.Div([
             html.H5("Execute Trades Metrics"),
             html.Ul([
@@ -746,7 +755,11 @@ def render_tab(tab, n_intervals, n_log_intervals, refresh_clicks):
             className="text-muted mb-2",
         )
 
-        return dbc.Container([timestamp, download, table, html.Hr(), metrics_view], fluid=True)
+        components = [timestamp, download, table, html.Hr()]
+        if api_error_alert:
+            components.append(api_error_alert)
+        components.append(metrics_view)
+        return dbc.Container(components, fluid=True)
 
     elif tab == "tab-positions":
         positions_df, alert = load_csv(
@@ -849,11 +862,11 @@ def render_tab(tab, n_intervals, n_log_intervals, refresh_clicks):
         )
         limit_info = html.Div(
             f"Max Open Trades Limit: {MAX_OPEN_TRADES}",
-            className="text-muted",
+            style={"font-weight": "bold"},
         )
         limit_alert = (
             dbc.Alert(
-                "Max Open Trades limit reached - new trades blocked.",
+                "Warning: Maximum open trades limit reached, new trades skipped!",
                 color="danger",
                 className="m-2",
             )

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -9,18 +9,10 @@ from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.timeframe import TimeFrame
 from alpaca.trading.enums import QueryOrderStatus, OrderSide, TimeInForce
 from alpaca.trading.requests import GetOrdersRequest, TrailingStopOrderRequest
-from logging.handlers import RotatingFileHandler
 from utils import fetch_bars_with_cutoff
+from utils.logger_utils import init_logging
 import shutil
 from tempfile import NamedTemporaryFile
-
-
-class InfoRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that logs when a rollover occurs."""
-
-    def doRollover(self):
-        super().doRollover()
-        logging.info("Log rotated due to size limit.")
 
 
 from dotenv import load_dotenv
@@ -38,22 +30,8 @@ ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
 os.makedirs(os.path.join(BASE_DIR, "logs"), exist_ok=True)
 os.makedirs(os.path.join(BASE_DIR, "data"), exist_ok=True)
 
-log_dir = os.path.join(BASE_DIR, "logs")
-os.makedirs(log_dir, exist_ok=True)
-log_path = os.path.join(log_dir, "monitor.log")
-
-LOG_FORMAT = "%(asctime)s [%(levelname)s] %(message)s"
-handler = InfoRotatingFileHandler(log_path, maxBytes=2_000_000, backupCount=5)
-handler.setFormatter(logging.Formatter(LOG_FORMAT))
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-logger.handlers = []  # Clear existing handlers
-logger.addHandler(handler)
-
-console_handler = logging.StreamHandler()
-console_handler.setFormatter(logging.Formatter(LOG_FORMAT))
-logger.addHandler(console_handler)
+logger = init_logging(__name__, "monitor.log")
+logger.info("Monitoring service active.")
 
 
 def send_alert(message: str):

--- a/utils/logger_utils.py
+++ b/utils/logger_utils.py
@@ -17,7 +17,9 @@ def init_logging(module_name: str, log_filename: str) -> logging.Logger:
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
-    file_handler = RotatingFileHandler(log_path, maxBytes=2 * 1024 * 1024, backupCount=5)
+    file_handler = RotatingFileHandler(
+        log_path, maxBytes=5 * 1024 * 1024, backupCount=5
+    )
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 


### PR DESCRIPTION
## Summary
- adjust rotating file size in `logger_utils`
- simplify logging setup in `monitor_positions` and log startup
- add API error alert and clearer position limit messaging to dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68813e6577d08331ac0e4c65c83cd10e