### PR TITLE
Fix Alpaca API usage and order quantity checks

### DIFF
--- a/scripts/enhanced_execute_trades.py
+++ b/scripts/enhanced_execute_trades.py
@@ -29,7 +29,7 @@ from dotenv import load_dotenv
 
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import LimitOrderRequest, MarketOrderRequest, GetOrdersRequest
-from alpaca.trading.enums import OrderSide, TimeInForce, QueryOrderStatus
+from alpaca.trading.enums import OrderSide, TimeInForce, OrderStatus
 from alpaca.trading.requests import TrailingStopOrderRequest
 
 from utils import write_csv_atomic
@@ -203,7 +203,7 @@ def attach_trailing_stops() -> None:
     """Attach a trailing stop order to each open position lacking one."""
     positions = get_open_positions()
     for symbol, pos in positions.items():
-        request = GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
+        request = GetOrdersRequest(status=OrderStatus.OPEN, symbols=[symbol])
         orders = trading_client.get_orders(filter=request)
         if any(o.order_type == 'trailing_stop' for o in orders):
             continue
@@ -225,7 +225,7 @@ def attach_trailing_stops() -> None:
 def daily_exit_check() -> None:
     """Close positions that hit the max holding period or trigger early exit signals."""
     positions = get_open_positions()
-    request = GetOrdersRequest(status=QueryOrderStatus.CLOSED)
+    request = GetOrdersRequest(status=OrderStatus.CLOSED)
     orders = trading_client.get_orders(filter=request)
     for symbol, pos in positions.items():
         entry_orders = [o for o in orders if o.symbol == symbol and o.side == 'buy']

--- a/scripts/fetch_trades_history.py
+++ b/scripts/fetch_trades_history.py
@@ -1,6 +1,6 @@
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import GetOrdersRequest
-from alpaca.trading.enums import QueryOrderStatus
+from alpaca.trading.enums import OrderStatus
 from dotenv import load_dotenv
 from datetime import datetime, timezone
 import pandas as pd
@@ -28,7 +28,7 @@ end = pd.Timestamp.utcnow().isoformat()
 
 while True:
     req = GetOrdersRequest(
-        status=QueryOrderStatus.CLOSED,
+        status=OrderStatus.CLOSED,
         until=end,
         limit=500,
         direction='desc',

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -9,7 +9,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from alpaca.trading.client import TradingClient
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.timeframe import TimeFrame
-from alpaca.trading.enums import QueryOrderStatus, OrderSide, TimeInForce
+from alpaca.trading.enums import OrderStatus, OrderSide, TimeInForce
 from alpaca.trading.requests import GetOrdersRequest, TrailingStopOrderRequest, LimitOrderRequest
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -351,7 +351,7 @@ def check_sell_signal(indicators) -> list:
 
 
 def get_open_orders(symbol):
-    request = GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
+    request = GetOrdersRequest(status=OrderStatus.OPEN, symbols=[symbol])
     try:
         return trading_client.get_orders(filter=request)
     except Exception as e:
@@ -369,7 +369,7 @@ def get_trailing_stop_order(symbol):
 
 def last_filled_trailing_stop(symbol):
     request = GetOrdersRequest(
-        status=QueryOrderStatus.CLOSED, symbols=[symbol], limit=10
+        status=OrderStatus.CLOSED, symbols=[symbol], limit=10
     )
     try:
         orders = trading_client.get_orders(filter=request)
@@ -512,7 +512,9 @@ def manage_trailing_stop(position):
 def check_pending_orders():
     """Log status of any open sell orders."""
     try:
-        open_orders = trading_client.get_orders(status="open")
+        open_orders = trading_client.get_orders(
+            filter=GetOrdersRequest(status=OrderStatus.OPEN)
+        )
         for order in open_orders:
             try:
                 status = trading_client.get_order_by_id(order.id).status


### PR DESCRIPTION
## Summary
- update all Alpaca order queries to use `OrderStatus`
- use `StockBarsRequest` when fetching prices
- persist entry time when saving open positions
- validate available quantities before submitting sell orders
- adjust dashboard updater to keep entry time consistent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68838791376883319d8d98c9758eb8a9