### PR TITLE
Remove TradingView fallback and use Alpaca data

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ cd /home/RasPatrick/jbravo_screener && /home/RasPatrick/.virtualenvs/jbravo-env/
 cd /home/RasPatrick/jbravo_screener && /home/RasPatrick/.virtualenvs/jbravo-env/bin/python scripts/weekly_summary.py
 cd /home/RasPatrick/jbravo_screener && /home/RasPatrick/.virtualenvs/jbravo-env/bin/python scripts/monitor_positions.py
 ```
+
+## Market Data
+
+Historical prices and volume are now fetched exclusively from the Alpaca Market Data API using the `alpaca_trade_api` library. The previous fallback to the `tvdatafeed` package has been removed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,5 @@ urllib3==2.5.0
 Werkzeug==3.1.3
 zipp==3.23.0
 alpaca-py>=0.42.0
-tvdatafeed==3.3.1
+alpaca-trade-api>=3.3.0
 atomicwrites==1.4.1


### PR DESCRIPTION
## Summary
- drop deprecated tvdatafeed dependency
- fetch fallback market data using Alpaca REST
- document the market data change

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68840b7f7788833188901da17fad37a4