### PR TITLE
Fix Alpaca limit order submission

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -738,17 +738,17 @@ def submit_order_with_polling(
     """Submit a limit order and poll until it completes or times out."""
 
     try:
-        order = trading_client.submit_order(
+        order_request = LimitOrderRequest(
             symbol=symbol,
             qty=qty,
-            side=side,
-            type="limit",
-            time_in_force="day",
+            side=OrderSide.BUY if side.lower() == "buy" else OrderSide.SELL,
             limit_price=limit_price,
+            time_in_force=TimeInForce.DAY,
             extended_hours=False,
         )
+        order = trading_client.submit_order(order_request)
         logger.info(
-            "[SUBMIT] Order for %s: qty=%s, price=%s, session=regular, order_id=%s",
+            "[SUBMIT] Order submitted for %s qty=%s at price=%s, id=%s",
             symbol,
             qty,
             limit_price,


### PR DESCRIPTION
## Summary
- use `LimitOrderRequest` in `submit_order_with_polling`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd187e658833193328554e3a90bd8