### PR TITLE
Fix trade execution utilities and Alpaca API calls

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -238,13 +238,14 @@ def cache_bars_batch(symbols: list[str], data_client, cache_dir: str, days: int 
         bars_df = pd.DataFrame()
         while attempt <= retries:
             try:
-                bars_df = data_client.get_bars(
-                    batch,
+                req = StockBarsRequest(
+                    symbol_or_symbols=batch,
                     timeframe=TimeFrame.Day,
                     start=min_start,
                     end=end_safe.isoformat(),
                     feed="sip",
-                ).df
+                )
+                bars_df = data_client.get_stock_bars(req).df
                 break
             except APIError as exc:
                 if getattr(exc, "status_code", None) == 429:


### PR DESCRIPTION
## Summary
- update trailing stop order lookup to avoid removed OPEN enum
- add robust fallback price handling in `allocate_position` and `submit_trades`
- replace deprecated `get_bars` calls with `get_stock_bars`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for alpaca and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6883e12c921883318de338803a138ab4