### PR TITLE
Fix NameError & finalize multi-symbol bars flattening + dtype coercion; lock ingestion metrics

### DIFF
--- a/scripts/utils/normalize.py
+++ b/scripts/utils/normalize.py
@@ -5,48 +5,12 @@ from typing import Any
 
 import pandas as pd
 
-try:  # pragma: no cover - optional dependency handling
-    import pytz
-except Exception:  # pragma: no cover - pytz not required for functionality
-    pytz = None
-
 CANON = ["symbol", "timestamp", "open", "high", "low", "close", "volume"]
 
 
-def _rename_columns(df: pd.DataFrame) -> pd.DataFrame:
-    return df.rename(
-        columns={
-            "S": "symbol",
-            "Symbol": "symbol",
-            "t": "timestamp",
-            "T": "timestamp",
-            "time": "timestamp",
-            "Time": "timestamp",
-            "level_0": "symbol",
-            "level_1": "timestamp",
-            "index": "symbol",
-            "o": "open",
-            "Open": "open",
-            "h": "high",
-            "High": "high",
-            "l": "low",
-            "Low": "low",
-            "c": "close",
-            "Close": "close",
-            "v": "volume",
-            "Volume": "volume",
-        }
-    )
+def to_bars_df(obj: Any) -> pd.DataFrame:
+    """Normalize a bars payload into a canonical DataFrame."""
 
-
-def _ensure_columns(df: pd.DataFrame) -> pd.DataFrame:
-    for column in CANON:
-        if column not in df.columns:
-            df[column] = pd.NA
-    return df
-
-
-def to_bars_df(obj: Any, symbol_hint: str | None = None) -> pd.DataFrame:
     if isinstance(obj, dict) and "bars" in obj:
         obj = obj["bars"]
 
@@ -54,51 +18,66 @@ def to_bars_df(obj: Any, symbol_hint: str | None = None) -> pd.DataFrame:
         df = obj.copy()
         if isinstance(df.index, pd.MultiIndex):
             df = df.reset_index()
-        df = _rename_columns(df)
-    elif isinstance(obj, (list, tuple)):
-        df = _rename_columns(pd.DataFrame(obj))
-    elif hasattr(obj, "df") or hasattr(obj, "data"):
-        try:
-            if hasattr(obj, "df") and obj.df is not None:
-                df = obj.df
-                if isinstance(df.index, pd.MultiIndex):
-                    df = df.reset_index()
-                df = _rename_columns(df)
-            elif hasattr(obj, "data") and isinstance(obj.data, dict):
-                rows: list[dict[str, Any]] = []
-                for sym, items in obj.data.items():
-                    for bar in items or []:
-                        rows.append(
-                            {
-                                "symbol": str(sym).upper(),
-                                "timestamp": getattr(bar, "timestamp", getattr(bar, "t", None)),
-                                "open": getattr(bar, "open", getattr(bar, "o", None)),
-                                "high": getattr(bar, "high", getattr(bar, "h", None)),
-                                "low": getattr(bar, "low", getattr(bar, "l", None)),
-                                "close": getattr(bar, "close", getattr(bar, "c", None)),
-                                "volume": getattr(bar, "volume", getattr(bar, "v", None)),
-                            }
-                        )
-                df = pd.DataFrame(rows)
-            else:
-                df = pd.DataFrame(columns=CANON)
-        except Exception:
-            df = pd.DataFrame(columns=CANON)
+    elif hasattr(obj, "df") and isinstance(getattr(obj, "df"), pd.DataFrame):
+        df = obj.df.copy()
+        if isinstance(df.index, pd.MultiIndex):
+            df = df.reset_index()
+    elif hasattr(obj, "data") and isinstance(getattr(obj, "data"), dict):
+        rows: list[dict[str, Any]] = []
+        for symbol, items in obj.data.items():
+            for bar in items or []:
+                rows.append(
+                    {
+                        "symbol": (
+                            getattr(bar, "symbol", None)
+                            or getattr(bar, "S", None)
+                            or symbol
+                        ),
+                        "timestamp": getattr(bar, "timestamp", getattr(bar, "t", None)),
+                        "open": getattr(bar, "open", getattr(bar, "o", None)),
+                        "high": getattr(bar, "high", getattr(bar, "h", None)),
+                        "low": getattr(bar, "low", getattr(bar, "l", None)),
+                        "close": getattr(bar, "close", getattr(bar, "c", None)),
+                        "volume": getattr(bar, "volume", getattr(bar, "v", None)),
+                    }
+                )
+        df = pd.DataFrame(rows)
     else:
