### PR TITLE
Normalize Alpaca bars DataFrame and harden metadata merge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ dependencies = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+markers = [
+    "alpaca_optional: tests that can run without Alpaca credentials",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@ def _tf_eq(self, other):
 TimeFrame.__eq__ = _tf_eq
 
 @pytest.fixture(autouse=True)
-def check_alpaca_env():
+def check_alpaca_env(request):
+    if request.node.get_closest_marker("alpaca_optional"):
+        return
     api_key = os.getenv("APCA_API_KEY_ID")
     secret = os.getenv("APCA_API_SECRET_KEY")
     if not api_key or not secret:

--- a/tests/test_bars_normalize.py
+++ b/tests/test_bars_normalize.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+import pytest
+
+from scripts.screener import normalize_bars_to_df
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_normalize_handles_multiindex_and_http():
+    idx = pd.MultiIndex.from_tuples(
+        [("AAPL", "2024-10-01"), ("MSFT", "2024-10-01")],
+        names=["symbol", "timestamp"],
+    )
+    df = pd.DataFrame(
+        {
+            "open": [1, 2],
+            "high": [1, 2],
+            "low": [1, 2],
+            "close": [1, 2],
+            "volume": [10, 20],
+        },
+        index=idx,
+    )
+
+    class Obj:
+        pass
+
+    obj = Obj()
+    obj.df = df
+
+    out = normalize_bars_to_df(obj)
+    assert list(sorted(out.columns)) == sorted(
+        ["symbol", "timestamp", "open", "high", "low", "close", "volume"]
+    )
+    assert out["symbol"].tolist() == ["AAPL", "MSFT"]
+
+    raw = [
+        {"S": "AAPL", "t": "2024-10-01T00:00:00Z", "o": 1, "h": 1, "l": 1, "c": 1, "v": 10}
+    ]
+    out2 = normalize_bars_to_df(raw)
+    assert list(out2.columns) == [
+        "symbol",
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    assert out2.loc[0, "symbol"] == "AAPL"


### PR DESCRIPTION
## Summary
- add a reusable normalize_bars_to_df helper so Alpaca SDK and HTTP bar payloads share the same schema
- constrain Alpaca universe fetches to the requested limit, merge asset metadata onto bars, and promote blank exchanges to equity defaults
- allow credential-agnostic tests and cover the new normalizer with pytest

## Testing
- pytest tests/test_bars_normalize.py

------
https://chatgpt.com/codex/tasks/task_e_68e570f1e81883319a478c6f7c70b462