### PR TITLE
Never-drop symbol: canonicalize in fetcher, ensure_symbol guard, map meta (no merge), and metrics parity

### DIFF
--- a/scripts/utils/frame_guards.py
+++ b/scripts/utils/frame_guards.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+
+def ensure_symbol_column(df: pd.DataFrame) -> pd.DataFrame:
+    """Guarantee a 'symbol' column exists (uppercase), even if it drifted to index or _x/_y after joins."""
+    if "symbol" in df.columns:
+        df["symbol"] = df["symbol"].astype(str).str.upper()
+        return df
+
+    # Look for common collisions
+    for cand in ("symbol_x", "symbol_y", "S", "Symbol"):
+        if cand in df.columns:
+            df["symbol"] = df[cand].astype(str).str.upper()
+            return df
+
+    # Index-level rescue
+    if isinstance(df.index, pd.MultiIndex) and df.index.names:
+        for i, name in enumerate(df.index.names):
+            if (name or "").lower() == "symbol":
+                df = df.reset_index()
+                df.rename(columns={name: "symbol"}, inplace=True)
+                df["symbol"] = df["symbol"].astype(str).str.upper()
+                return df
+    if getattr(df.index, "name", None) and df.index.name.lower() == "symbol":
+        name = df.index.name
+        df = df.reset_index().rename(columns={name: "symbol"})
+        df["symbol"] = df["symbol"].astype(str).str.upper()
+        return df
+
+    if not isinstance(df.index, pd.RangeIndex):
+        df = df.reset_index()
+        first_col = df.columns[0]
+        df.rename(columns={first_col: "symbol"}, inplace=True)
+        df["symbol"] = df["symbol"].astype(str).str.upper()
+        return df
+
+    # Last resort: create empty uppercase string column to avoid hard failure; downstream history check will drop it
+    df = df.copy()
+    df["symbol"] = pd.Series(dtype="string")
+    return df

--- a/tests/test_ensure_symbol_column.py
+++ b/tests/test_ensure_symbol_column.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import pytest
+
+from scripts.utils.frame_guards import ensure_symbol_column
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_symbol_x_y_rescue():
+    df = pd.DataFrame({"symbol_x": ["aapl", "msft"], "close": [1, 2]})
+    df2 = ensure_symbol_column(df)
+    assert "symbol" in df2.columns and set(df2["symbol"]) == {"AAPL", "MSFT"}
+
+
+def test_index_rescue():
+    df = pd.DataFrame({"close": [1, 2]})
+    df.index.name = "symbol"
+    df.index = ["aapl", "msft"]
+    df2 = ensure_symbol_column(df)
+    assert "symbol" in df2.columns and set(df2["symbol"]) == {"AAPL", "MSFT"}


### PR DESCRIPTION
## Summary
- add a reusable ensure_symbol_column guard and apply it throughout the screener flow
- update bar normalization to coerce canon columns while keeping indices untouched and preventing symbol loss
- swap asset metadata merging for map-based enrichment and tighten history/metrics calculations

## Testing
- pytest tests/test_ensure_symbol_column.py
- pytest tests/test_to_bars_df.py tests/test_normalize_canon_types.py

------
https://chatgpt.com/codex/tasks/task_e_68e5e1fd30e483319943d6516b7886ab