### PR TITLE
Fix import for fetch_bars_with_cutoff

### DIFF
--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -15,7 +15,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if BASE_DIR not in sys.path:
     sys.path.insert(0, BASE_DIR)
 
-from utils import fetch_bars_with_cutoff
+from scripts.utils import fetch_bars_with_cutoff
 from utils.logger_utils import init_logging
 import shutil
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
## Summary
- import fetch_bars_with_cutoff from `scripts.utils`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688173357c20833181d9d17252e54d01