### PR TITLE
Fix Screener imports & Alpaca enum drift; module-mode pipeline; always write screener artifacts

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -19,27 +19,35 @@ def emit(evt, **kvs):
     subprocess.run(cmd, check=False)
 
 
-def main():
+def _run_step(name: str, module: str, success_event: str, error_event: str, cwd: Path) -> bool:
+    print(f"Starting {name} step...")
+    result = subprocess.run([sys.executable, "-m", module], cwd=cwd)
+    if result.returncode != 0:
+        emit(error_event, component="pipeline", returncode=str(result.returncode))
+        print(f"{name} step failed with exit code {result.returncode}.")
+        return False
+
+    emit(success_event, component="pipeline")
+    print(f"{name} step completed.")
+    return True
+
+
+def main() -> int:
     root = repo_root()
     os.chdir(root)
     emit("PIPELINE_START", component="pipeline")
 
+    exit_code = 0
     try:
-        # ---- screener step ----
-        result = subprocess.run(
-            [sys.executable, "scripts/screener.py"],
-            cwd=root,
+        screener_ok = _run_step(
+            "Screener",
+            "scripts.screener",
+            "SCREENER_SUCCESS",
+            "SCREENER_ERROR",
+            root,
         )
 
-        if result.returncode != 0:
-            emit(
-                "SCREENER_ERROR",
-                component="pipeline",
-                returncode=str(result.returncode),
-            )
-            print("Screener step failed (non-zero exit); dashboard will show stale.")
-        else:
-            emit("SCREENER_SUCCESS", component="pipeline")
+        if screener_ok:
             top_path = root / "data" / "top_candidates.csv"
             latest_path = root / "data" / "latest_candidates.csv"
             if top_path.exists():
@@ -65,17 +73,39 @@ def main():
                 print(
                     "top_candidates.csv not found after screener run; latest_candidates.csv left untouched."
                 )
+        else:
+            exit_code = 1
 
-        # ---- executor import ----
-        try:
-            from scripts.execute_trades import main as exec_main
-            emit("IMPORT_SUCCESS", component="execute_trades")
-        except Exception as e:
-            emit("IMPORT_FAILURE", component="execute_trades", error=str(e).replace(" ", "_"))
-            raise
+        backtest_ok = False
+        if screener_ok:
+            backtest_ok = _run_step(
+                "Backtest",
+                "scripts.backtest",
+                "BACKTEST_SUCCESS",
+                "BACKTEST_ERROR",
+                root,
+            )
+            if not backtest_ok:
+                exit_code = 1
+        else:
+            print("Skipping Backtest step because Screener failed.")
 
-        # ---- run executor (will log its own events once imports work) ----
-        exec_main()
+        metrics_ok = False
+        if backtest_ok:
+            metrics_ok = _run_step(
+                "Metrics",
+                "scripts.metrics",
+                "METRICS_SUCCESS",
+                "METRICS_ERROR",
+                root,
+            )
+            if not metrics_ok:
+                exit_code = 1
+        else:
+            if screener_ok:
+                print("Skipping Metrics step because Backtest failed.")
+            else:
+                print("Skipping Metrics step because Screener failed.")
 
     except Exception as e:
         emit("PIPELINE_ERROR", component="pipeline", error=str(e).replace(" ", "_"))
@@ -83,6 +113,8 @@ def main():
     finally:
         emit("PIPELINE_END", component="pipeline")
 
+    return exit_code
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/utils/models.py
+++ b/scripts/utils/models.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover - fallback for Pydantic v1
     _PYDANTIC_V2 = False
 
 
-known_equity_exchanges = {
+KNOWN_EQUITY = {
     "NASDAQ",
     "NYSE",
     "ARCA",
@@ -33,7 +33,7 @@ def classify_exchange(raw: Any) -> str:
     code = str(raw).strip().upper()
     if not code:
         return "OTHER"
-    if code in known_equity_exchanges:
+    if code in KNOWN_EQUITY:
         return "EQUITY"
     return "CRYPTO" if "CRYPTO" in code else "OTHER"
 
@@ -138,4 +138,4 @@ else:
             return self.dict()
 
 
-__all__ = ["BarData", "classify_exchange", "known_equity_exchanges"]
+__all__ = ["BarData", "classify_exchange", "KNOWN_EQUITY"]


### PR DESCRIPTION
## Summary
- harden screener imports so both module and script execution paths can locate indicators/models and gracefully fall back to cached Alpaca assets when enum validation fails
- ensure screener data preparation drops bad bars, adds indicators idempotently, and always writes top/scored CSVs plus metrics JSON for the dashboard
- update the nightly pipeline to run screener/backtest/metrics via `python -m` and refresh `latest_candidates.csv` after the screener step

## Testing
- pytest tests/test_screener_unknown_exchange.py tests/test_run_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e5399b73f883318ecf0a1b069f0ef1