### PR TITLE
Add gate preset CLI options and expose gating metrics

### DIFF
--- a/config/ranker.yml
+++ b/config/ranker.yml
@@ -60,7 +60,7 @@ presets:
     max_liq_penalty: 0.00001
   aggressive:
     min_rsi: 49
-    max_rsi: 70
+    max_rsi: null
     min_adx: 14
     min_aroon: 45
     min_volexp: 0.6

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from scripts.ranking import apply_gates, score_universe
+from scripts.ranking import FAILURE_KEYS, apply_gates, score_universe
 
 
 pytestmark = pytest.mark.alpaca_optional
@@ -107,6 +107,6 @@ def test_apply_gates_counts():
     cfg = _load_ranker_cfg()
     ranked = score_universe(_sample_features(), cfg)
     candidates, fail_counts, rejects = apply_gates(ranked, cfg)
-    total_failures = sum(fail_counts.values())
+    total_failures = sum(int(fail_counts.get(key, 0)) for key in FAILURE_KEYS)
     assert total_failures + len(candidates) == len(ranked)
     assert len(rejects) <= len(ranked)

--- a/tests/test_screener_unknown_exchange.py
+++ b/tests/test_screener_unknown_exchange.py
@@ -79,6 +79,7 @@ def test_screener_skips_unknown_exchanges(tmp_path):
         skips,
         reject_samples,
         gate_counters,
+        ranker_cfg,
     ) = screener.run_screener(
         df,
         top_n=5,
@@ -103,6 +104,7 @@ def test_screener_skips_unknown_exchanges(tmp_path):
         gate_counters=gate_counters,
         fetch_metrics={},
         asset_metrics={},
+        ranker_cfg=ranker_cfg,
     )
 
     top_path = tmp_path / "data" / "top_candidates.csv"
@@ -116,17 +118,22 @@ def test_screener_skips_unknown_exchanges(tmp_path):
     assert metrics["status"] == "ok"
     assert "reject_samples" in metrics
     assert "gate_fail_counts" in metrics
-    assert set(
-        [
-            "failed_sma_stack",
-            "failed_rsi",
-            "failed_cross",
-            "failed_macd_hist",
-            "failed_adx",
-            "failed_aroon",
-            "nan_data",
-            "insufficient_history",
-        ]
-    ).issubset(metrics["gate_fail_counts"].keys())
+    expected_gate_keys = {
+        "failed_sma_stack",
+        "failed_rsi",
+        "failed_adx",
+        "failed_aroon",
+        "failed_volexp",
+        "failed_gap",
+        "failed_liquidity",
+        "nan_data",
+        "insufficient_history",
+        "gate_preset",
+        "gate_relax_mode",
+        "gate_total_evaluated",
+        "gate_total_passed",
+        "gate_total_failed",
+    }
+    assert expected_gate_keys.issubset(metrics["gate_fail_counts"].keys())
     if not top_df.empty:
         assert int(top_df["universe_count"].iloc[0]) == stats["symbols_in"]


### PR DESCRIPTION
## Summary
- add --gate-preset/--relax-gates CLI switches and thread preset metadata through the screener configuration
- extend gate failure accounting to include preset/relax details and total tallies, and relax the aggressive preset RSI cap
- refresh screener tests to assert gate metadata is written to metrics

## Testing
- pytest tests/test_ranking.py::test_apply_gates_counts
- pytest tests/test_screener_api_mode.py::test_screener_api_mode_creates_outputs


------
https://chatgpt.com/codex/tasks/task_e_68e69bd5ca3883319decadabfe663181