### PR TITLE
Screener hot-fix: tolerate Alpaca enum drift (assets + exchange), always write outputs, atomic file writes

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,12 @@
 from .csv_utils import write_csv_atomic
 from .bar_cache import cache_bars, fetch_bars_with_cutoff
+from .io_utils import atomic_write_bytes
 from .logger_utils import get_logger
+
+__all__ = [
+    "write_csv_atomic",
+    "cache_bars",
+    "fetch_bars_with_cutoff",
+    "atomic_write_bytes",
+    "get_logger",
+]

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -1,0 +1,43 @@
+"""I/O helpers for atomic file writes used across the project."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Union
+
+PathLike = Union[str, os.PathLike[str]]
+
+
+def atomic_write_bytes(path: PathLike, data: bytes) -> None:
+    """Atomically write ``data`` to ``path``.
+
+    The data is first written to a temporary file in the target directory and
+    then moved into place via :func:`os.replace` to guarantee that readers never
+    observe a partially written file.
+    """
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    # ``NamedTemporaryFile`` on Windows does not allow reopening the file while
+    # it is still open, so we create the file manually using ``mkstemp``.
+    fd, tmp_path = tempfile.mkstemp(dir=str(target.parent), prefix=target.name + ".tmp.")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, target)
+    finally:
+        # ``os.replace`` removes the temp file on success; if an exception is
+        # raised before that point we remove the temporary file to avoid
+        # littering the filesystem.
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+__all__ = ["atomic_write_bytes"]


### PR DESCRIPTION
## Summary
- add a resilient Alpaca asset fetch helper with HTTP and cache fallbacks to survive enum drift
- reuse a shared atomic_write_bytes helper for screener CSV/JSON outputs and expose it via utils

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e532feae788331a610604c026beda6