### PR TITLE
Use Alpaca IEX feed

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -113,25 +113,15 @@ def get_latest_price(symbol: str) -> float | None:
             timeframe=TimeFrame.Minute,
             start=datetime.now(timezone.utc) - timedelta(minutes=5),
             end=datetime.now(timezone.utc),
-            feed="sip",
+            feed="iex",
         )
         bars = data_client.get_stock_bars(req).df
         if bars.empty:
-            raise ValueError("No SIP data available")
-    except Exception as exc:  # pragma: no cover - API errors
-        logger.warning("SIP data unavailable for %s, falling back to IEX feed: %s", symbol, exc)
-        try:
-            req = StockBarsRequest(
-                symbol_or_symbols=[symbol],
-                timeframe=TimeFrame.Minute,
-                start=datetime.now(timezone.utc) - timedelta(minutes=5),
-                end=datetime.now(timezone.utc),
-                feed="iex",
-            )
-            bars = data_client.get_stock_bars(req).df
-        except Exception as exc2:
-            logger.error("Fallback price fetch failed for %s: %s", symbol, exc2)
+            logger.warning("No bars available for %s using IEX feed", symbol)
             return None
+    except Exception as exc:  # pragma: no cover - API errors
+        logger.error("Failed to fetch latest price for %s via IEX: %s", symbol, exc)
+        return None
     if not bars.empty:
         return float(bars["close"].iloc[-1])
     return None
@@ -484,6 +474,7 @@ def allocate_position(symbol):
             timeframe=TimeFrame.Minute,
             start=start,
             end=datetime.now(timezone.utc) - timedelta(minutes=16),
+            feed="iex",
         )
         bars = data_client.get_stock_bars(req).df
         if bars.empty:


### PR DESCRIPTION
## Summary
- default to IEX feed for all Alpaca data requests
- clean up fallback logic and error handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688806f75dbc8331a46689c4571c730c