### PR TITLE
Switch to alpaca-py SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ cd /home/RasPatrick/jbravo_screener && /home/RasPatrick/.virtualenvs/jbravo-env/
 
 ## Market Data
 
-Historical prices and volume are now fetched exclusively from the Alpaca Market Data API using the `alpaca_trade_api` library. The previous fallback to the `tvdatafeed` package has been removed.
+Historical prices and volume are now fetched exclusively from the Alpaca Market Data API using the `alpaca-py` SDK. The previous fallback to the `tvdatafeed` package has been removed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,4 @@ urllib3==2.5.0
 Werkzeug==3.1.3
 zipp==3.23.0
 alpaca-py>=0.42.0
-alpaca-trade-api>=3.3.0
 atomicwrites==1.4.1

--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -26,11 +26,7 @@ from alpaca.trading.requests import (
 )
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.data.requests import StockBarsRequest
-
-try:  # Compatibility with alpaca-py and alpaca-trade-api
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback import
-    from alpaca.common.exceptions import APIError  # type: ignore
+from alpaca.common.exceptions import APIError
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.timeframe import TimeFrame
 from dotenv import load_dotenv

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -10,7 +10,6 @@ import time
 from alpaca.data.requests import StockBarsRequest
 from alpaca.data.timeframe import TimeFrame
 from alpaca.common.exceptions import APIError
-from alpaca_trade_api.rest import REST as TradeREST, TimeFrame as RESTTimeFrame
 
 
 def has_datetime_index(idx) -> bool:
@@ -165,24 +164,7 @@ def cache_bars(
 
     if new_df.empty:
         logging.warning("cache_bars: %s returned empty data", symbol)
-        try:
-            api_key = os.getenv("APCA_API_KEY_ID")
-            api_secret = os.getenv("APCA_API_SECRET_KEY")
-            base_url = os.getenv("APCA_API_BASE_URL")
-            rest_client = TradeREST(api_key, api_secret, base_url)
-            start_dt = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
-            end_dt = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            fallback_df = rest_client.get_bars(symbol, RESTTimeFrame.Day, start_dt, end_dt).df
-            if not fallback_df.empty:
-                fallback_df.index = pd.to_datetime(fallback_df.index)
-                if fallback_df.index.tzinfo is None:
-                    fallback_df.index = fallback_df.index.tz_localize("UTC")
-                new_df = fallback_df[["open", "high", "low", "close", "volume"]]
-            else:
-                return df
-        except Exception as rest_exc:
-            logging.error("Alpaca REST fallback failed for %s: %s", symbol, rest_exc)
-            return df
+        return df
 
     if not new_df.empty:
         idx_list = new_df.index.tolist()

--- a/tests/test_bar_cache.py
+++ b/tests/test_bar_cache.py
@@ -24,7 +24,7 @@ class TestFetchBarsWithCutoff(unittest.TestCase):
         client.get_stock_bars.return_value.df = df
         cutoff = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
 
-        result = fetch_bars_with_cutoff("FAKE", client, cutoff)
+        result = fetch_bars_with_cutoff("FAKE", cutoff, client)
 
         self.assertTrue((result.index <= cutoff).all())
         self.assertEqual(len(result), 1)


### PR DESCRIPTION
## Summary
- drop `alpaca-trade-api` dependency and rely on `alpaca-py`
- update documentation to mention the new SDK
- remove legacy REST fallback logic
- adjust imports for `APIError`
- fix tests for updated utility signature

## Testing
- `pip uninstall -y alpaca-trade-api`
- `pip install alpaca-py>=0.42.0` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*


------
https://chatgpt.com/codex/tasks/task_e_68840ee1829083319d42bb60192135fe