### PR TITLE
Add ranking helpers for screener scoring and gating

### DIFF
--- a/config/ranker.yml
+++ b/config/ranker.yml
@@ -1,0 +1,40 @@
+weights:
+  trend: 0.25
+  momentum: 0.2
+  breakout: 0.12
+  pivot_trend: 0.1
+  multi_horizon: 0.08
+  rsi: 0.07
+  adx: 0.06
+  aroon: 0.04
+  vol_contraction: 0.04
+  volume_expansion: 0.03
+  gap_penalty: -0.04
+  liquidity_penalty: -0.05
+
+components:
+  trend: TS
+  momentum: MS
+  breakout: BP
+  pivot_trend: PT
+  multi_horizon: MH
+  rsi: RSI
+  adx: ADX
+  aroon: AROON
+  vol_contraction: VCP
+  volume_expansion: VOLexp
+  gap_penalty: GAPpen
+  liquidity_penalty: LIQpen
+
+gates:
+  min_history: 20
+  min_rsi: 52
+  max_rsi: 68
+  min_adx: 18
+  min_aroon: 40
+  min_volexp: 0.8
+  max_gap: 0.08
+  max_liq_penalty: 0.00001
+  require_sma_stack: true
+  min_score: null
+  history_column: history

--- a/scripts/ranking.py
+++ b/scripts/ranking.py
@@ -1,0 +1,336 @@
+"""Ranking helpers for the screener pipeline.
+
+This module encapsulates the scoring logic for the nightly screener along with
+gate checks that enforce the minimum technical requirements for a candidate.
+
+The public surface intentionally mirrors the previous inline implementation in
+``scripts.screener`` so it can be imported without pulling in the heavy
+dependencies from the rest of that module.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Mapping, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+DEFAULT_COMPONENT_MAP: Mapping[str, str] = {
+    "trend": "TS",
+    "momentum": "MS",
+    "breakout": "BP",
+    "pivot_trend": "PT",
+    "multi_horizon": "MH",
+    "rsi": "RSI",
+    "adx": "ADX",
+    "aroon": "AROON",
+    "vol_contraction": "VCP",
+    "volume_expansion": "VOLexp",
+    "gap_penalty": "GAPpen",
+    "liquidity_penalty": "LIQpen",
+}
+
+
+DEFAULT_WEIGHTS: Mapping[str, float] = {
+    "trend": 0.25,
+    "momentum": 0.2,
+    "breakout": 0.12,
+    "pivot_trend": 0.1,
+    "multi_horizon": 0.08,
+    "rsi": 0.07,
+    "adx": 0.06,
+    "aroon": 0.04,
+    "vol_contraction": 0.04,
+    "volume_expansion": 0.03,
+    "gap_penalty": -0.04,
+    "liquidity_penalty": -0.05,
+}
+
+
+DEFAULT_GATES: Mapping[str, float | bool] = {
+    "min_history": 20,
+    "min_rsi": 52.0,
+    "max_rsi": 68.0,
+    "min_adx": 18.0,
+    "min_aroon": 40.0,
+    "min_volexp": 0.8,
+    "max_gap": 0.08,
+    "max_liq_penalty": 0.00001,
+    "require_sma_stack": True,
+    "min_score": None,
+    "history_column": "history",
+}
+
+
+FAILURE_KEYS: Tuple[str, ...] = (
+    "insufficient_history",
+    "failed_score",
+    "nan_data",
+    "failed_sma_stack",
+    "failed_rsi",
+    "failed_adx",
+    "failed_aroon",
+    "failed_volexp",
+    "failed_gap",
+    "failed_liquidity",
+)
+
+
+REJECT_SAMPLE_LIMIT = 10
+
+
+def _standardize(series: pd.Series) -> pd.Series:
+    values = pd.to_numeric(series, errors="coerce")
+    mask = values.notna()
+    if mask.sum() == 0:
+        return pd.Series(0.0, index=series.index)
+    std = values[mask].std(ddof=0)
+    if not np.isfinite(std) or std == 0:
+        return pd.Series(0.0, index=series.index)
+    mean = values[mask].mean()
+    standardized = (values - mean) / std
+    standardized[~mask] = 0.0
+    return standardized
+
+
+def _normalise_config(mapping: Optional[Mapping[str, float]]) -> Dict[str, float]:
+    base = dict(DEFAULT_WEIGHTS)
+    if not mapping:
+        return base
+    for key, value in mapping.items():
+        try:
+            base[str(key)] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return base
+
+
+def _select_latest(bars_df: pd.DataFrame) -> pd.DataFrame:
+    if "timestamp" not in bars_df.columns:
+        return bars_df.copy()
+    df = bars_df.copy()
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    df = df.sort_values(["symbol", "timestamp"])
+    latest = df.groupby("symbol", as_index=False).tail(1)
+    latest.reset_index(drop=True, inplace=True)
+    return latest
+
+
+def score_universe(bars_df: pd.DataFrame, cfg: Optional[Mapping[str, object]] = None) -> pd.DataFrame:
+    """Score every symbol in ``bars_df`` and return a ranked DataFrame.
+
+    Parameters
+    ----------
+    bars_df:
+        DataFrame containing the engineered features used for scoring.  When
+        multiple rows per symbol are present the most recent row (by
+        ``timestamp``) is used.
+    cfg:
+        Optional configuration mapping.  Supported keys:
+            ``weights`` - overrides for component weights.
+            ``components`` - mapping from component names to column names.
+
+    Returns
+    -------
+    pd.DataFrame
+        The input rows collapsed to one per symbol with ``Score`` and
+        ``score_breakdown`` columns added.  Rows are sorted in descending score
+        order.
+    """
+
+    cfg = cfg or {}
+    latest = _select_latest(bars_df)
+    if latest.empty:
+        empty = latest.copy()
+        empty["Score"] = pd.Series(dtype="float64")
+        empty["score_breakdown"] = pd.Series(dtype="object")
+        return empty
+
+    components_map = dict(DEFAULT_COMPONENT_MAP)
+    for key, value in (cfg.get("components") or {}).items():
+        if not value:
+            continue
+        components_map[str(key)] = str(value)
+
+    weights = _normalise_config(cfg.get("weights"))
+
+    standardized_columns: Dict[str, pd.Series] = {}
+    for comp, column in components_map.items():
+        if column not in latest.columns:
+            standardized_columns[comp] = pd.Series(0.0, index=latest.index)
+            continue
+        standardized_columns[comp] = _standardize(latest[column])
+
+    standardized_df = pd.DataFrame(standardized_columns)
+
+    aligned_weights = pd.Series({key: weights.get(key, 0.0) for key in standardized_df.columns})
+    standardized_df = standardized_df.reindex(columns=aligned_weights.index, fill_value=0.0)
+
+    contributions = standardized_df.multiply(aligned_weights, axis=1)
+    score_series = contributions.sum(axis=1)
+
+    breakdown_strings = standardized_df.apply(
+        lambda row: json.dumps({k: round(float(v), 4) for k, v in sorted(row.items())}),
+        axis=1,
+    )
+
+    result = latest.copy()
+    result["Score"] = score_series.round(4)
+    result["score_breakdown"] = breakdown_strings
+    result.sort_values("Score", ascending=False, inplace=True)
+    result.reset_index(drop=True, inplace=True)
+    return result
+
+
+def _initialise_fail_counts() -> Dict[str, int]:
+    return {key: 0 for key in FAILURE_KEYS}
+
+
+def _resolve_float(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float, np.floating)):
+        if np.isnan(value):
+            return None
+        return float(value)
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if np.isnan(parsed):
+        return None
+    return parsed
+
+
+def apply_gates(
+    df: pd.DataFrame,
+    cfg: Optional[Mapping[str, object]] = None,
+) -> Tuple[pd.DataFrame, Dict[str, int], List[Dict[str, str]]]:
+    """Filter ``df`` according to the configured gate thresholds."""
+
+    cfg = cfg or {}
+    gates_cfg = dict(DEFAULT_GATES)
+    gates_cfg.update({key: cfg.get("gates", {}).get(key, gates_cfg.get(key)) for key in gates_cfg})
+
+    fail_counts = _initialise_fail_counts()
+    if df is None or df.empty:
+        return df.copy() if isinstance(df, pd.DataFrame) else pd.DataFrame(), fail_counts, []
+
+    gate_rows = []
+    reject_samples: List[Dict[str, str]] = []
+    history_col = str(gates_cfg.get("history_column") or "history")
+    min_history = _resolve_float(gates_cfg.get("min_history")) or 0.0
+    require_sma_stack = bool(gates_cfg.get("require_sma_stack", True))
+    min_rsi = _resolve_float(gates_cfg.get("min_rsi"))
+    max_rsi = _resolve_float(gates_cfg.get("max_rsi"))
+    min_adx = _resolve_float(gates_cfg.get("min_adx"))
+    min_aroon = _resolve_float(gates_cfg.get("min_aroon"))
+    min_volexp = _resolve_float(gates_cfg.get("min_volexp"))
+    max_gap = _resolve_float(gates_cfg.get("max_gap"))
+    max_liq_pen = _resolve_float(gates_cfg.get("max_liq_penalty"))
+    min_score = _resolve_float(gates_cfg.get("min_score"))
+
+    for idx, row in df.iterrows():
+        symbol = str(row.get("symbol", "")).strip().upper() or "<UNKNOWN>"
+
+        def record_failure(reason_key: str, reason_label: str) -> None:
+            fail_counts[reason_key] += 1
+            if len(reject_samples) < REJECT_SAMPLE_LIMIT:
+                reject_samples.append({"symbol": symbol, "reason": reason_label})
+
+        history_value = _resolve_float(row.get(history_col))
+        if min_history and (history_value is None or history_value < min_history):
+            record_failure("insufficient_history", "INSUFFICIENT_HISTORY")
+            continue
+
+        if min_score is not None:
+            score_value = _resolve_float(row.get("Score"))
+            if score_value is None:
+                record_failure("nan_data", "MISSING_SCORE")
+                continue
+            if score_value < min_score:
+                record_failure("failed_score", "LOW_SCORE")
+                continue
+
+        if require_sma_stack:
+            sma9 = _resolve_float(row.get("SMA9"))
+            ema20 = _resolve_float(row.get("EMA20"))
+            sma50 = _resolve_float(row.get("SMA50"))
+            sma100 = _resolve_float(row.get("SMA100"))
+            values = [sma9, ema20, sma50, sma100]
+            if any(v is None for v in values):
+                record_failure("nan_data", "MISSING_MA")
+                continue
+            if not (sma9 > ema20 > sma50 > sma100):
+                record_failure("failed_sma_stack", "FAILED_SMA_STACK")
+                continue
+
+        if min_rsi is not None or max_rsi is not None:
+            rsi_value = _resolve_float(row.get("RSI"))
+            if rsi_value is None:
+                record_failure("nan_data", "MISSING_RSI")
+                continue
+            if min_rsi is not None and rsi_value < min_rsi:
+                record_failure("failed_rsi", "LOW_RSI")
+                continue
+            if max_rsi is not None and rsi_value > max_rsi:
+                record_failure("failed_rsi", "HIGH_RSI")
+                continue
+
+        if min_adx is not None:
+            adx_value = _resolve_float(row.get("ADX"))
+            if adx_value is None:
+                record_failure("nan_data", "MISSING_ADX")
+                continue
+            if adx_value < min_adx:
+                record_failure("failed_adx", "LOW_ADX")
+                continue
+
+        if min_aroon is not None:
+            aroon_value = _resolve_float(row.get("AROON"))
+            if aroon_value is None:
+                record_failure("nan_data", "MISSING_AROON")
+                continue
+            if aroon_value < min_aroon:
+                record_failure("failed_aroon", "LOW_AROON")
+                continue
+
+        if min_volexp is not None:
+            volexp_value = _resolve_float(row.get("VOLexp"))
+            if volexp_value is None:
+                record_failure("nan_data", "MISSING_VOLEXP")
+                continue
+            if volexp_value < min_volexp:
+                record_failure("failed_volexp", "LOW_VOLEXP")
+                continue
+
+        if max_gap is not None:
+            gap_value = _resolve_float(row.get("GAPpen"))
+            if gap_value is None:
+                record_failure("nan_data", "MISSING_GAP")
+                continue
+            if gap_value > max_gap:
+                record_failure("failed_gap", "HIGH_GAP")
+                continue
+
+        if max_liq_pen is not None:
+            liq_value = _resolve_float(row.get("LIQpen"))
+            if liq_value is None:
+                record_failure("nan_data", "MISSING_LIQUIDITY")
+                continue
+            if liq_value > max_liq_pen:
+                record_failure("failed_liquidity", "LOW_LIQUIDITY")
+                continue
+
+        gate_rows.append(idx)
+
+    candidates_df = df.loc[gate_rows].copy()
+    candidates_df.sort_values("Score", ascending=False, inplace=True)
+    candidates_df.reset_index(drop=True, inplace=True)
+    return candidates_df, fail_counts, reject_samples
+
+
+__all__ = ["score_universe", "apply_gates", "DEFAULT_COMPONENT_MAP", "DEFAULT_WEIGHTS", "DEFAULT_GATES"]
+

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts.ranking import apply_gates, score_universe
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def _sample_features() -> pd.DataFrame:
+    rows = [
+        {
+            "symbol": "AAA",
+            "timestamp": pd.Timestamp("2024-01-05", tz="UTC"),
+            "TS": 1.2,
+            "MS": 0.8,
+            "BP": 0.15,
+            "PT": 0.2,
+            "MH": 0.1,
+            "RSI": 60.0,
+            "ADX": 30.0,
+            "AROON": 70.0,
+            "VCP": -0.5,
+            "VOLexp": 1.5,
+            "GAPpen": 0.02,
+            "LIQpen": 0.000001,
+            "SMA9": 11.0,
+            "EMA20": 10.0,
+            "SMA50": 9.5,
+            "SMA100": 9.0,
+            "history": 40,
+        },
+        {
+            "symbol": "BBB",
+            "timestamp": pd.Timestamp("2024-01-05", tz="UTC"),
+            "TS": 0.4,
+            "MS": -0.2,
+            "BP": -0.1,
+            "PT": 0.05,
+            "MH": -0.1,
+            "RSI": 44.0,
+            "ADX": 15.0,
+            "AROON": 30.0,
+            "VCP": 0.2,
+            "VOLexp": 0.7,
+            "GAPpen": 0.01,
+            "LIQpen": 0.00002,
+            "SMA9": 10.5,
+            "EMA20": 10.2,
+            "SMA50": 10.0,
+            "SMA100": 9.8,
+            "history": 35,
+        },
+        {
+            "symbol": "CCC",
+            "timestamp": pd.Timestamp("2024-01-05", tz="UTC"),
+            "TS": 0.9,
+            "MS": 0.6,
+            "BP": 0.05,
+            "PT": 0.12,
+            "MH": 0.05,
+            "RSI": 58.0,
+            "ADX": 25.0,
+            "AROON": 65.0,
+            "VCP": -0.2,
+            "VOLexp": 1.1,
+            "GAPpen": 0.03,
+            "LIQpen": 0.00003,
+            "SMA9": 12.0,
+            "EMA20": 11.8,
+            "SMA50": 11.5,
+            "SMA100": 11.6,
+            "history": 10,
+        },
+    ]
+    return pd.DataFrame(rows)
+
+
+def _load_ranker_cfg() -> dict:
+    cfg_path = Path("config/ranker.yml")
+    if not cfg_path.exists():
+        return {}
+    try:
+        import yaml
+
+        with cfg_path.open("r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle) or {}
+    except Exception:
+        return {}
+
+
+def test_score_shapes():
+    cfg = _load_ranker_cfg()
+    ranked = score_universe(_sample_features(), cfg)
+    assert "Score" in ranked.columns
+    assert "score_breakdown" in ranked.columns
+    assert ranked["Score"].is_monotonic_decreasing
+    parsed = json.loads(ranked.loc[0, "score_breakdown"])
+    assert isinstance(parsed, dict)
+    assert "trend" in parsed
+
+
+def test_apply_gates_counts():
+    cfg = _load_ranker_cfg()
+    ranked = score_universe(_sample_features(), cfg)
+    candidates, fail_counts, rejects = apply_gates(ranked, cfg)
+    total_failures = sum(fail_counts.values())
+    assert total_failures + len(candidates) == len(ranked)
+    assert len(rejects) <= len(ranked)


### PR DESCRIPTION
## Summary
- add a standalone ranking module that encapsulates scoring with configurable component weights and detailed gate filtering
- provide a default `config/ranker.yml` that records the baseline weights, component mapping, and gating thresholds
- add unit tests that exercise the scoring output schema and verify gate failure accounting

## Testing
- pytest tests/test_ranking.py

------
https://chatgpt.com/codex/tasks/task_e_68e6918b7ae88331833ef12df256e2dc