### PR TITLE
Fix pandas concat warning in trade logging

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -467,7 +467,12 @@ def update_trades_log() -> None:
         if os.path.exists(csv_path):
             try:
                 existing_df = pd.read_csv(csv_path)
-                df = pd.concat([existing_df, df_new], ignore_index=True)
+                if existing_df.empty:
+                    df = df_new.copy()
+                elif df_new.empty:
+                    df = existing_df.copy()
+                else:
+                    df = pd.concat([existing_df, df_new], ignore_index=True)
             except Exception as exc:
                 logger.error("Failed reading existing trades log: %s", exc)
                 df = df_new


### PR DESCRIPTION
## Summary
- patch trade log updater to avoid concatenating empty DataFrames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd4abf1648331b35433c9a0c9343b