### PR TITLE
Improve metrics validation and logging

### DIFF
--- a/scripts/run_pipeline_enhanced.py
+++ b/scripts/run_pipeline_enhanced.py
@@ -18,7 +18,7 @@ from logging.handlers import RotatingFileHandler
 import requests
 import pandas as pd
 
-from utils import write_csv_atomic
+from utils import write_csv_atomic, logger_utils
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.makedirs(os.path.join(BASE_DIR, 'logs'), exist_ok=True)
@@ -26,17 +26,10 @@ os.makedirs(os.path.join(BASE_DIR, 'logs'), exist_ok=True)
 log_path = os.path.join(BASE_DIR, 'logs', 'pipeline_enhanced.log')
 error_log_path = os.path.join(BASE_DIR, 'logs', 'error.log')
 
+logger = logger_utils.init_logging(__name__, 'pipeline_enhanced.log')
 error_handler = RotatingFileHandler(error_log_path, maxBytes=2_000_000, backupCount=5)
 error_handler.setLevel(logging.ERROR)
-
-logging.basicConfig(
-    handlers=[
-        RotatingFileHandler(log_path, maxBytes=2_000_000, backupCount=5),
-        error_handler,
-    ],
-    level=logging.INFO,
-    format='%(asctime)s UTC [%(levelname)s] %(message)s'
-)
+logger.addHandler(error_handler)
 
 ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
 
@@ -47,26 +40,40 @@ def send_alert(msg: str) -> None:
     try:
         requests.post(ALERT_WEBHOOK_URL, json={"text": msg}, timeout=5)
     except Exception as exc:
-        logging.error("Failed to send alert: %s", exc)
+        logger.error("Failed to send alert: %s", exc)
 
 
 def run_step(step_name, command):
-    logging.info(f"Starting {step_name}...")
+    start_time = datetime.utcnow()
+    logger.info("Starting %s", step_name)
     try:
-        subprocess.run(command, check=True)
-        logging.info(f"Completed {step_name} successfully.")
+        result = subprocess.run(
+            command,
+            cwd=BASE_DIR,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        duration = datetime.utcnow() - start_time
+        logger.info("%s stdout:\n%s", step_name, result.stdout)
+        logger.info("%s stderr:\n%s", step_name, result.stderr)
+        logger.info("Completed %s successfully in %s", step_name, duration)
     except subprocess.CalledProcessError as e:
-        logging.error("ERROR in %s: %s", step_name, e)
+        duration = datetime.utcnow() - start_time
+        logger.error("%s failed with exit %d after %s", step_name, e.returncode, duration)
+        logger.error("%s stdout:\n%s", step_name, e.stdout)
+        logger.error("%s stderr:\n%s", step_name, e.stderr)
         send_alert(f"Pipeline step {step_name} failed: {e}")
         raise
     except Exception as e:
-        logging.error("Unexpected failure in %s: %s", step_name, e)
+        duration = datetime.utcnow() - start_time
+        logger.exception("Unexpected failure in %s after %s: %s", step_name, duration, e)
         send_alert(f"Pipeline step {step_name} exception: {e}")
         raise
 
 
 if __name__ == "__main__":
-    logging.info("Enhanced pipeline execution started.")
+    logger.info("Enhanced pipeline execution started.")
     steps = [
         (
             "Enhanced Screener",
@@ -85,7 +92,7 @@ if __name__ == "__main__":
         try:
             run_step(name, cmd)
         except Exception:
-            logging.error("Step %s failed", name)
+            logger.error("Step %s failed", name)
             send_alert(f"Pipeline halted at step {name}")
             break
     # Copy latest results into latest_candidates.csv
@@ -95,15 +102,15 @@ if __name__ == "__main__":
         try:
             df = pd.read_csv(source_path)
             write_csv_atomic(target_path, df)
-            logging.info(
+            logger.info(
                 "Updated latest_candidates.csv at %s",
                 datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
             )
         except Exception as exc:
-            logging.error("Failed to update latest_candidates.csv: %s", exc)
+            logger.error("Failed to update latest_candidates.csv: %s", exc)
             send_alert(f"Failed to update latest candidates: {exc}")
     else:
         msg = "top_candidates.csv not found; latest_candidates.csv was not updated."
-        logging.error(msg)
+        logger.error(msg)
         send_alert(msg)
-    logging.info("Enhanced pipeline execution complete.")
+    logger.info("Enhanced pipeline execution complete.")


### PR DESCRIPTION
## Summary
- improve logging setup for metrics script
- validate trades_log columns and drop invalid net_pnl rows
- compute metrics only when data is valid and always write metrics_summary.csv
- enhance pipeline_enhanced logging with stdout/stderr capture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9559ef7c8331bfa60445a693929a