### PR TITLE
Fix utils imports in monitor_positions

### DIFF
--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -1,6 +1,7 @@
 # monitor_positions.py
 
 import os
+import sys
 import time
 from datetime import datetime, timedelta, timezone
 import pandas as pd
@@ -9,6 +10,11 @@ from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.timeframe import TimeFrame
 from alpaca.trading.enums import QueryOrderStatus, OrderSide, TimeInForce
 from alpaca.trading.requests import GetOrdersRequest, TrailingStopOrderRequest
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+
 from utils import fetch_bars_with_cutoff
 from utils.logger_utils import init_logging
 import shutil
@@ -19,8 +25,6 @@ from dotenv import load_dotenv
 import logging
 import pytz
 import requests
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 dotenv_path = os.path.join(BASE_DIR, ".env")
 load_dotenv(dotenv_path)


### PR DESCRIPTION
## Summary
- prepend project root to `sys.path` in `monitor_positions.py`
- import monitoring utilities after adjusting the path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement blinker==1.9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68814ef6aac083319df72c64332f1d44