### PR TITLE
Remove deprecated OrderStatus enum

### DIFF
--- a/scripts/enhanced_execute_trades.py
+++ b/scripts/enhanced_execute_trades.py
@@ -29,7 +29,7 @@ from dotenv import load_dotenv
 
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import LimitOrderRequest, MarketOrderRequest, GetOrdersRequest
-from alpaca.trading.enums import OrderSide, TimeInForce, OrderStatus
+from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.trading.requests import TrailingStopOrderRequest
 
 from utils import write_csv_atomic
@@ -203,7 +203,7 @@ def attach_trailing_stops() -> None:
     """Attach a trailing stop order to each open position lacking one."""
     positions = get_open_positions()
     for symbol, pos in positions.items():
-        request = GetOrdersRequest(status=OrderStatus.OPEN, symbols=[symbol])
+        request = GetOrdersRequest(status="open", symbols=[symbol])
         orders = trading_client.get_orders(filter=request)
         if any(o.order_type == 'trailing_stop' for o in orders):
             continue
@@ -225,7 +225,7 @@ def attach_trailing_stops() -> None:
 def daily_exit_check() -> None:
     """Close positions that hit the max holding period or trigger early exit signals."""
     positions = get_open_positions()
-    request = GetOrdersRequest(status=OrderStatus.CLOSED)
+    request = GetOrdersRequest(status="closed")
     orders = trading_client.get_orders(filter=request)
     for symbol, pos in positions.items():
         entry_orders = [o for o in orders if o.symbol == symbol and o.side == 'buy']

--- a/scripts/fetch_trades_history.py
+++ b/scripts/fetch_trades_history.py
@@ -1,6 +1,5 @@
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import GetOrdersRequest
-from alpaca.trading.enums import OrderStatus
 from dotenv import load_dotenv
 from datetime import datetime, timezone
 import pandas as pd
@@ -28,7 +27,7 @@ end = pd.Timestamp.utcnow().isoformat()
 
 while True:
     req = GetOrdersRequest(
-        status=OrderStatus.CLOSED,
+        status="closed",
         until=end,
         limit=500,
         direction='desc',

--- a/scripts/update_dashboard_data.py
+++ b/scripts/update_dashboard_data.py
@@ -9,7 +9,6 @@ from tempfile import NamedTemporaryFile
 import pandas as pd
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import GetOrdersRequest
-from alpaca.trading.enums import OrderStatus
 from dotenv import load_dotenv
 import requests
 
@@ -222,7 +221,7 @@ def fetch_all_orders(limit=500):
     end = None
     while True:
         req = GetOrdersRequest(
-            status=OrderStatus.ALL, limit=limit, until=end, direction="desc"
+            status="all", limit=limit, until=end, direction="desc"
         )
         chunk = trading_client.get_orders(filter=req)
         if not chunk:
@@ -437,7 +436,7 @@ def update_pending_orders():
     """Poll open orders and refresh their status in CSV."""
     try:
         open_orders = trading_client.get_orders(
-            filter=GetOrdersRequest(status=OrderStatus.OPEN)
+            filter=GetOrdersRequest(status="open")
         )
         for order in open_orders:
             current = trading_client.get_order_by_id(order.id).status


### PR DESCRIPTION
## Summary
- refactor Alpaca order status checks to use string values
- drop OrderStatus enum imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_6883ebfda55083319c224ea3ebc21749