### PR TITLE
Revamp screener windowing and diagnostics

### DIFF
--- a/scripts/utils/calendar.py
+++ b/scripts/utils/calendar.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Iterable, Optional, Tuple
+
+from alpaca.trading.client import TradingClient
+from alpaca.trading.requests import GetCalendarRequest
+
+
+def _coerce_date(value: object) -> Optional[date]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            try:
+                return datetime.fromisoformat(value).date()
+            except ValueError:
+                return None
+    return None
+
+
+def _calendar_entries(calendar: Iterable[object]) -> list[object]:
+    return list(calendar or [])
+
+
+def calc_daily_window(trading_client: TradingClient, days: int) -> Tuple[str, str, str]:
+    """Return ISO start/end strings for the most recent ``days`` trading sessions."""
+
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    lookback_start = today - timedelta(days=4000)
+    request = GetCalendarRequest(start=lookback_start, end=today)
+    calendar = _calendar_entries(trading_client.get_calendar(request))
+
+    sessions: list[tuple[date, object]] = []
+    for entry in calendar:
+        session_date = _coerce_date(getattr(entry, "date", None) or getattr(entry, "session", None))
+        if session_date is None or session_date > today:
+            continue
+        close_value = getattr(entry, "close", None) or getattr(entry, "close_time", None)
+        if not close_value:
+            continue
+        sessions.append((session_date, entry))
+
+    if not sessions:
+        raise RuntimeError("No closed trading sessions returned by Alpaca calendar")
+
+    sessions.sort(key=lambda item: item[0])
+    last_day = sessions[-1][0]
+
+    days = max(1, int(days))
+    start_index = max(0, len(sessions) - 1 - days)
+    start_day = sessions[start_index][0]
+
+    start_iso = f"{start_day.isoformat()}T00:00:00Z"
+    end_iso = f"{last_day.isoformat()}T23:59:59Z"
+
+    return start_iso, end_iso, last_day.isoformat()
+
+
+__all__ = ["calc_daily_window"]

--- a/scripts/utils/http_alpaca.py
+++ b/scripts/utils/http_alpaca.py
@@ -9,7 +9,6 @@ from typing import Dict, Iterable, List, Tuple
 import requests
 
 from .env import market_data_base_url
-from .rate import TokenBucket
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +24,25 @@ def _batched(symbols: Iterable[str], size: int) -> Iterable[List[str]]:
         yield batch
 
 
+def _coerce_bars(payload: dict) -> list[dict]:
+    bars = payload.get("bars", []) if isinstance(payload, dict) else []
+    if isinstance(bars, list):
+        return [bar for bar in bars if isinstance(bar, dict)]
+    if isinstance(bars, dict):
+        collected: list[dict] = []
+        for symbol, entries in bars.items():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                record = dict(entry)
+                record.setdefault("symbol", symbol)
+                collected.append(record)
+        return collected
+    return []
+
+
 def fetch_bars_http(
     symbols: list[str],
     start: str,
@@ -33,14 +51,22 @@ def fetch_bars_http(
     timeframe: str = "1Day",
     feed: str = "iex",
     per_page: int = 10_000,
-    chunk_size: int = 50,
-    rate_limit: int = 200,
     sleep_s: float = 0.35,
+    verify_hook=None,
+    first_page_callback=None,
 ) -> Tuple[list[dict], Dict[str, int]]:
     """Fetch daily bars via Alpaca's REST API with pagination support."""
 
     if not symbols:
-        return [], {"rate_limited": 0, "pages": 0, "requests": 0, "chunks": 0}
+        empty_metrics = {
+            "rate_limited": 0,
+            "pages": 0,
+            "requests": 0,
+            "chunks": 0,
+            "http_404_batches": 0,
+            "http_empty_batches": 0,
+        }
+        return [], empty_metrics
 
     base = market_data_base_url()
     url = f"{base}/v2/stocks/bars"
@@ -48,18 +74,19 @@ def fetch_bars_http(
         "APCA-API-KEY-ID": os.getenv("APCA_API_KEY_ID"),
         "APCA-API-SECRET-KEY": os.getenv("APCA_API_SECRET_KEY"),
     }
-    limiter = TokenBucket(rate_limit)
     output: list[dict] = []
     metrics: Dict[str, int] = {
         "rate_limited": 0,
         "pages": 0,
         "requests": 0,
         "chunks": 0,
+        "http_404_batches": 0,
+        "http_empty_batches": 0,
     }
-    rate_logged = False
-    not_found_logged = False
+    first_request_logged = False
+    first_page_notified = False
 
-    for chunk in _batched(symbols, max(1, min(chunk_size, 50))):
+    for chunk in _batched(symbols, 50):
         metrics["chunks"] += 1
         page_token: str | None = None
         while True:
@@ -73,36 +100,43 @@ def fetch_bars_http(
             }
             if page_token:
                 params["page_token"] = page_token
-            limiter.acquire()
+            if verify_hook and not first_request_logged:
+                try:
+                    verify_hook(url, params)
+                except Exception:  # pragma: no cover - diagnostics must not break fetch
+                    LOGGER.debug("Verify hook failed for request preview", exc_info=True)
+                first_request_logged = True
             metrics["requests"] += 1
             response = requests.get(url, headers=headers, params=params, timeout=30)
-            if response.status_code == 404:
-                if not not_found_logged:
-                    sample = ",".join(chunk[:5])
-                    LOGGER.info(
-                        "No bars returned for request chunk (size=%d sample=%s)",
-                        len(chunk),
-                        sample,
-                    )
-                    not_found_logged = True
-                break
             if response.status_code == 429:
-                if not rate_logged:
-                    LOGGER.warning("Alpaca rate limit hit when fetching bars; retrying once")
-                    rate_logged = True
                 metrics["rate_limited"] += 1
                 time.sleep(1.0)
                 metrics["requests"] += 1
                 response = requests.get(url, headers=headers, params=params, timeout=30)
+            if response.status_code == 404:
+                metrics["http_404_batches"] += 1
+                break
             response.raise_for_status()
             payload = response.json() or {}
-            output.extend(payload.get("bars", []) or [])
+            if not first_page_notified:
+                first_page_notified = True
+                if first_page_callback is not None:
+                    try:
+                        first_page_callback(payload)
+                    except Exception:  # pragma: no cover - diagnostics only
+                        LOGGER.debug("First-page callback failed", exc_info=True)
+            bars = _coerce_bars(payload)
+            if not bars:
+                metrics["http_empty_batches"] += 1
+            else:
+                output.extend(bars)
             metrics["pages"] += 1
-            page_token = payload.get("next_page_token")
+            page_token = payload.get("next_page_token") if isinstance(payload, dict) else None
             if not page_token:
                 break
             time.sleep(sleep_s)
         time.sleep(sleep_s)
+
     return output, metrics
 
 

--- a/scripts/utils/normalize.py
+++ b/scripts/utils/normalize.py
@@ -63,6 +63,8 @@ def _normalize_multiindex(df: pd.DataFrame) -> pd.DataFrame:
             names[0] = "symbol"
         if len(names) >= 2 and not names[1]:
             names[1] = "timestamp"
+        if names:
+            df.index = df.index.set_names(names)
         df = df.reset_index()
     elif df.index.name in {"symbol", "timestamp"}:
         df = df.reset_index()


### PR DESCRIPTION
## Summary
- derive screener bar windows from the Alpaca trading calendar with window fallbacks, symbol overrides, and richer metrics output
- expose diagnostics including a request verifier/preview and propagate HTTP fetch statistics through the screener
- harden data normalization for multi-index bar frames to retain symbol information

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b8b3bf3483318041a18e06317587