### PR TITLE
Fix metrics and monitoring

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -35,14 +35,13 @@ def fetch_bars_with_cutoff(symbol: str, start_date, timeframe, data_client):
     else:
         tf = timeframe
 
-    req = StockBarsRequest(
-        symbol_or_symbols=symbol,
+    return data_client.get_bars(
+        symbol,
         timeframe=tf,
         start=start_date,
         end=end_safe.isoformat(),
-        feed="iex",
+        feed="sip",
     )
-    return data_client.get_stock_bars(req)
 
 
 def get_last_trading_day_end(now: datetime | None = None) -> datetime:
@@ -235,7 +234,13 @@ def cache_bars_batch(symbols: list[str], data_client, cache_dir: str, days: int 
         bars_df = pd.DataFrame()
         while attempt <= retries:
             try:
-                bars_df = data_client.get_stock_bars(request_params).df
+                bars_df = data_client.get_bars(
+                    batch,
+                    timeframe=TimeFrame.Day,
+                    start=min_start,
+                    end=end_safe.isoformat(),
+                    feed="sip",
+                ).df
                 break
             except APIError as exc:
                 if getattr(exc, "status_code", None) == 429:

--- a/tests/test_bar_cache.py
+++ b/tests/test_bar_cache.py
@@ -21,7 +21,7 @@ class TestFetchBarsWithCutoff(unittest.TestCase):
                 "2024-01-03",
             ], utc=True),
         )
-        client.get_stock_bars.return_value.df = df
+        client.get_bars.return_value.df = df
         cutoff = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
 
         result = fetch_bars_with_cutoff("FAKE", client, cutoff)


### PR DESCRIPTION
## Summary
- fix metrics logger
- keep original entry time for open positions and add days-in-trade
- verify qty before trailing stop
- update Alpaca get_bars usage
- clean up dashboard data loading and logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6883c2fc58808331be7321d1d74c9721