### PR TITLE
Enhance screener fetch pipeline and add tests

### DIFF
--- a/scripts/utils/dataframe_utils.py
+++ b/scripts/utils/dataframe_utils.py
@@ -1,10 +1,15 @@
 """DataFrame helpers for screener normalization."""
 from __future__ import annotations
 
+from __future__ import annotations
+
+import logging
 from typing import Iterable
 
 import pandas as pd
 
+
+LOGGER = logging.getLogger(__name__)
 
 BARS_COLUMNS = ["symbol", "timestamp", "open", "high", "low", "close", "volume"]
 
@@ -58,6 +63,12 @@ def to_bars_df(bars) -> pd.DataFrame:
         for column in BARS_COLUMNS:
             if column not in result.columns:
                 result[column] = pd.NA
+        if "symbol" not in result.columns:
+            LOGGER.warning(
+                "Unable to locate symbol column when normalizing bars; type=%s columns=%s",
+                type(bars),
+                list(result.columns),
+            )
         result["symbol"] = result["symbol"].astype(str).str.upper()
         return result[BARS_COLUMNS].copy()
 
@@ -105,6 +116,12 @@ def to_bars_df(bars) -> pd.DataFrame:
     for column in BARS_COLUMNS:
         if column not in frame.columns:
             frame[column] = pd.NA
+    if "symbol" not in frame.columns:
+        LOGGER.warning(
+            "HTTP bars payload missing symbol column after normalization; type=%s columns=%s",
+            type(bars),
+            list(frame.columns),
+        )
     frame["symbol"] = frame["symbol"].astype(str).str.upper()
     return frame[BARS_COLUMNS].copy()
 

