### PR TITLE
Pipeline always refreshes latest_candidates.csv post-screener + gate toggles for controlled loosening

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,20 +1,29 @@
+import argparse
+import logging
 import os
 import sys
 import subprocess
 from pathlib import Path
-import io
-from typing import Optional
-
-import pandas as pd
+from shutil import copyfile
+from typing import Iterable, Optional
 
 from utils.env import load_env
-from utils.io_utils import atomic_write_bytes
 
 load_env()
 
 
 def repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the JBRAVO pipeline")
+    parser.add_argument(
+        "--steps",
+        default="screener,backtest,metrics",
+        help="Comma-separated list of steps to run (default: screener,backtest,metrics)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
 
 
 def emit(evt, **kvs):
@@ -47,89 +56,102 @@ def _run_step(
     return True
 
 
-def main() -> int:
+def refresh_latest_candidates() -> None:
+    src = Path("data/top_candidates.csv")
+    dst = Path("data/latest_candidates.csv")
+    logger = logging.getLogger(__name__)
+    if src.exists():
+        try:
+            copyfile(src, dst)
+        except Exception as exc:  # pragma: no cover - copy failures are unexpected
+            logger.error("Failed to refresh %s from %s: %s", dst, src, exc)
+            emit(
+                "LATEST_COPY_FAILED",
+                component="pipeline",
+                error=str(exc).replace(" ", "_"),
+            )
+        else:
+            logger.info("Refreshed %s from %s.", dst, src)
+            emit("LATEST_UPDATED", component="pipeline")
+    else:
+        logger.warning("Top candidates file %s not found; latest not updated.", src)
+        emit("TOP_MISSING", component="pipeline")
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    requested_steps = [
+        step.strip().lower()
+        for step in str(args.steps or "").split(",")
+        if step.strip()
+    ]
+    if not requested_steps:
+        requested_steps = ["screener", "backtest", "metrics"]
+
     root = repo_root()
     os.chdir(root)
     emit("PIPELINE_START", component="pipeline")
 
     exit_code = 0
     try:
-        screener_ok = _run_step(
-            "Screener",
-            "scripts.screener",
-            "SCREENER_SUCCESS",
-            "SCREENER_ERROR",
-            root,
-            extra_args=["--universe", "alpaca-active", "--days", "750", "--feed", "iex"],
-        )
+        last_step_success = True
 
-        if screener_ok:
-            top_path = root / "data" / "top_candidates.csv"
-            latest_path = root / "data" / "latest_candidates.csv"
-            if top_path.exists():
-                try:
-                    csv_bytes = top_path.read_bytes()
-                    df = pd.read_csv(io.BytesIO(csv_bytes))
-                    rows = len(df)
-                    if rows:
-                        atomic_write_bytes(latest_path, csv_bytes)
-                        emit(
-                            "LATEST_UPDATED",
-                            component="pipeline",
-                            rows=str(rows),
-                        )
-                        print(
-                            f"Screener produced {rows} candidates; refreshed latest_candidates.csv."
-                        )
-                    else:
-                        print(
-                            "Screener produced 0 candidates; latest_candidates.csv left untouched."
-                        )
-                except Exception as copy_exc:
-                    emit(
-                        "LATEST_COPY_FAILED",
-                        component="pipeline",
-                        error=str(copy_exc).replace(" ", "_"),
-                    )
-            else:
-                emit("TOP_MISSING", component="pipeline")
-                print(
-                    "top_candidates.csv not found after screener run; latest_candidates.csv left untouched."
+        for step in requested_steps:
+            if step == "screener":
+                screener_ok = _run_step(
+                    "Screener",
+                    "scripts.screener",
+                    "SCREENER_SUCCESS",
+                    "SCREENER_ERROR",
+                    root,
+                    extra_args=[
+                        "--universe",
+                        "alpaca-active",
+                        "--days",
+                        "750",
+                        "--feed",
+                        "iex",
+                    ],
                 )
-        else:
-            exit_code = 1
-
-        backtest_ok = False
-        if screener_ok:
-            backtest_ok = _run_step(
-                "Backtest",
-                "scripts.backtest",
-                "BACKTEST_SUCCESS",
-                "BACKTEST_ERROR",
-                root,
-            )
-            if not backtest_ok:
-                exit_code = 1
-        else:
-            print("Skipping Backtest step because Screener failed.")
-
-        metrics_ok = False
-        if backtest_ok:
-            metrics_ok = _run_step(
-                "Metrics",
-                "scripts.metrics",
-                "METRICS_SUCCESS",
-                "METRICS_ERROR",
-                root,
-            )
-            if not metrics_ok:
-                exit_code = 1
-        else:
-            if screener_ok:
-                print("Skipping Metrics step because Backtest failed.")
+                last_step_success = screener_ok
+                if screener_ok:
+                    refresh_latest_candidates()
+                else:
+                    exit_code = 1
+            elif step == "backtest":
+                if last_step_success:
+                    backtest_ok = _run_step(
+                        "Backtest",
+                        "scripts.backtest",
+                        "BACKTEST_SUCCESS",
+                        "BACKTEST_ERROR",
+                        root,
+                    )
+                    last_step_success = backtest_ok
+                    if not backtest_ok:
+                        exit_code = 1
+                else:
+                    print("Skipping Backtest step because a previous step failed.")
+                    exit_code = 1
+                    last_step_success = False
+            elif step == "metrics":
+                if last_step_success:
+                    metrics_ok = _run_step(
+                        "Metrics",
+                        "scripts.metrics",
+                        "METRICS_SUCCESS",
+                        "METRICS_ERROR",
+                        root,
+                    )
+                    last_step_success = metrics_ok
+                    if not metrics_ok:
+                        exit_code = 1
+                else:
+                    print("Skipping Metrics step because a previous step failed.")
+                    exit_code = 1
+                    last_step_success = False
             else:
-                print("Skipping Metrics step because Screener failed.")
-
+                print(f"Unknown step '{step}' requested; skipping.")
     except Exception as e:
         emit("PIPELINE_ERROR", component="pipeline", error=str(e).replace(" ", "_"))
         raise

--- a/tests/test_screener_unknown_exchange.py
+++ b/tests/test_screener_unknown_exchange.py
@@ -115,5 +115,18 @@ def test_screener_skips_unknown_exchanges(tmp_path):
     assert metrics["skips"]["UNKNOWN_EXCHANGE"] >= 1
     assert metrics["status"] == "ok"
     assert "reject_samples" in metrics
+    assert "gate_fail_counts" in metrics
+    assert set(
+        [
+            "failed_sma_stack",
+            "failed_rsi",
+            "failed_cross",
+            "failed_macd_hist",
+            "failed_adx",
+            "failed_aroon",
+            "nan_data",
+            "insufficient_history",
+        ]
+    ).issubset(metrics["gate_fail_counts"].keys())
     if not top_df.empty:
         assert int(top_df["universe_count"].iloc[0]) == stats["symbols_in"]


### PR DESCRIPTION
## Summary
- add a --steps selector to the pipeline runner and refresh `data/latest_candidates.csv` immediately after the screener completes
- introduce gated screening relax flags plus diagnostics while keeping the default behaviour unchanged and persist richer gate metrics
- extend screener metrics tests to cover the new gate fail counts payload

## Testing
- pytest tests/test_screener_unknown_exchange.py

------
https://chatgpt.com/codex/tasks/task_e_68e673279e048331895f47dc743eb766