### PR TITLE
Switch Market Data to https://data.alpaca.markets + IEX paging/limits; keep Trading API host for account/assets

### DIFF
--- a/scripts/utils/env.py
+++ b/scripts/utils/env.py
@@ -1,0 +1,31 @@
+"""Environment helpers for Alpaca configuration."""
+from __future__ import annotations
+
+import os
+
+
+def trading_base_url() -> str:
+    """Return the Alpaca trading API base URL.
+
+    Prefers explicit ``APCA_API_BASE_URL``/``ALPACA_API_BASE_URL`` but falls back to
+    ``APCA_API_ENV`` to determine paper vs live trading. Defaults to the paper
+    trading host.
+    """
+
+    env_base = os.getenv("APCA_API_BASE_URL") or os.getenv("ALPACA_API_BASE_URL")
+    if env_base:
+        return env_base.rstrip("/")
+    env = (os.getenv("APCA_API_ENV") or "paper").strip().lower()
+    if env == "live":
+        return "https://api.alpaca.markets"
+    return "https://paper-api.alpaca.markets"
+
+
+def market_data_base_url() -> str:
+    """Return the Alpaca market data API base URL."""
+
+    base = os.getenv("APCA_DATA_API_BASE_URL") or "https://data.alpaca.markets"
+    return base.rstrip("/")
+
+
+__all__ = ["trading_base_url", "market_data_base_url"]

--- a/scripts/utils/http_alpaca.py
+++ b/scripts/utils/http_alpaca.py
@@ -1,13 +1,17 @@
 """HTTP helpers for Alpaca market data."""
 from __future__ import annotations
 
+import logging
 import os
 import time
-from typing import Iterable, List
+from typing import Dict, Iterable, List, Tuple
 
 import requests
 
+from .env import market_data_base_url
 from .rate import TokenBucket
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _batched(symbols: Iterable[str], size: int) -> Iterable[List[str]]:
@@ -32,13 +36,13 @@ def fetch_bars_http(
     chunk_size: int = 50,
     rate_limit: int = 200,
     sleep_s: float = 0.35,
-) -> list[dict]:
+) -> Tuple[list[dict], Dict[str, int]]:
     """Fetch daily bars via Alpaca's REST API with pagination support."""
 
     if not symbols:
-        return []
+        return [], {"rate_limited": 0, "pages": 0, "requests": 0, "chunks": 0}
 
-    base = os.getenv("APCA_API_BASE_URL", "https://paper-api.alpaca.markets").rstrip("/")
+    base = market_data_base_url()
     url = f"{base}/v2/stocks/bars"
     headers = {
         "APCA-API-KEY-ID": os.getenv("APCA_API_KEY_ID"),
@@ -46,8 +50,17 @@ def fetch_bars_http(
     }
     limiter = TokenBucket(rate_limit)
     output: list[dict] = []
+    metrics: Dict[str, int] = {
+        "rate_limited": 0,
+        "pages": 0,
+        "requests": 0,
+        "chunks": 0,
+    }
+    rate_logged = False
+    not_found_logged = False
 
     for chunk in _batched(symbols, max(1, min(chunk_size, 50))):
+        metrics["chunks"] += 1
         page_token: str | None = None
         while True:
             params = {
@@ -61,16 +74,36 @@ def fetch_bars_http(
             if page_token:
                 params["page_token"] = page_token
             limiter.acquire()
+            metrics["requests"] += 1
             response = requests.get(url, headers=headers, params=params, timeout=30)
+            if response.status_code == 404:
+                if not not_found_logged:
+                    sample = ",".join(chunk[:5])
+                    LOGGER.info(
+                        "No bars returned for request chunk (size=%d sample=%s)",
+                        len(chunk),
+                        sample,
+                    )
+                    not_found_logged = True
+                break
+            if response.status_code == 429:
+                if not rate_logged:
+                    LOGGER.warning("Alpaca rate limit hit when fetching bars; retrying once")
+                    rate_logged = True
+                metrics["rate_limited"] += 1
+                time.sleep(1.0)
+                metrics["requests"] += 1
+                response = requests.get(url, headers=headers, params=params, timeout=30)
             response.raise_for_status()
             payload = response.json() or {}
             output.extend(payload.get("bars", []) or [])
+            metrics["pages"] += 1
             page_token = payload.get("next_page_token")
             if not page_token:
                 break
             time.sleep(sleep_s)
         time.sleep(sleep_s)
-    return output
+    return output, metrics
 
 
 __all__ = ["fetch_bars_http"]

--- a/tests/test_http_alpaca.py
+++ b/tests/test_http_alpaca.py
@@ -1,0 +1,45 @@
+import pytest
+
+from scripts.utils.http_alpaca import fetch_bars_http
+from scripts.utils.normalize import BARS_COLUMNS, to_bars_df
+
+
+@pytest.mark.alpaca_optional
+def test_market_data_host(monkeypatch):
+    captured_urls: list[str] = []
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {"bars": [], "next_page_token": None}
+
+        def raise_for_status(self):
+            return None
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        captured_urls.append(url)
+        return DummyResponse()
+
+    monkeypatch.delenv("APCA_DATA_API_BASE_URL", raising=False)
+    monkeypatch.setattr("scripts.utils.http_alpaca.requests.get", fake_get)
+
+    bars, metrics = fetch_bars_http(["AAPL"], "2024-01-01", "2024-01-02", sleep_s=0)
+
+    assert captured_urls == ["https://data.alpaca.markets/v2/stocks/bars"]
+    assert bars == []
+    assert metrics["pages"] == 1
+
+
+def test_normalize_http():
+    payload = [
+        {"S": "spy", "t": "2024-01-01T00:00:00Z", "o": 1, "h": 2, "l": 0.5, "c": 1.5, "v": 10},
+        {"S": "msft", "t": "2024-01-02T00:00:00Z", "o": 2, "h": 3, "l": 1.5, "c": 2.5, "v": 20},
+    ]
+
+    df = to_bars_df(payload)
+
+    assert list(df.columns) == BARS_COLUMNS
+    assert df.shape == (2, len(BARS_COLUMNS))
+    assert df.loc[0, "symbol"] == "SPY"
+    assert df.loc[1, "symbol"] == "MSFT"


### PR DESCRIPTION
## Summary
- add dedicated helpers for trading and market data base URLs so HTTP calls use the data host by default
- update the HTTP bar fetcher to call data.alpaca.markets, handle paging and 404/429 responses, and surface rate-limit metrics
- extend the screener to propagate the new metrics, record IEX filter skips, and safely coerce metric values for reporting
- cover the changes with unit tests for the data host selection and HTTP normalisation behaviour

## Testing
- pytest tests/test_http_alpaca.py tests/test_screener_api_mode.py


------
https://chatgpt.com/codex/tasks/task_e_68e58f5af1d883318cbc5d56e33e02f7