### PR TITLE
Fix multi-symbol bars flattening (dict→list), enforce dtypes, and solid metrics for IEX ingestion

### DIFF
--- a/tests/test_flatten_multisymbol.py
+++ b/tests/test_flatten_multisymbol.py
@@ -1,0 +1,19 @@
+from scripts.utils.normalize import to_bars_df
+
+
+def test_flatten_dict_of_lists():
+    raw = {"bars": {
+        "AAPL": [{"t": "2024-01-02T00:00:00Z", "o": 1, "h": 2, "l": 1, "c": 2, "v": 10}],
+        "MSFT": [{"t": "2024-01-02T00:00:00Z", "o": 2, "h": 3, "l": 2, "c": 3, "v": 20}],
+    }}
+    flattened = []
+    for sym, arr in raw["bars"].items():
+        for bar in arr:
+            flattened.append({**bar, "S": sym})
+    df = to_bars_df(flattened)
+    assert "symbol" in df.columns
+    assert len(df) == 2
+    assert set(df["symbol"]) == {"AAPL", "MSFT"}
+    assert df["open"].dtype.kind in "f"
+    dtype_str = str(df["timestamp"].dtype)
+    assert dtype_str.endswith("UTC]") or dtype_str.endswith("[UTC]")


### PR DESCRIPTION
## Summary
- flatten HTTP bar payloads that are returned as symbol->bars mappings and preserve the inferred symbol when normalizing
- harden bar normalization with canonical column renames, numeric coercion, and UTC tz conversion for timestamps
- tighten screener metrics bookkeeping to capture symbols processed, dump debug artifacts when parsing fails, and gate history with richer counters
- add a regression test to lock in the multi-symbol flatten + dtype behaviour

## Testing
- pytest
- python -m scripts.screener --symbols AAPL,MSFT,SPY --feed iex --bars-source http --verify-request *(fails: Missing Alpaca credentials; set APCA_API_KEY_ID and APCA_API_SECRET_KEY.)*
- python -m scripts.screener --feed iex --limit 300 --batch-size 50 *(fails: Missing Alpaca credentials; set APCA_API_KEY_ID and APCA_API_SECRET_KEY.)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d0ffe1088331b409ef9f3ad26e8d