-        df = pd.DataFrame(columns=CANON)
+        df = pd.DataFrame(obj or [])
+    rename_map = {
+        "S": "symbol",
+        "Symbol": "symbol",
+        "t": "timestamp",
+        "T": "timestamp",
+        "time": "timestamp",
+        "Time": "timestamp",
+        "level_0": "symbol",
+        "level_1": "timestamp",
+        "index": "symbol",
+        "o": "open",
+        "h": "high",
+        "l": "low",
+        "c": "close",
+        "v": "volume",
+        "Open": "open",
+        "High": "high",
+        "Low": "low",
+        "Close": "close",
+        "Volume": "volume",
+    }
 
-    df = _rename_columns(df)
-    df = _ensure_columns(df)
-    if symbol_hint:
-        df["symbol"] = df["symbol"].fillna(symbol_hint)
-        mask = df["symbol"].astype(str).str.strip() == ""
-        if mask.any():
-            df.loc[mask, "symbol"] = symbol_hint
-    df["symbol"] = df["symbol"].astype(str).str.strip().str.upper()
+    df = df.rename(
+        columns={
+            **rename_map,
+        }
+    )
+
+    for column in CANON:
+        if column not in df.columns:
+            df[column] = pd.NA
+
+    df["symbol"] = df["symbol"].astype("string").str.strip().str.upper()
     df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
-    if isinstance(df["timestamp"].dtype, pd.DatetimeTZDtype):
-        target_tz = pytz.UTC if pytz is not None else "UTC"
-        df["timestamp"] = df["timestamp"].dt.tz_convert(target_tz)
     for column in ["open", "high", "low", "close"]:
         df[column] = pd.to_numeric(df[column], errors="coerce").astype("float64")
     df["volume"] = pd.to_numeric(df["volume"], errors="coerce").astype("Int64")

--- a/tests/test_flatten_bars_payload.py
+++ b/tests/test_flatten_bars_payload.py
@@ -1,0 +1,27 @@
+from scripts.utils.http_alpaca import _flatten_bars_payload
+
+
+def test_flatten_dict_of_lists():
+    data = {
+        "bars": {
+            "AAPL": [
+                {"t": "2024-01-02T00:00:00Z", "o": 1, "h": 2, "l": 1, "c": 2, "v": 10}
+            ],
+            "MSFT": [
+                {"t": "2024-01-02T00:00:00Z", "o": 2, "h": 3, "l": 2, "c": 3, "v": 20}
+            ],
+        }
+    }
+    flat = _flatten_bars_payload(data)
+    assert len(flat) == 2
+    assert {"S", "t", "o", "h", "l", "c", "v"}.issubset(flat[0].keys())
+
+
+def test_flatten_list_of_dicts():
+    data = {
+        "bars": [
+            {"S": "SPY", "t": "2024-01-02T00:00:00Z", "o": 1, "h": 1, "l": 1, "c": 1, "v": 5}
+        ]
+    }
+    flat = _flatten_bars_payload(data)
+    assert len(flat) == 1 and flat[0]["S"] == "SPY"

--- a/tests/test_to_bars_df.py
+++ b/tests/test_to_bars_df.py
@@ -1,11 +1,7 @@
 import pandas as pd
 import pytest
 
-import pandas as pd
-import pytest
-
 from scripts.utils.normalize import BARS_COLUMNS, to_bars_df
-
 
 pytestmark = pytest.mark.alpaca_optional
 
@@ -80,3 +76,22 @@ def test_to_bars_df_handles_dataframe_with_named_index():
     out = to_bars_df(df)
     assert list(out.columns) == BARS_COLUMNS
     assert out.loc[0, "symbol"] == "SPY"
+
+
+def test_to_bars_df_coercion():
+    flat = [
+        {
+            "S": "AAPL",
+            "t": "2024-01-02T00:00:00Z",
+            "o": "1",
+            "h": "2.5",
+            "l": "1",
+            "c": "2",
+            "v": "10",
+        }
+    ]
+    df = to_bars_df(flat)
+    assert list(df.columns) == ["symbol", "timestamp", "open", "high", "low", "close", "volume"]
+    assert df["open"].dtype.kind == "f"
+    assert isinstance(df["timestamp"].dtype, pd.DatetimeTZDtype)
+    assert "UTC" in str(df["timestamp"].dtype)


### PR DESCRIPTION
## Summary
- replace the unused finalize helper by flattening HTTP bar payloads in place and wiring the ingestion path through the normalizer
- tighten `to_bars_df` to cover Alpaca dict/list SDK shapes while enforcing canonical OHLC/volume dtypes
- update screener metrics bookkeeping and add regression tests for the new flatten/normalize flow

## Testing
- pytest tests/test_flatten_bars_payload.py tests/test_to_bars_df.py tests/test_normalize_bars.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d58ae17883318899b58a10b075a7