### PR TITLE
Add setup script

### DIFF
--- a/.setup
+++ b/.setup
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+apt-get update
+apt-get install -y build-essential
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add `.setup` script to install dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68840051a2008331bd0904f6b772c93c