### PR TITLE
Always refresh latest candidates in pipeline + gate presets & diagnostics

### DIFF
--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -44,3 +44,33 @@ def test_log_event_appends_and_valid_json(tmp_path, monkeypatch):
     assert second_event == {"event": "SECOND", "component": "pipeline", "ts": second_event["ts"]}
     assert first_event["component"] == second_event["component"] == "pipeline"
     assert "ts" in first_event
+
+
+def test_pipeline_refresh_latest(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "top_candidates.csv").write_text("symbol\nAAPL\n", encoding="utf-8")
+    metrics_path = data_dir / "screener_metrics.json"
+    metrics_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    def fake_exists(path: str) -> bool:
+        return (tmp_path / path).exists()
+
+    copied: dict[str, tuple[str, str]] = {}
+
+    def fake_copy(src: str, dst: str) -> None:
+        copied["call"] = (src, dst)
+        dest_path = tmp_path / dst
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_text("symbol\nAAPL\n", encoding="utf-8")
+
+    monkeypatch.setattr(run_pipeline.os.path, "exists", fake_exists)
+    monkeypatch.setattr(run_pipeline, "copyfile", fake_copy)
+
+    run_pipeline.refresh_latest_candidates()
+
+    assert copied.get("call") == ("data/top_candidates.csv", "data/latest_candidates.csv")
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert "last_run_utc" in metrics and metrics["last_run_utc"]

--- a/tests/test_screener_helpers.py
+++ b/tests/test_screener_helpers.py
@@ -133,3 +133,13 @@ def test_paginate(monkeypatch):
     assert "symbol" in columns_desc
     total_rows = sum(frame.shape[0] for frame in batch_frames)
     assert total_rows == 4
+
+
+def test_gate_presets_parsing():
+    parsed = screener.parse_args(["--gate-preset", "aggressive", "--relax-gates", "cross_or_rsi"])
+    assert parsed.gate_preset == "aggressive"
+    assert parsed.relax_gates == "cross_or_rsi"
+
+    defaults = screener.parse_args([])
+    assert defaults.gate_preset == "standard"
+    assert defaults.relax_gates == "none"


### PR DESCRIPTION
## Summary
- ensure the pipeline refreshes latest_candidates.csv and bumps screener metrics freshness after the screener stage
- add screener gate presets with relaxed diagnostic modes and surface failure counts in metrics
- cover the new behaviors with targeted pipeline and CLI parsing tests

## Testing
- pytest tests/test_run_pipeline.py::test_pipeline_refresh_latest tests/test_screener_helpers.py::test_gate_presets_parsing

------
https://chatgpt.com/codex/tasks/task_e_68e678ab805c8331ae0f9c277f5a6038