### PR TITLE
Fix pandas append usage

### DIFF
--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -430,7 +430,8 @@ def log_closed_positions(trading_client, closed_symbols, existing_positions_df, 
         }
 
         trades_log_df = pd.read_csv(trades_log_path)
-        trades_log_df = trades_log_df.append(trade_entry, ignore_index=True)
+        trade_entry_df = pd.DataFrame([trade_entry])
+        trades_log_df = pd.concat([trades_log_df, trade_entry_df], ignore_index=True)
         trades_log_df.to_csv(trades_log_path, index=False)
 
         logger.info(f"Closed position logged: {symbol}, qty={qty}, exit={exit_price}")


### PR DESCRIPTION
## Summary
- fix deprecated DataFrame.append call in `monitor_positions`
- use `pd.concat()` for closed position logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c1a25b2788331aa366211d08d7883