### PR TITLE
Screener: guarantee symbol column in all bar shapes; add diagnostics; harden single-symbol fallback

### DIFF
--- a/scripts/utils/dataframe_utils.py
+++ b/scripts/utils/dataframe_utils.py
@@ -1,8 +1,6 @@
 """DataFrame helpers for screener normalization."""
 from __future__ import annotations
 
-from __future__ import annotations
-
 import logging
 from typing import Iterable
 
@@ -20,67 +18,109 @@ def _empty_bars_df() -> pd.DataFrame:
     return pd.DataFrame(columns=BARS_COLUMNS)
 
 
-def to_bars_df(bars) -> pd.DataFrame:
-    """Normalize Alpaca bars/HTTP bars to a flat DataFrame.
+def to_bars_df(bars_obj, symbol_hint: str | None = None) -> pd.DataFrame:
+    """Normalize Alpaca/HTTP bar payloads to a canonical DataFrame.
 
-    The resulting DataFrame always contains the columns:
-    ``symbol, timestamp, open, high, low, close, volume``.
-    The helper understands the following shapes:
-
-    A) ``alpaca-py`` ``BarsSet`` with ``.df`` (MultiIndex ``[symbol, timestamp]``)
-    B) ``alpaca-py`` ``BarsSet`` with ``.data`` (``dict[str, list[Bar]]``)
-    C) HTTP ``list[dict]`` with keys ``'S','t','o','h','l','c','v'``
-    D) HTTP ``dict`` containing ``'bars': [...]``
-
-    Empty inputs result in an empty DataFrame with the expected schema.
+    The resulting DataFrame always contains the columns ``symbol, timestamp, open,
+    high, low, close, volume``. Unknown or empty inputs yield an empty DataFrame
+    with the expected schema.
     """
 
-    # Case A: BarsSet.df (MultiIndex or regular index)
-    if hasattr(bars, "df"):
-        df = getattr(bars, "df")
+    required = BARS_COLUMNS
+
+    def _index_names(index: pd.MultiIndex) -> list[str]:
+        raw_names = list(index.names or [])
+        names: list[str] = []
+        for idx, name in enumerate(raw_names):
+            if name:
+                names.append(str(name))
+                continue
+            if idx == 0:
+                names.append("symbol")
+            elif idx == 1:
+                names.append("timestamp")
+            else:
+                names.append(f"level_{idx}")
+        return names
+
+    def _standardize(df: pd.DataFrame) -> pd.DataFrame:
+        rename = {
+            "S": "symbol",
+            "Symbol": "symbol",
+            "symbol": "symbol",
+            "t": "timestamp",
+            "time": "timestamp",
+            "Time": "timestamp",
+            "Timestamp": "timestamp",
+            "T": "timestamp",
+            "o": "open",
+            "O": "open",
+            "open": "open",
+            "Open": "open",
+            "h": "high",
+            "H": "high",
+            "high": "high",
+            "High": "high",
+            "l": "low",
+            "L": "low",
+            "low": "low",
+            "Low": "low",
+            "c": "close",
+            "C": "close",
+            "close": "close",
+            "Close": "close",
+            "v": "volume",
+            "V": "volume",
+            "volume": "volume",
+            "Volume": "volume",
+        }
+        df = df.rename(columns=rename)
+        for column in required:
+            if column not in df.columns:
+                df[column] = pd.NA
+        if symbol_hint and df.empty:
+            df["symbol"] = symbol_hint.upper()
+        if "symbol" in df.columns:
+            df["symbol"] = df["symbol"].astype(str).str.strip().str.upper()
+        return df[required]
+
+    if isinstance(bars_obj, pd.DataFrame):
+        frame = bars_obj.copy()
+        if isinstance(frame.index, pd.MultiIndex):
+            names = _index_names(frame.index)
+            frame.index.set_names(names, inplace=True)
+            frame = frame.reset_index()
+        elif frame.index.name in {"symbol", "timestamp"}:
+            frame = frame.reset_index()
+        if "symbol" not in frame.columns and symbol_hint:
+            frame["symbol"] = symbol_hint.upper()
+        return _standardize(frame)
+
+    if hasattr(bars_obj, "df"):
+        df = getattr(bars_obj, "df")
         if df is None or getattr(df, "empty", False):
             return _empty_bars_df()
-        data = df
-        if isinstance(data.index, pd.MultiIndex):
-            data = data.reset_index()  # symbol, timestamp become columns
-        rename = {
-            "time": "timestamp",
-            "t": "timestamp",
-            "o": "open",
-            "h": "high",
-            "l": "low",
-            "c": "close",
-            "v": "volume",
-            "S": "symbol",
-        }
-        data = data.rename(columns=rename)
-        # If 'symbol' still missing but there is a single-symbol frame, add it
-        if "symbol" not in data.columns and hasattr(bars, "data") and isinstance(bars.data, dict):
-            symbols = [str(sym).upper() for sym in bars.data.keys() if sym]
-            if len(symbols) == 1:
-                data["symbol"] = symbols[0]
-        result = data.copy()
-        for column in BARS_COLUMNS:
-            if column not in result.columns:
-                result[column] = pd.NA
-        if "symbol" not in result.columns:
-            LOGGER.warning(
-                "Unable to locate symbol column when normalizing bars; type=%s columns=%s",
-                type(bars),
-                list(result.columns),
-            )
-        result["symbol"] = result["symbol"].astype(str).str.upper()
-        return result[BARS_COLUMNS].copy()
+        frame = df.copy()
+        if isinstance(frame.index, pd.MultiIndex):
+            names = _index_names(frame.index)
+            frame.index.set_names(names, inplace=True)
+            frame = frame.reset_index()
+        if "symbol" not in frame.columns:
+            if symbol_hint:
+                frame["symbol"] = symbol_hint.upper()
+            elif hasattr(bars_obj, "data") and isinstance(bars_obj.data, dict) and bars_obj.data:
+                if len(bars_obj.data) == 1:
+                    frame["symbol"] = str(next(iter(bars_obj.data.keys()))).upper()
+        return _standardize(frame)
 
-    # Case B: BarsSet.data (dict[str, list[Bar]])
-    if hasattr(bars, "data") and isinstance(bars.data, dict):
+    if hasattr(bars_obj, "data") and isinstance(bars_obj.data, dict):
         rows: list[dict[str, object]] = []
-        for sym, items in bars.data.items():
-            symbol = str(sym or "").upper()
+        for symbol, items in bars_obj.data.items():
+            sym = str(symbol or "").upper()
             for bar in items or []:
                 rows.append(
                     {
-                        "symbol": symbol,
+                        "symbol": sym,
                         "timestamp": getattr(bar, "timestamp", getattr(bar, "t", None)),
                         "open": getattr(bar, "open", getattr(bar, "o", None)),
                         "high": getattr(bar, "high", getattr(bar, "h", None)),
@@ -89,41 +129,20 @@ def to_bars_df(bars) -> pd.DataFrame:
                         "volume": getattr(bar, "volume", getattr(bar, "v", None)),
                     }
                 )
-        return pd.DataFrame(rows, columns=BARS_COLUMNS) if rows else _empty_bars_df()
+        return _standardize(pd.DataFrame(rows)) if rows else _empty_bars_df()
 
-    # Case C/D: HTTP JSON payloads
     records: Iterable[dict] | None = None
-    if isinstance(bars, dict) and "bars" in bars:
-        records = bars.get("bars")
-    elif isinstance(bars, (list, tuple)):
-        records = bars
-    frame = pd.DataFrame(list(records or []))
-    if frame.empty:
-        return _empty_bars_df()
-    frame = frame.rename(
-        columns={
-            "S": "symbol",
-            "Symbol": "symbol",
-            "t": "timestamp",
-            "time": "timestamp",
-            "o": "open",
-            "h": "high",
-            "l": "low",
-            "c": "close",
-            "v": "volume",
-        }
-    )
-    for column in BARS_COLUMNS:
-        if column not in frame.columns:
-            frame[column] = pd.NA
-    if "symbol" not in frame.columns:
-        LOGGER.warning(
-            "HTTP bars payload missing symbol column after normalization; type=%s columns=%s",
-            type(bars),
-            list(frame.columns),
-        )
-    frame["symbol"] = frame["symbol"].astype(str).str.upper()
-    return frame[BARS_COLUMNS].copy()
+    if isinstance(bars_obj, dict) and "bars" in bars_obj:
+        records = bars_obj.get("bars")
+    elif isinstance(bars_obj, (list, tuple)):
+        records = bars_obj
+    if records is not None:
+        df = pd.DataFrame(list(records))
+        if df.empty and symbol_hint:
+            return _empty_bars_df()
+        return _standardize(df)
+
+    return _empty_bars_df()
 
 
 __all__ = ["to_bars_df", "BARS_COLUMNS"]


### PR DESCRIPTION
## Summary
- normalize every bar payload into a shared symbol/timestamp schema with optional symbol hints and improved MultiIndex handling
- add guards and diagnostics when batched or per-symbol fetches produce frames without symbols before merging
- extend tests covering Alpaca BarsSet, dict, HTTP, and DataFrame inputs to ensure the symbol column is always present

## Testing
- pytest tests/test_to_bars_df.py


------
https://chatgpt.com/codex/tasks/task_e_68e58315f2a8833185372b4f62a58d2d