### PR TITLE
Canonicalize bars in fetcher (dict→flat with symbol), hard guard symbol column, dtype coercion, and reliable history metrics

### DIFF
--- a/tests/test_http_flatten_canon.py
+++ b/tests/test_http_flatten_canon.py
@@ -1,7 +1,7 @@
 from scripts.utils.http_alpaca import _flatten_to_canonical
 
 
-def test_flatten_dict_of_lists():
+def test_dict_of_lists_to_canon():
     data = {
         "bars": {
             "AAPL": [
@@ -12,18 +12,23 @@ def test_flatten_dict_of_lists():
             ],
         }
     }
-    flat = _flatten_to_canonical(data)
-    assert len(flat) == 2
-    assert {"symbol", "timestamp", "open", "high", "low", "close", "volume"}.issubset(
-        flat[0].keys()
-    )
+    out = _flatten_to_canonical(data)
+    assert len(out) == 2 and set(out[0].keys()) == {
+        "symbol",
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    }
 
 
-def test_flatten_list_of_dicts():
+def test_list_of_dicts_to_canon():
     data = {
         "bars": [
             {"S": "SPY", "t": "2024-01-02T00:00:00Z", "o": 1, "h": 1, "l": 1, "c": 1, "v": 5}
         ]
     }
-    flat = _flatten_to_canonical(data)
-    assert len(flat) == 1 and flat[0]["symbol"] == "SPY"
+    out = _flatten_to_canonical(data)
+    assert len(out) == 1 and out[0]["symbol"] == "SPY"

--- a/tests/test_normalize_canon_types.py
+++ b/tests/test_normalize_canon_types.py
@@ -1,0 +1,27 @@
+from scripts.utils.normalize import to_bars_df
+
+
+def test_canon_types():
+    flat = [
+        {
+            "symbol": "AAPL",
+            "timestamp": "2024-01-02T00:00:00Z",
+            "open": "1",
+            "high": "2",
+            "low": "1",
+            "close": "2",
+            "volume": "10",
+        }
+    ]
+    df = to_bars_df(flat)
+    assert list(df.columns) == [
+        "symbol",
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    assert df["open"].dtype.kind == "f"
+    assert str(df["timestamp"].dtype).endswith("[UTC]")


### PR DESCRIPTION
## Summary
- canonicalize HTTP bar responses into a flat symbol/timestamp schema before pandas ingestion
- harden bar normalization with dtype coercion and safeguards against the symbol column becoming an index
- add ingestion guardrails plus regression tests covering the canonical flattening and type expectations

## Testing
- pytest tests/test_http_flatten_canon.py tests/test_flatten_bars_payload.py tests/test_normalize_canon_types.py tests/test_to_bars_df.py

------
https://chatgpt.com/codex/tasks/task_e_68e5de3ca5188331a3339c03fced5044