### PR TITLE
Add structured trade execution event logging

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -14,6 +14,7 @@ import subprocess
 import logging
 import pandas as pd
 import json
+import secrets
 from datetime import datetime, timedelta, timezone, time
 import pytz
 from time import sleep
@@ -112,6 +113,32 @@ metrics = {
     "api_failures": 0,
 }
 metrics_path = os.path.join(BASE_DIR, "data", "execute_metrics.json")
+EVENTS_LOG_PATH = os.path.join(BASE_DIR, "data", "execute_events.jsonl")
+run_id = f"{datetime.utcnow().isoformat()}#{secrets.token_hex(3)}"
+
+
+def utcnow() -> str:
+    """Return the current UTC timestamp in ISO 8601 format."""
+
+    return datetime.utcnow().isoformat()
+
+
+def inc(metric: str, by: int = 1) -> None:
+    """Increment ``metric`` in the global metrics dictionary."""
+
+    current = metrics.get(metric, 0)
+    metrics[metric] = current + by
+
+
+def log_event(event: dict) -> None:
+    """Append ``event`` as a JSON line to the execute events log."""
+
+    payload = {"run_id": run_id, "timestamp": utcnow(), **event}
+    path = Path(EVENTS_LOG_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload))
+        f.write("\n")
 
 
 def load_cached_prices(symbols: list[str], cache_dir: str = os.path.join(BASE_DIR, "data", "history_cache")) -> dict[str, float]:

--- a/tests/test_execute_trades_logging.py
+++ b/tests/test_execute_trades_logging.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import json
+from pathlib import Path
+from datetime import datetime
+from importlib import import_module
+
+import types
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+dummy_indicators = types.ModuleType("indicators")
+dummy_indicators.rsi = lambda series: series
+dummy_indicators.macd = lambda series: (series, series, series)
+sys.modules.setdefault("indicators", dummy_indicators)
+
+os.environ.setdefault("APCA_API_KEY_ID", "test_key")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test_secret")
+
+
+@pytest.fixture(scope="module")
+def execute_trades_module():
+    return import_module("scripts.execute_trades")
+
+
+def test_log_event_appends_valid_json(tmp_path, monkeypatch, execute_trades_module):
+    module = execute_trades_module
+    events_path = tmp_path / "execute_events.jsonl"
+    monkeypatch.setattr(module, "EVENTS_LOG_PATH", events_path)
+
+    module.log_event({"event": "first"})
+    module.log_event({"event": "second", "value": 2})
+
+    lines = events_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+
+    first = json.loads(lines[0])
+    second = json.loads(lines[1])
+
+    assert first["event"] == "first"
+    assert second["event"] == "second"
+    assert second["value"] == 2
+
+    assert first["run_id"] == second["run_id"] == module.run_id
+
+    datetime.fromisoformat(first["timestamp"])
+    datetime.fromisoformat(second["timestamp"])
+
+    assert json.loads(lines[0]) == first
+    assert json.loads(lines[1]) == second


### PR DESCRIPTION
## Summary
- add run identifier, timestamp helper, and metric increment helper for execute_trades
- persist structured execution events to data/execute_events.jsonl with append-only logging
- add unit test covering JSON append behaviour for log_event

## Testing
- pytest tests/test_execute_trades_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e2fafe202083318f009842aa0baae0