--- a/tests/test_screener_helpers.py
+++ b/tests/test_screener_helpers.py
@@ -1,0 +1,135 @@
+import types
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from scripts import screener
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_merge_meta():
+    bars = pd.DataFrame(
+        {
+            "symbol": ["AAPL", "MSFT"],
+            "timestamp": pd.to_datetime([
+                "2024-01-02T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+            ], utc=True),
+            "open": [100.0, 200.0],
+            "high": [105.0, 205.0],
+            "low": [99.0, 198.0],
+            "close": [104.0, 203.0],
+            "volume": [1_000_000, 2_000_000],
+        }
+    )
+    meta = {
+        "AAPL": {"exchange": "NASDAQ", "asset_class": "US_EQUITY"},
+        "MSFT": {"exchange": "NYSE", "asset_class": "US_EQUITY"},
+    }
+
+    merged = screener.merge_asset_metadata(bars, meta)
+
+    assert set(merged["exchange"]) == {"NASDAQ", "NYSE"}
+    assert set(merged["kind"]) == {"EQUITY"}
+    assert merged["tradable"].all()
+
+
+def test_paginate(monkeypatch):
+    original_request = screener.StockBarsRequest
+    original_timeframe = screener.TimeFrame
+
+    class DummyRequest:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(screener, "StockBarsRequest", DummyRequest)
+    monkeypatch.setattr(screener, "TimeFrame", types.SimpleNamespace(Day="day"))
+    monkeypatch.setattr(screener, "to_bars_df", lambda response: response.df.copy())
+    monkeypatch.setattr(screener, "_normalize_bars_frame", lambda df: df)
+
+    class FakeResponse:
+        def __init__(self, rows, next_token=None):
+            frame = pd.DataFrame(rows)
+            frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True)
+            self.df = frame
+            self.data = {str(sym): [] for sym in frame["symbol"].unique()}
+            self.next_page_token = next_token
+
+    class FakeClient:
+        def __init__(self, responses):
+            self.responses = list(responses)
+            self.calls = []
+
+        def get_stock_bars(self, request):
+            self.calls.append(request.kwargs)
+            if not self.responses:
+                raise AssertionError("No more responses queued")
+            return self.responses.pop(0)
+
+    page_one = [
+        {
+            "symbol": "AAPL",
+            "timestamp": "2024-01-08T00:00:00Z",
+            "open": 101,
+            "high": 103,
+            "low": 99,
+            "close": 102,
+            "volume": 1_000,
+        },
+        {
+            "symbol": "AAPL",
+            "timestamp": "2024-01-09T00:00:00Z",
+            "open": 102,
+            "high": 104,
+            "low": 100,
+            "close": 103,
+            "volume": 1_100,
+        },
+    ]
+    page_two = [
+        {
+            "symbol": "MSFT",
+            "timestamp": "2024-01-08T00:00:00Z",
+            "open": 201,
+            "high": 204,
+            "low": 199,
+            "close": 203,
+            "volume": 2_000,
+        },
+        {
+            "symbol": "MSFT",
+            "timestamp": "2024-01-09T00:00:00Z",
+            "open": 203,
+            "high": 205,
+            "low": 200,
+            "close": 204,
+            "volume": 2_100,
+        },
+    ]
+
+    client = FakeClient([FakeResponse(page_one, next_token="page-2"), FakeResponse(page_two)])
+
+    request_kwargs = {
+        "symbol_or_symbols": ["AAPL", "MSFT"],
+        "timeframe": "day",
+        "start": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "end": datetime(2024, 1, 11, tzinfo=timezone.utc),
+        "feed": "iex",
+        "adjustment": "raw",
+    }
+
+    batch_frames, page_count, paged, columns_desc, success = screener._collect_batch_pages(
+        client, request_kwargs
+    )
+
+    monkeypatch.setattr(screener, "StockBarsRequest", original_request)
+    monkeypatch.setattr(screener, "TimeFrame", original_timeframe)
+
+    assert success is True
+    assert page_count == 2
+    assert paged is True
+    assert "symbol" in columns_desc
+    total_rows = sum(frame.shape[0] for frame in batch_frames)
+    assert total_rows == 4

--- a/tests/test_screener_unknown_exchange.py
+++ b/tests/test_screener_unknown_exchange.py
@@ -1,8 +1,6 @@
 import json
 from datetime import datetime, timezone
 
-import json
-
 import numpy as np
 import pandas as pd
 
@@ -74,7 +72,14 @@ def test_screener_skips_unknown_exchanges(tmp_path):
     df = _sample_universe()
     now = datetime(2024, 1, 10, 14, tzinfo=timezone.utc)
 
-    top_df, scored_df, stats, skips, reject_samples = screener.run_screener(
+    (
+        top_df,
+        scored_df,
+        stats,
+        skips,
+        reject_samples,
+        gate_counters,
+    ) = screener.run_screener(
         df,
         top_n=5,
         min_history=2,
@@ -88,7 +93,16 @@ def test_screener_skips_unknown_exchanges(tmp_path):
     assert "EQ1" in scored_df["symbol"].tolist()
 
     metrics_path = screener.write_outputs(
-        tmp_path, top_df, scored_df, stats, skips, reject_samples, now=now
+        tmp_path,
+        top_df,
+        scored_df,
+        stats,
+        skips,
+        reject_samples,
+        now=now,
+        gate_counters=gate_counters,
+        fetch_metrics={},
+        asset_metrics={},
     )
 
     top_path = tmp_path / "data" / "top_candidates.csv"


### PR DESCRIPTION
## Summary
- add CLI flags for fetch tuning, OTC filtering, and worker limits
- refactor Alpaca asset and bars fetching to support pagination, batch fallback, and richer metrics
- expand screener instrumentation, metadata merging, and output reporting
- add targeted unit tests for normalization, metadata merge, and paginated fetching helpers

## Testing
- `pytest tests/test_to_bars_df.py tests/test_screener_helpers.py tests/test_screener_unknown_exchange.py`


------
https://chatgpt.com/codex/tasks/task_e_68e57c3a9a3c8331a3387c5fe0ba92b7