### PR TITLE
Centralize Alpaca environment handling and harden pipeline copy

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -48,13 +48,13 @@ from alpaca.data.requests import StockBarsRequest, StockLatestTradeRequest
 from alpaca.common.exceptions import APIError
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.timeframe import TimeFrame
-from dotenv import load_dotenv
 # Alerting
 import requests
 from .utils import cache_bars
 
 from .exit_signals import should_exit_early
 from .monitor_positions import log_trade_exit
+from utils.env import load_env, get_alpaca_creds
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LOG_DIR = os.path.join(BASE_DIR, "logs")
@@ -69,8 +69,7 @@ logger = logging.getLogger(__name__)
 
 os.makedirs(os.path.join(BASE_DIR, 'data'), exist_ok=True)
 
-dotenv_path = os.path.join(BASE_DIR, '.env')
-load_dotenv(dotenv_path)
+load_env()
 start_time = datetime.utcnow()
 logger.info("Trade execution script started.")
 
@@ -85,9 +84,7 @@ def send_alert(message: str) -> None:
     except Exception as exc:
         logger.error("Failed to send alert: %s", exc)
 
-API_KEY = os.getenv("APCA_API_KEY_ID")
-API_SECRET = os.getenv("APCA_API_SECRET_KEY")
-BASE_URL = os.getenv("APCA_API_BASE_URL") or os.getenv("ALPACA_BASE_URL")
+API_KEY, API_SECRET, BASE_URL, _ = get_alpaca_creds()
 
 
 def detect_trading_env() -> str:

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -13,6 +13,9 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 from utils import write_csv_atomic
+from utils.env import load_env
+
+load_env()
 
 logfile = os.path.join(BASE_DIR, "logs", "metrics.log")
 logging.basicConfig(

--- a/utils/env.py
+++ b/utils/env.py
@@ -1,0 +1,25 @@
+"""Environment loading helpers for CLI and service entry points."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+from dotenv import load_dotenv, find_dotenv
+
+
+def load_env() -> None:
+    """Load project and user-level environment variables if available."""
+    load_dotenv(find_dotenv(usecwd=True))
+    alt = os.path.expanduser("~/.config/jbravo/.env")
+    if os.path.exists(alt):
+        load_dotenv(alt, override=False)
+
+
+def get_alpaca_creds() -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """Return Alpaca credentials from the environment with sensible fallbacks."""
+    key = os.getenv("APCA_API_KEY_ID") or os.getenv("ALPACA_API_KEY_ID")
+    secret = os.getenv("APCA_API_SECRET_KEY") or os.getenv("ALPACA_API_SECRET_KEY")
+    base = os.getenv("APCA_API_BASE_URL") or os.getenv("ALPACA_API_BASE_URL")
+    feed = os.getenv("ALPACA_DATA_FEED", "iex")
+    return key, secret, base, feed


### PR DESCRIPTION
## Summary
- add a reusable utils.env helper to load .env files and expose Alpaca credential lookups with legacy fallbacks
- ensure screener, backtest, metrics, pipeline, and trade execution entrypoints load environment data and share the same credential retrieval
- make the screener exit non-zero when credentials are missing and guard the pipeline from copying empty top_candidates outputs

## Testing
- python -m scripts.screener --universe csv --source-csv data/screener_source.csv
- python -m scripts.run_pipeline


------
https://chatgpt.com/codex/tasks/task_e_68e54c35c61c8331a71bb932c359f373