### PR TITLE
Add structured pipeline event logging and test

### DIFF
--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,32 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+
+from scripts import run_pipeline
+
+
+def test_log_event_appends_and_valid_json(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_pipeline, "BASE_DIR", tmp_path)
+
+    log_file = tmp_path / "data" / "execute_events.jsonl"
+
+    run_pipeline.log_event({"event": "FIRST"})
+    run_pipeline.log_event({"event": "SECOND"})
+
+    assert log_file.exists()
+
+    lines = log_file.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+
+    first_event = json.loads(lines[0])
+    second_event = json.loads(lines[1])
+
+    assert first_event["event"] == "FIRST"
+    assert second_event["event"] == "SECOND"
+    assert "timestamp" in first_event


### PR DESCRIPTION
## Summary
- ensure the pipeline script resolves BASE_DIR via pathlib and logs structured events for start, errors, and completion
- append pipeline events to data/execute_events.jsonl via a new log_event helper that writes NDJSON with timestamps
- cover log_event with a unit test that validates append behavior and JSON structure

## Testing
- pytest tests/test_run_pipeline.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68e3e3ef0a808331b88ebc3ff06cc018