### PR TITLE
Fix Alpaca enum usage

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -24,7 +24,7 @@ from alpaca.trading.requests import (
     GetOrdersRequest,
     TrailingStopOrderRequest,
 )
-from alpaca.trading.enums import OrderSide, TimeInForce, OrderStatus
+from alpaca.trading.enums import OrderSide, TimeInForce, QueryOrderStatus
 from alpaca.data.requests import StockBarsRequest
 from alpaca.common.exceptions import APIError
 from alpaca.data.historical import StockHistoricalDataClient
@@ -629,7 +629,7 @@ def submit_trades():
 def attach_trailing_stops():
     positions = get_open_positions()
     for symbol, pos in positions.items():
-        request = GetOrdersRequest(symbols=[symbol], statuses=[OrderStatus.OPEN])
+        request = GetOrdersRequest(symbols=[symbol], statuses=[QueryOrderStatus.OPEN])
         try:
             orders = trading_client.get_orders(request)
         except Exception as exc:

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -9,7 +9,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from alpaca.trading.client import TradingClient
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.timeframe import TimeFrame
-from alpaca.trading.enums import OrderSide, TimeInForce, OrderStatus
+from alpaca.trading.enums import OrderSide, TimeInForce, QueryOrderStatus
 from alpaca.trading.requests import (
     GetOrdersRequest,
     TrailingStopOrderRequest,
@@ -361,7 +361,7 @@ def check_sell_signal(indicators) -> list:
 
 
 def get_open_orders(symbol):
-    request = GetOrdersRequest(statuses=[OrderStatus.OPEN], symbols=[symbol])
+    request = GetOrdersRequest(statuses=[QueryOrderStatus.OPEN], symbols=[symbol])
     try:
         orders = trading_client.get_orders(request)
         return list(orders)
@@ -563,7 +563,7 @@ def manage_trailing_stop(position):
 def check_pending_orders():
     """Log status of any open sell orders."""
     try:
-        request = GetOrdersRequest(statuses=[OrderStatus.OPEN])
+        request = GetOrdersRequest(statuses=[QueryOrderStatus.OPEN])
         open_orders = trading_client.get_orders(request)
         for order in open_orders:
             try:


### PR DESCRIPTION
## Summary
- update trading enum imports in trading scripts
- query open orders using `QueryOrderStatus`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c92f64a88331bd2f9557ca0b4b8e