### PR TITLE
Centralize control events + absolute event path + entrypoint wiring

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -7,9 +7,9 @@ import traceback
 
 from pathlib import Path
 
-# Ensure the script runs from the repository root regardless of where it is
-# invoked from.
-BASE_DIR = Path(__file__).resolve().parents[1]
+from utils.telemetry import RunSentinel, repo_root, log_event as telemetry_log_event
+
+BASE_DIR = repo_root()
 os.chdir(BASE_DIR)
 
 # Add project root to sys.path so that sibling packages (like scripts) can be imported
@@ -26,25 +26,18 @@ from utils import write_csv_atomic
 
 
 logger = logger_utils.init_logging(__name__, "pipeline.log")
-start_time = datetime.now(timezone.utc)
-logger.info("Pipeline execution started")
 error_log_path = os.path.join(BASE_DIR, "logs", "error.log")
 
 ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
 
 
-def log_event(event: dict) -> None:
-    """Append a structured event to the pipeline execution log."""
+COMPONENT_NAME = "pipeline"
 
-    event_path = BASE_DIR / "data" / "execute_events.jsonl"
-    event_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        **event,
-    }
-    with event_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(payload))
-        f.write("\n")
+
+def log_event(event: dict) -> None:
+    payload = {"component": COMPONENT_NAME}
+    payload.update(event)
+    telemetry_log_event(payload)
 
 
 def send_alert(msg: str) -> None:
@@ -90,150 +83,169 @@ def run_step(step_name, command):
         send_alert(f"Pipeline step {step_name} exception: {e}")
         raise
 
-if __name__ == "__main__":
-    log_event({"event": "PIPELINE_START"})
+
+def main() -> int:
+    start_time = datetime.now(timezone.utc)
+    logger.info("Pipeline execution started")
+    exit_code = 0
+    summarize = True
+
+    screener_processed = "N/A"
+    screener_skipped = "N/A"
+    backtest_tested = "N/A"
+    total_trades = "N/A"
+    win_rate = "N/A"
+    net_pnl = "N/A"
+    exec_metrics = {
+        "orders_submitted": "N/A",
+        "orders_skipped": "N/A",
+        "api_failures": "N/A",
+    }
+
     try:
-        try:
-            run_step("Screener", [sys.executable, "scripts/screener.py"])
-        except Exception:
-            logger.error("Screener step failed")
-            sys.exit(1)
-
-        steps = [
-            (
-                "Backtest",
-                [sys.executable, "scripts/backtest.py"],
-            ),
-            (
-                "Metrics Calculation",
-                [sys.executable, "scripts/metrics.py"],
-            ),
-        ]
-
-        for name, cmd in steps:
+        with RunSentinel(component=COMPONENT_NAME) as rs:
+            log_event({"event": "PIPELINE_START"})
             try:
-                run_step(name, cmd)
-                if name == "Backtest":
-                    backtest_path = os.path.join(BASE_DIR, "data", "backtest_results.csv")
-                    if os.path.exists(backtest_path):
-                        logger.info("Backtest results written to %s", backtest_path)
-                    else:
-                        logger.error("Expected backtest results at %s not found", backtest_path)
-                if name == "Metrics Calculation":
-                    metrics_summary_file = os.path.join(BASE_DIR, "data", "metrics_summary.csv")
-                    if Path(metrics_summary_file).exists():
+                try:
+                    run_step("Screener", [sys.executable, "scripts/screener.py"])
+                except Exception:
+                    logger.error("Screener step failed")
+                    summarize = False
+                    exit_code = 1
+                    return exit_code
+
+                steps = [
+                    ("Backtest", [sys.executable, "scripts/backtest.py"]),
+                    ("Metrics Calculation", [sys.executable, "scripts/metrics.py"]),
+                ]
+
+                for name, cmd in steps:
+                    try:
+                        run_step(name, cmd)
+                        if name == "Backtest":
+                            backtest_path = os.path.join(BASE_DIR, "data", "backtest_results.csv")
+                            if os.path.exists(backtest_path):
+                                logger.info("Backtest results written to %s", backtest_path)
+                            else:
+                                logger.error("Expected backtest results at %s not found", backtest_path)
+                        if name == "Metrics Calculation":
+                            metrics_summary_file = os.path.join(BASE_DIR, "data", "metrics_summary.csv")
+                            if Path(metrics_summary_file).exists():
+                                logger.info(
+                                    "Metrics summary file exists and is confirmed updated at: %s",
+                                    metrics_summary_file,
+                                )
+                            else:
+                                logger.error(
+                                    "Metrics summary file missing after metrics calculation step: %s",
+                                    metrics_summary_file,
+                                )
+                    except Exception:
+                        logger.error("Step %s failed", name)
+                        send_alert(f"Pipeline halted at step {name}")
+                        exit_code = 1
+                        break
+
+                from scripts.execute_trades import main as exec_main
+
+                exec_result = exec_main()
+                if isinstance(exec_result, int) and exec_result != 0:
+                    exit_code = exec_result
+
+                source_path = os.path.join(BASE_DIR, 'data', 'top_candidates.csv')
+                target_path = os.path.join(BASE_DIR, 'data', 'latest_candidates.csv')
+                if os.path.exists(source_path):
+                    try:
+                        df = pd.read_csv(source_path)
+                        write_csv_atomic(target_path, df)
                         logger.info(
-                            "Metrics summary file exists and is confirmed updated at: %s",
-                            metrics_summary_file,
+                            "Updated latest_candidates.csv at %s",
+                            datetime.now(timezone.utc).isoformat(),
                         )
