### PR TITLE
Add HTTP bars fetch and normalize utilities

### DIFF
--- a/tests/test_screener_api_mode.py
+++ b/tests/test_screener_api_mode.py
@@ -61,12 +61,26 @@ def test_screener_api_mode_creates_outputs(tmp_path, monkeypatch):
                 "UNKNOWN1": {"exchange": "PINK", "asset_class": "OTC", "tradable": True},
                 "CRYPTO1": {"exchange": "CRYPTO", "asset_class": "CRYPTO", "tradable": True},
             },
+            {"assets_total": 3, "assets_tradable_equities": 1, "assets_after_filters": 1},
         ),
     )
     monkeypatch.setattr(
         screener,
         "_fetch_daily_bars",
-        lambda *args, **kwargs: (mock_bars.copy(), 0),
+        lambda *args, **kwargs: (
+            mock_bars.copy(),
+            {
+                "batches_total": 0,
+                "batches_paged": 0,
+                "pages_total": 0,
+                "bars_rows_total": int(mock_bars.shape[0]),
+                "symbols_with_bars": 1,
+                "symbols_no_bars": [],
+                "fallback_batches": 0,
+                "insufficient_history": 0,
+            },
+            {},
+        ),
     )
 
     exit_code = screener.main([], output_dir=tmp_path)

--- a/tests/test_to_bars_df.py
+++ b/tests/test_to_bars_df.py
@@ -7,7 +7,7 @@ from scripts.utils.dataframe_utils import BARS_COLUMNS, to_bars_df
 pytestmark = pytest.mark.alpaca_optional
 
 
-def test_to_bars_df_handles_multiindex():
+def test_to_bars_df_sdk_multiindex():
     idx = pd.MultiIndex.from_tuples(
         [("AAPL", "2024-10-01"), ("MSFT", "2024-10-01")],
         names=["symbol", "timestamp"],
@@ -53,7 +53,7 @@ def test_to_bars_df_handles_dict_of_lists():
     assert out.loc[0, "symbol"] == "AAPL"
 
 
-def test_to_bars_df_handles_http_payload():
+def test_to_bars_df_http_renames():
     payload = [
         {"S": "msft", "t": "2024-10-01T00:00:00Z", "o": 1, "h": 2, "l": 0.5, "c": 1.5, "v": 200}
     ]


### PR DESCRIPTION
## Summary
- add a --bars-source flag with HTTP as the default and wire a paginated fetch_bars_http flow into the screener with per-symbol fallbacks
- ensure bar payloads normalize to a flat schema via an updated to_bars_df helper and guard against missing symbol columns
- refresh tests to cover HTTP renaming, SDK multi-index normalization, and the screener API fixture expectations

## Testing
- pytest tests/test_to_bars_df.py tests/test_screener_api_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68e58799fba0833180df6794512ed5fc