### PR TITLE
Join screener bars with asset metadata

### DIFF
--- a/tests/test_screener_api_mode.py
+++ b/tests/test_screener_api_mode.py
@@ -54,7 +54,14 @@ def test_screener_api_mode_creates_outputs(tmp_path, monkeypatch):
     monkeypatch.setattr(
         screener,
         "fetch_active_equity_symbols",
-        lambda *args, **kwargs: ["GOOD", "UNKNOWN1", "CRYPTO1"],
+        lambda *args, **kwargs: (
+            ["GOOD", "UNKNOWN1", "CRYPTO1"],
+            {
+                "GOOD": {"exchange": "NASDAQ", "asset_class": "US_EQUITY", "tradable": True},
+                "UNKNOWN1": {"exchange": "PINK", "asset_class": "OTC", "tradable": True},
+                "CRYPTO1": {"exchange": "CRYPTO", "asset_class": "CRYPTO", "tradable": True},
+            },
+        ),
     )
     monkeypatch.setattr(
         screener,

--- a/tests/test_screener_unknown_exchange.py
+++ b/tests/test_screener_unknown_exchange.py
@@ -1,22 +1,73 @@
 import json
 from datetime import datetime, timezone
 
+import json
+
+import numpy as np
 import pandas as pd
 
 from scripts import screener
 
 
 def _sample_universe() -> pd.DataFrame:
-    rows = [
-        {"symbol": "EQ1", "exchange": "NASDAQ", "timestamp": "2024-01-01", "open": 10, "high": 11, "low": 9.5, "close": 10.5, "volume": 1_000},
-        {"symbol": "EQ1", "exchange": "NASDAQ", "timestamp": "2024-01-02", "open": 10.5, "high": 11.2, "low": 10.1, "close": 11.0, "volume": 1_200},
-        {"symbol": "EQ1", "exchange": "NASDAQ", "timestamp": "2024-01-03", "open": 11.0, "high": 11.5, "low": 10.8, "close": 11.4, "volume": 1_300},
-        {"symbol": "CR1", "exchange": "CRYPTO", "timestamp": "2024-01-01", "open": 5, "high": 5.6, "low": 4.8, "close": 5.2, "volume": 500},
-        {"symbol": "CR1", "exchange": "CRYPTO", "timestamp": "2024-01-02", "open": 5.1, "high": 5.5, "low": 5.0, "close": 5.3, "volume": 450},
-        {"symbol": "UNK1", "exchange": "XFTXU", "timestamp": "2024-01-01", "open": 7, "high": 7.5, "low": 6.8, "close": 7.1, "volume": 600},
-        {"symbol": "BLANK", "exchange": "", "timestamp": "2024-01-01", "open": 3, "high": 3.3, "low": 2.9, "close": 3.1, "volume": 300},
-    ]
-    return pd.DataFrame(rows)
+    dates = pd.date_range("2024-01-01", periods=200, tz="UTC", freq="B")
+    trend = np.linspace(50, 130, len(dates))
+    trend[-2] = trend[-3] - 15
+    trend[-1] = trend[-3] + 10
+    eq_frame = pd.DataFrame(
+        {
+            "symbol": "EQ1",
+            "exchange": "NASDAQ",
+            "timestamp": dates,
+            "open": trend - 0.5,
+            "high": trend + 1.0,
+            "low": trend - 1.0,
+            "close": trend,
+            "volume": np.full(len(dates), 1_000_000, dtype=float),
+        }
+    )
+
+    crypto_dates = pd.date_range("2024-01-01", periods=3, tz="UTC", freq="B")
+    crypto_frame = pd.DataFrame(
+        {
+            "symbol": "CR1",
+            "exchange": "CRYPTO",
+            "timestamp": crypto_dates,
+            "open": [5.0, 5.1, 5.2],
+            "high": [5.6, 5.5, 5.4],
+            "low": [4.8, 4.9, 5.0],
+            "close": [5.2, 5.3, 5.1],
+            "volume": [500, 450, 425],
+        }
+    )
+
+    unknown_frame = pd.DataFrame(
+        {
+            "symbol": "UNK1",
+            "exchange": "XFTXU",
+            "timestamp": crypto_dates,
+            "open": [7.0, 7.1, 7.2],
+            "high": [7.5, 7.6, 7.7],
+            "low": [6.8, 6.9, 7.0],
+            "close": [7.1, 7.0, 6.9],
+            "volume": [600, 580, 560],
+        }
+    )
+
+    blank_frame = pd.DataFrame(
+        {
+            "symbol": "BLANK",
+            "exchange": "",
+            "timestamp": [pd.Timestamp("2024-01-01", tz="UTC")],
+            "open": [3.0],
+            "high": [3.3],
+            "low": [2.9],
+            "close": [3.1],
+            "volume": [300],
+        }
+    )
+
+    return pd.concat([eq_frame, crypto_frame, unknown_frame, blank_frame], ignore_index=True)
 
 
 def test_screener_skips_unknown_exchanges(tmp_path):


### PR DESCRIPTION
## Summary
- add Alpaca asset metadata filtering helpers and join exchange data when loading the universe
- promote blank exchanges based on asset_class, silence groupby.apply warnings, and pass metadata through the screener
- update API and exchange tests to exercise the new metadata flow

## Testing
- pytest tests/test_screener_api_mode.py tests/test_screener_unknown_exchange.py

------
https://chatgpt.com/codex/tasks/task_e_68e55f4acb408331af009af1c623fef8