### PR TITLE
Fix order status enum usage

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -671,7 +671,7 @@ def attach_trailing_stops():
         # Fetch current open orders and cancel existing trailing stops
         try:
             request = GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
-            existing_orders = trading_client.get_orders(filter=request)
+            existing_orders = trading_client.get_orders(request)
         except Exception as exc:
             logger.error("Failed to fetch open orders for %s: %s", symbol, exc)
             continue

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -375,7 +375,7 @@ def check_sell_signal(indicators) -> list:
 def get_open_orders(symbol):
     request = GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
     try:
-        open_orders = trading_client.get_orders(filter=request)
+        open_orders = trading_client.get_orders(request)
         logger.info(
             f"Fetched open orders for {symbol}: {len(open_orders)} found.")
         return list(open_orders)
@@ -494,7 +494,7 @@ def manage_trailing_stop(position):
 
     try:
         request = GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
-        existing_orders = trading_client.get_orders(filter=request)
+        existing_orders = trading_client.get_orders(request)
         logger.info(
             f"Fetched open orders for {symbol}: {len(existing_orders)} found.")
         for order in existing_orders:
@@ -589,7 +589,7 @@ def check_pending_orders():
     """Log status of any open sell orders."""
     try:
         request = GetOrdersRequest(status=QueryOrderStatus.OPEN)
-        open_orders = trading_client.get_orders(filter=request)
+        open_orders = trading_client.get_orders(request)
         logger.info(
             f"Fetched open orders for all symbols: {len(open_orders)} found.")
         for order in open_orders:


### PR DESCRIPTION
## Summary
- use `QueryOrderStatus` when fetching open orders
- pass the order request positionally to `TradingClient.get_orders`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888155894ac83319284623b152b8df7