### PR TITLE
Fix stale service checks and order submission bugs

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -96,8 +96,8 @@ metrics_path = os.path.join(BASE_DIR, "data", "execute_metrics.json")
 
 
 def round_price(value: float) -> float:
-    """Return ``value`` rounded to two decimal places."""
-    return float(Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+    """Return ``value`` rounded to the nearest cent."""
+    return round(value + 1e-6, 2)
 
 
 def get_latest_price(symbol: str) -> float | None:
@@ -369,7 +369,11 @@ def allocate_position(symbol):
         return None, reason
     if len(open_positions) >= MAX_OPEN_TRADES:
         reason = "max open trades reached"
-        logger.debug("Skipping %s: %s", symbol, reason)
+        logger.info(
+            "Skipped %s due to reaching max open trades (%s).",
+            symbol,
+            MAX_OPEN_TRADES,
+        )
         return None, reason
 
     buying_power = get_buying_power()


### PR DESCRIPTION
## Summary
- warn when monitoring data is stale using newest of monitor.log and open_positions.csv
- highlight when max open trades are reached
- ensure price rounding uses cents
- handle Alpaca cancel_order compatibility
- avoid sell submissions when no quantity is available
- log when trades skipped due to open trade limit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68825b21c644833192b04c28bb3d4ef1