-                    else:
-                        logger.error(
-                            "Metrics summary file missing after metrics calculation step: %s",
-                            metrics_summary_file,
-                        )
-            except Exception:
-                logger.error("Step %s failed", name)
-                send_alert(f"Pipeline halted at step {name}")
-                break
+                    except Exception as exc:
+                        logger.error("Failed to update latest_candidates.csv: %s", exc)
+                        send_alert(f"Failed to update latest candidates: {exc}")
+                else:
+                    msg = "top_candidates.csv not found; latest_candidates.csv was not updated."
+                    logger.error(msg)
+                    send_alert(msg)
 
-        # Update latest_candidates.csv with the newest results
-        source_path = os.path.join(BASE_DIR, 'data', 'top_candidates.csv')
-        target_path = os.path.join(BASE_DIR, 'data', 'latest_candidates.csv')
-        if os.path.exists(source_path):
-            try:
-                df = pd.read_csv(source_path)
-                write_csv_atomic(target_path, df)
-                logger.info(
-                    "Updated latest_candidates.csv at %s",
-                    datetime.now(timezone.utc).isoformat(),
-                )
-            except Exception as exc:
-                logger.error("Failed to update latest_candidates.csv: %s", exc)
-                send_alert(f"Failed to update latest candidates: {exc}")
-        else:
-            msg = "top_candidates.csv not found; latest_candidates.csv was not updated."
-            logger.error(msg)
-            send_alert(msg)
+                scored_path = os.path.join(BASE_DIR, "data", "scored_candidates.csv")
+                if os.path.exists(scored_path):
+                    try:
+                        screener_processed = len(pd.read_csv(scored_path))
+                    except Exception:
+                        screener_processed = "error"
 
-        # Summaries from generated artifacts
-        screener_processed = "N/A"
-        screener_skipped = "N/A"
-        scored_path = os.path.join(BASE_DIR, "data", "scored_candidates.csv")
-        if os.path.exists(scored_path):
-            try:
-                screener_processed = len(pd.read_csv(scored_path))
-            except Exception:
-                screener_processed = "error"
+                backtest_path = os.path.join(BASE_DIR, "data", "backtest_results.csv")
+                if os.path.exists(backtest_path):
+                    try:
+                        backtest_tested = len(pd.read_csv(backtest_path))
+                    except Exception:
+                        backtest_tested = "error"
 
-        backtest_tested = "N/A"
-        backtest_path = os.path.join(BASE_DIR, "data", "backtest_results.csv")
-        if os.path.exists(backtest_path):
-            try:
-                backtest_tested = len(pd.read_csv(backtest_path))
-            except Exception:
-                backtest_tested = "error"
+                metrics_file = os.path.join(BASE_DIR, "data", "metrics_summary.csv")
+                if os.path.exists(metrics_file):
+                    try:
+                        mdf = pd.read_csv(metrics_file)
+                        if not mdf.empty:
+                            last = mdf.iloc[-1]
+                            total_trades = int(last.get("total_trades", 0))
+                            win_rate = round(last.get("win_rate", 0), 2)
+                            net_pnl = round(last.get("net_pnl", 0), 2)
+                    except Exception:
+                        pass
 
