### PR TITLE
Fix metrics summary schema and improve error handling

### DIFF
--- a/alpaca_test.py
+++ b/alpaca_test.py
@@ -1,0 +1,12 @@
+from alpaca.trading.client import TradingClient
+from dotenv import load_dotenv
+import os
+
+load_dotenv('.env')
+
+API_KEY = os.getenv('APCA_API_KEY_ID')
+API_SECRET = os.getenv('APCA_API_SECRET_KEY')
+
+trading_client = TradingClient(API_KEY, API_SECRET, paper=True)
+positions = trading_client.get_all_positions()
+print('Positions:', positions)

--- a/data/metrics_summary.csv
+++ b/data/metrics_summary.csv
@@ -1,2 +1,2 @@
-Total Trades,Total Wins,Total Losses,Win Rate (%),Total Net PnL,Average Return per Trade,Average Win,Average Loss
-160,60,100,37.5,-4.672900000000003,-0.02920562500000002,5.099016666666667,-3.9185555555555567
+total_trades,net_pnl,win_rate,expectancy,profit_factor,max_drawdown
+2,0,0,0,0,0

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -151,9 +151,9 @@ if __name__ == "__main__":
             mdf = pd.read_csv(metrics_file)
             if not mdf.empty:
                 last = mdf.iloc[-1]
-                total_trades = int(last.get("Total Trades", 0))
-                win_rate = round(last.get("Win Rate (%)", 0), 2)
-                net_pnl = round(last.get("Total Net PnL", 0), 2)
+                total_trades = int(last.get("total_trades", 0))
+                win_rate = round(last.get("win_rate", 0), 2)
+                net_pnl = round(last.get("net_pnl", 0), 2)
         except Exception:
             pass
 

--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -204,8 +204,8 @@ def calculate_weekly_summary() -> dict:
     if not metrics_row.empty:
         summary.update(
             {
-                "Overall Win Rate (%)": metrics_row.get("Win Rate (%)", 0),
-                "Overall Net PnL": metrics_row.get("Total Net PnL", 0),
+                "Overall Win Rate (%)": metrics_row.get("win_rate", 0),
+                "Overall Net PnL": metrics_row.get("net_pnl", 0),
             }
         )
 


### PR DESCRIPTION
## Summary
- fix imports in `metrics.py`
- compute new metrics summary schema
- update related scripts for new columns
- improve dashboard callbacks for missing file errors
- add Alpaca API test helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688392f671748331b45afcdf9fb4a33b