### PR TITLE
Switch to get_stock_bars

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -40,7 +40,7 @@ import requests
 from utils.logger_utils import init_logging
 
 # Import scripts/utils explicitly
-from scripts.utils import fetch_bars_with_cutoff, cache_bars
+from scripts.utils import cache_bars
 
 # Explicit import from scripts directory
 from scripts.exit_signals import should_exit_early
@@ -424,7 +424,13 @@ def allocate_position(symbol):
     alloc_amount = buying_power * ALLOC_PERCENT
     start = datetime.now(timezone.utc) - timedelta(hours=1, minutes=16)
     try:
-        bars = fetch_bars_with_cutoff(symbol, start, TimeFrame.Minute, data_client).df
+        req = StockBarsRequest(
+            symbol_or_symbols=[symbol],
+            timeframe=TimeFrame.Minute,
+            start=start,
+            end=datetime.now(timezone.utc) - timedelta(minutes=16),
+        )
+        bars = data_client.get_stock_bars(req).df
         if bars.empty:
             logger.warning(
                 "No bars available for %s from %s to %s. Retrying with previous day's close.",

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -293,7 +293,7 @@ def fetch_indicators(symbol):
     """Fetch recent daily bars and compute indicators."""
     try:
         start_date = datetime.now(timezone.utc) - timedelta(days=750)
-        bars = fetch_bars_with_cutoff(symbol, start_date, TimeFrame.Day, data_client).df
+        bars = fetch_bars_with_cutoff(symbol, start_date, data_client)
         logger.info(f"Successfully fetched bars for {symbol}")
     except Exception as e:
         logger.exception(f"Failed to fetch bars for {symbol}: {e}")

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -240,9 +240,9 @@ def main() -> None:
     for symbol in symbols:
         logger.info("Processing %s...", symbol)
         start = datetime.now(timezone.utc) - timedelta(days=1500)
-        bars = fetch_bars_with_cutoff(symbol, start, TimeFrame.Day, data_client)
+        bars_df = fetch_bars_with_cutoff(symbol, start, data_client)
         cache_bars(symbol, data_client, DATA_CACHE_DIR)
-        df = bars.df.reset_index()
+        df = bars_df.reset_index()
         logger.debug("%s has %d bars", symbol, len(df))
         try:
             rec = compute_score(symbol, df)

--- a/tests/test_bar_cache.py
+++ b/tests/test_bar_cache.py
@@ -21,7 +21,7 @@ class TestFetchBarsWithCutoff(unittest.TestCase):
                 "2024-01-03",
             ], utc=True),
         )
-        client.get_bars.return_value.df = df
+        client.get_stock_bars.return_value.df = df
         cutoff = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
 
         result = fetch_bars_with_cutoff("FAKE", client, cutoff)


### PR DESCRIPTION
## Summary
- replace `get_bars` usage with `get_stock_bars`
- adjust screener and other scripts for new API
- update unit tests for the new interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca', 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6883c82dcda88331a03a379a1047d7ba