-        metrics_file = os.path.join(BASE_DIR, "data", "metrics_summary.csv")
-        total_trades = win_rate = net_pnl = "N/A"
-        if os.path.exists(metrics_file):
-            try:
-                mdf = pd.read_csv(metrics_file)
-                if not mdf.empty:
-                    last = mdf.iloc[-1]
-                    total_trades = int(last.get("total_trades", 0))
-                    win_rate = round(last.get("win_rate", 0), 2)
-                    net_pnl = round(last.get("net_pnl", 0), 2)
-            except Exception:
-                pass
+                exec_metrics_path = os.path.join(BASE_DIR, "data", "execute_metrics.json")
+                if os.path.exists(exec_metrics_path):
+                    try:
+                        with open(exec_metrics_path) as f:
+                            exec_metrics = json.load(f)
+                    except Exception:
+                        pass
+            except BaseException:
+                log_event({"event": "PIPELINE_ERROR", "traceback": traceback.format_exc()})
+                raise
+            finally:
+                end_time = datetime.now(timezone.utc)
+                total_duration = end_time - start_time
+                if summarize:
+                    logger.info("Pipeline Summary:")
+                    logger.info(
+                        "Screener: %s processed, %s skipped",
+                        screener_processed,
+                        screener_skipped,
+                    )
+                    logger.info(
+                        "Backtest: %s tested, %s skipped",
+                        backtest_tested,
+                        "N/A",
+                    )
+                    logger.info(
+                        "Metrics: %s trades, win rate %s%%, net PnL $%s",
+                        total_trades,
+                        win_rate,
+                        net_pnl,
+                    )
+                    logger.info(
+                        "Execution: %s orders submitted, %s skipped, %s API errors",
+                        exec_metrics.get("orders_submitted", "N/A"),
+                        exec_metrics.get("symbols_skipped", "N/A"),
+                        exec_metrics.get("api_failures", "N/A"),
+                    )
+                    logger.info("Total Pipeline Duration: %s", total_duration)
+                    logger.info("Pipeline execution complete.")
+                log_event({"event": "PIPELINE_END"})
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+        return int(code)
+    except Exception:
+        if exit_code == 0:
+            exit_code = 1
+        return exit_code
 
-        exec_metrics = {
-            "orders_submitted": "N/A",
-            "orders_skipped": "N/A",
-            "api_failures": "N/A",
-        }
-        exec_metrics_path = os.path.join(BASE_DIR, "data", "execute_metrics.json")
-        if os.path.exists(exec_metrics_path):
-            try:
-                with open(exec_metrics_path) as f:
-                    exec_metrics = json.load(f)
-            except Exception:
-                pass
+    return exit_code
 
-        end_time = datetime.now(timezone.utc)
-        total_duration = end_time - start_time
 
