### PR TITLE
Fix Alpaca open orders API usage

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -630,9 +630,10 @@ def attach_trailing_stops():
     positions = get_open_positions()
     for symbol, pos in positions.items():
         try:
-            open_orders = trading_client.get_orders(
-                GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
-            )
+            request = GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
+            open_orders = trading_client.get_orders(filter=request)
+            logger.info(
+                f"Fetched open orders for {symbol}: {len(open_orders)} found.")
         except Exception as exc:
             logger.error("Failed to fetch open orders for %s: %s", symbol, exc)
             continue


### PR DESCRIPTION
## Summary
- update Alpaca open order requests to use `QueryOrderStatus.OPEN`
- log how many open orders are fetched for easier debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e2ee99448331acbd2b2df156f377