-        logger.info("Pipeline Summary:")
-        logger.info(
-            "Screener: %s processed, %s skipped",
-            screener_processed,
-            screener_skipped,
-        )
-        logger.info(
-            "Backtest: %s tested, %s skipped",
-            backtest_tested,
-            "N/A",
-        )
-        logger.info(
-            "Metrics: %s trades, win rate %s%%, net PnL $%s",
-            total_trades,
-            win_rate,
-            net_pnl,
-        )
-        logger.info(
-            "Execution: %s orders submitted, %s skipped, %s API errors",
-            exec_metrics.get("orders_submitted", "N/A"),
-            exec_metrics.get("symbols_skipped", "N/A"),
-            exec_metrics.get("api_failures", "N/A"),
-        )
-        logger.info("Total Pipeline Duration: %s", total_duration)
-        logger.info("Pipeline execution complete.")
-    except BaseException:
-        log_event(
-            {
-                "event": "PIPELINE_ERROR",
-                "traceback": traceback.format_exc(),
-            }
-        )
-        raise
-    finally:
-        log_event({"event": "PIPELINE_END"})
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,70 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import utils.telemetry as telemetry
+
+
+@pytest.fixture(autouse=True)
+def _ensure_alpaca_env(monkeypatch):
+    monkeypatch.setenv("APCA_API_KEY_ID", "test_key")
+    monkeypatch.setenv("APCA_API_SECRET_KEY", "test_secret")
+    monkeypatch.setenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+
+
+def _read_events(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text("utf-8").splitlines()]
+
+
+def test_run_sentinel_writes_start_end(tmp_path, monkeypatch):
+    events_path = tmp_path / "events.jsonl"
+    monkeypatch.setattr(telemetry, "events_path", lambda: events_path)
+    monkeypatch.setattr(telemetry, "get_version", lambda: "test-version")
+
+    with telemetry.RunSentinel(component="unit-test", force=True, extra={"env": "paper"}) as rs:
+        rs.guard(status="OPEN", source="manual")
+
+    events = _read_events(events_path)
+    assert [event["event"] for event in events] == [
+        "RUN_START",
+        "MARKET_GUARD_STATUS",
+        "RUN_END",
+    ]
+
+    run_start, guard, run_end = events
+    assert run_start["component"] == "unit-test"
+    assert run_start["force"] is True
+    assert run_start["env"] == "paper"
+
+    assert guard["status"] == "OPEN"
+    assert guard["component"] == "unit-test"
+    assert guard["source"] == "manual"
+    assert guard["version"] == "test-version"
+
+    assert run_end["component"] == "unit-test"
+    assert run_end["status"] == "ok"
+    assert run_end["error"] is None
+
+
+def test_import_sentinel(tmp_path, monkeypatch):
+    events_path = tmp_path / "events.jsonl"
+    monkeypatch.setattr(telemetry, "events_path", lambda: events_path)
+    monkeypatch.setattr(telemetry, "get_version", lambda: "test-version")
+    monkeypatch.setenv("JBRAVO_IMPORT_SENTINEL", "1")
+
+    module = importlib.import_module("scripts.execute_trades")
+    importlib.reload(module)
+
+    events = _read_events(events_path)
+    assert any(event["event"] == "IMPORT_SENTINEL" for event in events)
+
+    monkeypatch.delenv("JBRAVO_IMPORT_SENTINEL", raising=False)

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -1,0 +1,87 @@
+import os
+import json
+import sys
+import subprocess
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def utcnow():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def repo_root() -> Path:
+    """Resolve the repository root regardless of the current working directory."""
+
+    here = Path(__file__).resolve()
+    return here.parents[1]
+
+
+def events_path() -> Path:
+    path = repo_root() / "data" / "execute_events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_version() -> str:
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True
+        ).strip()
+        return sha
+    except Exception:
+        return os.environ.get("JBRAVO_VERSION", "unknown")
+
+
+def log_event(ev: dict):
+    ev.setdefault("ts", utcnow())
+    ev.setdefault("component", "unknown")
+    path = events_path()
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(ev) + "\n")
+    if os.environ.get("JBRAVO_DEBUG_EVENT_PATH") == "1":
+        print(f"[telemetry] wrote event to: {path}", file=sys.stderr)
+
+
+class RunSentinel:
+    """Context manager that guarantees RUN_START/RUN_END emission."""
+
+    def __init__(self, component: str, force: bool = False, extra: dict | None = None):
+        self.component = component
+        self.force = force
+        self.extra = extra or {}
+        self.version = get_version()
+
+    def __enter__(self):
+        payload = {
+            "event": "RUN_START",
+            "component": self.component,
+            "version": self.version,
+            "force": self.force,
+            **self.extra,
+        }
+        log_event(payload)
+        return self
+
+    def guard(self, status: str, **kvs):
+        log_event(
+            {
+                "event": "MARKET_GUARD_STATUS",
+                "component": self.component,
+                "status": status,
+                "version": self.version,
+                **kvs,
+            }
+        )
+
+    def __exit__(self, exc_type, exc, tb):
+        log_event(
+            {
+                "event": "RUN_END",
+                "component": self.component,
+                "version": self.version,
+                "status": "error" if exc else "ok",
+                "error": None if not exc else str(exc),
+            }
+        )
+        return False


### PR DESCRIPTION
## Summary
- add a shared telemetry helper that anchors event paths at the repo root and provides the RunSentinel context manager
- integrate RunSentinel, guard emission, and repo-root chdir into `scripts/execute_trades.py`, including the import sentinel hook
- wrap the pipeline entrypoint with RunSentinel, invoke the executor directly, and refresh the related tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3fe2daed883319028fe092d1057ac