### PR TITLE
Add robust nightly feature engine and tests

### DIFF
--- a/scripts/features.py
+++ b/scripts/features.py
@@ -1,16 +1,18 @@
-"""Feature engineering helpers for the screener pipeline."""
+"""Feature engineering helpers for the nightly screener."""
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List
+from typing import Iterable, Mapping, Optional, Sequence
 
 import numpy as np
 import pandas as pd
 
-from .utils.stats import robust_z, rolling_apply, rolling_max, rolling_mean, rolling_min
+from .utils.stats import robust_z
 
 
-REQUIRED_FEATURE_COLUMNS: List[str] = [
+NUMERIC_COLUMNS: Sequence[str] = ("open", "high", "low", "close", "volume")
+
+CORE_FEATURE_COLUMNS: Sequence[str] = (
     "TS",
     "MS",
     "BP",
@@ -21,25 +23,45 @@ REQUIRED_FEATURE_COLUMNS: List[str] = [
     "AROON",
     "VCP",
     "VOLexp",
+)
+
+PENALTY_COLUMNS: Sequence[str] = (
     "GAPpen",
     "LIQpen",
+)
+
+INTERMEDIATE_COLUMNS: Sequence[str] = (
     "ATR14",
     "SMA9",
     "EMA20",
     "SMA50",
     "SMA100",
-    "H20",
-    "L20",
-]
+    "RSI14",
+    "MACD_HIST",
+    "AROON_UP",
+    "ADX",
+)
+
+Z_SCORE_COLUMNS: Sequence[str] = tuple(f"{col}_z" for col in (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS))
 
 
-def _get_min_history(cfg: Dict) -> int:
-    gates = cfg.get("gates", {}) if isinstance(cfg, dict) else {}
-    value = gates.get("min_history", 0)
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 0
+def _dedupe(seq: Sequence[str]) -> Sequence[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in seq:
+        if item not in seen:
+            seen.add(item)
+            ordered.append(item)
+    return tuple(ordered)
+
+
+REQUIRED_FEATURE_COLUMNS: Sequence[str] = _dedupe(
+    (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS, *INTERMEDIATE_COLUMNS)
+)
+
+ALL_FEATURE_COLUMNS: Sequence[str] = _dedupe(
+    (*REQUIRED_FEATURE_COLUMNS, *Z_SCORE_COLUMNS)
+)
 
 
 def _initialised_frame(columns: Iterable[str]) -> pd.DataFrame:
@@ -52,81 +74,88 @@ def _initialised_frame(columns: Iterable[str]) -> pd.DataFrame:
     return frame[cols]
 
 
-def compute_all_features(bars_df: pd.DataFrame, cfg) -> pd.DataFrame:
-    """Compute the full feature set for the screener.
+def _get_min_history(cfg: Optional[Mapping[str, object]]) -> int:
+    gates = cfg.get("gates") if isinstance(cfg, Mapping) else None
+    if isinstance(gates, Mapping):
+        value = gates.get("min_history", 0)
+    else:
+        value = 0
+    try:
+        return int(value) if int(value) > 0 else 0
+    except (TypeError, ValueError):
+        return 0
 
-    Parameters
-    ----------
-    bars_df:
-        Flat DataFrame containing columns ``symbol``, ``timestamp``, ``open``,
-        ``high``, ``low``, ``close`` and ``volume``.
-    cfg:
-        Configuration mapping.  ``cfg["gates"]["min_history"]`` determines
-        how many historical rows per symbol are required before emitting
-        features.
-    """
 
+def _prepare_bars_frame(bars_df: pd.DataFrame) -> pd.DataFrame:
     if bars_df is None or bars_df.empty:
-        return _initialised_frame(REQUIRED_FEATURE_COLUMNS)
+        return pd.DataFrame(columns=["symbol", "timestamp", *NUMERIC_COLUMNS])
 
     df = bars_df.copy()
+    df["symbol"] = df["symbol"].astype("string").str.strip().str.upper()
     df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    for column in NUMERIC_COLUMNS:
+        df[column] = pd.to_numeric(df[column], errors="coerce")
+    df = df.dropna(subset=["symbol", "timestamp"])
+    df = df[df["symbol"] != ""]
     df = df.sort_values(["symbol", "timestamp"]).reset_index(drop=True)
+    return df
 
-    grouped = df.groupby("symbol", group_keys=False)
-    close_g = grouped["close"]
-    high_g = grouped["high"]
-    low_g = grouped["low"]
-    volume_g = grouped["volume"]
 
-    df["SMA9"] = rolling_mean(close_g, 9, min_periods=9)
-    df["EMA20"] = close_g.transform(lambda s: s.ewm(span=20, adjust=False).mean())
-    df["SMA50"] = rolling_mean(close_g, 50, min_periods=50)
-    df["SMA100"] = rolling_mean(close_g, 100, min_periods=100)
-    df["H20"] = rolling_max(high_g, 20, min_periods=20)
-    df["L20"] = rolling_min(low_g, 20, min_periods=20)
-
-    prev_close = close_g.shift(1)
-    df["prev_close"] = prev_close
-
-    tr_components = pd.concat(
-        [
-            df["high"] - df["low"],
-            (df["high"] - prev_close).abs(),
-            (df["low"] - prev_close).abs(),
-        ],
-        axis=1,
-    )
-    df["TR"] = tr_components.max(axis=1)
+def _compute_atr(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    prev_close = grouped["close"].shift(1)
+    high_low = df["high"] - df["low"]
+    high_prev = (df["high"] - prev_close).abs()
+    low_prev = (df["low"] - prev_close).abs()
+    tr = np.maximum.reduce([
+        high_low.fillna(0.0).to_numpy(),
+        high_prev.fillna(0.0).to_numpy(),
+        low_prev.fillna(0.0).to_numpy(),
+    ])
+    df["TR"] = tr
     df["ATR14"] = grouped["TR"].transform(lambda s: s.rolling(14, min_periods=14).mean())
 
-    delta = close_g.diff()
-    df["gain"] = delta.clip(lower=0.0)
-    df["loss"] = -delta.clip(upper=0.0)
-    avg_gain = grouped["gain"].transform(
-        lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
-    )
-    avg_loss = grouped["loss"].transform(
-        lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
-    )
-    rs = avg_gain / avg_loss.replace(0.0, np.nan)
-    df["RSI"] = 100 - (100 / (1 + rs))
 
-    up_move = high_g.diff()
-    down_move = grouped["low"].shift(1) - df["low"]
+def _compute_rsi(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    def _rsi(series: pd.Series) -> pd.Series:
+        delta = series.diff()
+        gain = delta.clip(lower=0.0)
+        loss = -delta.clip(upper=0.0)
+        avg_gain = gain.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
+        avg_loss = loss.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
+        rs = avg_gain / avg_loss.replace(0.0, np.nan)
+        rsi = 100 - (100 / (1 + rs))
+        rsi = rsi.where(avg_loss != 0, 100.0)
+        rsi = rsi.where(avg_gain != 0, 0.0)
+        both_zero = (avg_gain == 0) & (avg_loss == 0)
+        rsi = rsi.where(~both_zero, 50.0)
+        return rsi.clip(lower=0.0, upper=100.0)
+
+    rsi = grouped["close"].apply(_rsi)
+    df["RSI14"] = rsi.reset_index(level=0, drop=True)
+
+
+def _compute_adx(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    high = grouped["high"]
+    low = grouped["low"]
+
+    up_move = high.diff()
+    down_move = low.shift(1) - df["low"]
     plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
     minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
+
     df["plus_dm"] = plus_dm
     df["minus_dm"] = minus_dm
+
     plus_smoothed = grouped["plus_dm"].transform(
         lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
     )
     minus_smoothed = grouped["minus_dm"].transform(
         lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
     )
-    atr_safe = df["ATR14"].replace(0.0, np.nan)
-    plus_di = 100 * (plus_smoothed / atr_safe)
-    minus_di = 100 * (minus_smoothed / atr_safe)
+
+    atr = df["ATR14"].replace(0.0, np.nan)
+    plus_di = 100 * (plus_smoothed / atr)
+    minus_di = 100 * (minus_smoothed / atr)
     di_sum = plus_di + minus_di
     dx = (plus_di - minus_di).abs() / di_sum.replace(0.0, np.nan)
     df["DX"] = dx * 100
@@ -134,48 +163,142 @@ def compute_all_features(bars_df: pd.DataFrame, cfg) -> pd.DataFrame:
         lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
     )
 
-    aroon_period = 25
-    high_rank = rolling_apply(high_g, aroon_period, np.argmax, min_periods=aroon_period)
-    low_rank = rolling_apply(low_g, aroon_period, np.argmin, min_periods=aroon_period)
-    periods_since_high = (aroon_period - 1) - high_rank
-    periods_since_low = (aroon_period - 1) - low_rank
-    aroon_up = 100 * (aroon_period - periods_since_high) / aroon_period
-    aroon_down = 100 * (aroon_period - periods_since_low) / aroon_period
+
+def _compute_aroon(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    period = 25
+
+    def _rolling_argmax(values: np.ndarray) -> float:
+        return float(np.argmax(values))
+
+    def _rolling_argmin(values: np.ndarray) -> float:
+        return float(np.argmin(values))
+
+    high_rank = (
+        grouped["high"].rolling(window=period, min_periods=period).apply(_rolling_argmax, raw=True)
+    )
+    low_rank = (
+        grouped["low"].rolling(window=period, min_periods=period).apply(_rolling_argmin, raw=True)
+    )
+
+    high_rank = high_rank.reset_index(level=0, drop=True)
+    low_rank = low_rank.reset_index(level=0, drop=True)
+
+    periods_since_high = (period - 1) - high_rank
+    periods_since_low = (period - 1) - low_rank
+
+    aroon_up = 100 * (period - periods_since_high) / period
+    aroon_down = 100 * (period - periods_since_low) / period
+
+    df["AROON_UP"] = aroon_up
+    df["AROON_DOWN"] = aroon_down
     df["AROON"] = aroon_up - aroon_down
 
-    df["momentum"] = close_g.pct_change(periods=5)
-    df["trend_ratio"] = np.where(df["SMA50"].abs() > 0, df["close"] / df["SMA50"] - 1, np.nan)
-    df["atr_ratio"] = df["ATR14"] / df["close"].replace(0.0, np.nan)
 
-    df["TS"] = grouped["trend_ratio"].transform(robust_z)
-    df["MS"] = grouped["momentum"].transform(robust_z)
-    df["VCP"] = grouped["atr_ratio"].transform(robust_z)
+def _compute_moving_averages(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    close = grouped["close"]
+    df["SMA9"] = close.transform(lambda s: s.rolling(9, min_periods=9).mean())
+    df["EMA20"] = close.transform(lambda s: s.ewm(span=20, adjust=False).mean())
+    df["SMA50"] = close.transform(lambda s: s.rolling(50, min_periods=50).mean())
+    df["SMA100"] = close.transform(lambda s: s.rolling(100, min_periods=100).mean())
 
-    rolling_vol = volume_g.transform(lambda s: s.rolling(20, min_periods=20).mean())
+
+def _compute_macd(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    def _macd_hist(series: pd.Series) -> pd.Series:
+        ema12 = series.ewm(span=12, adjust=False).mean()
+        ema26 = series.ewm(span=26, adjust=False).mean()
+        macd_line = ema12 - ema26
+        signal = macd_line.ewm(span=9, adjust=False).mean()
+        return macd_line - signal
+
+    macd_hist = grouped["close"].apply(_macd_hist)
+    df["MACD_HIST"] = macd_hist.reset_index(level=0, drop=True)
+
+
+def _compute_volume_features(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    rolling_vol = grouped["volume"].transform(lambda s: s.rolling(20, min_periods=20).mean())
     df["VOLexp"] = df["volume"] / rolling_vol
 
-    df["dollar_volume"] = df["close"] * df["volume"]
-    rolling_dollar = grouped["dollar_volume"].transform(
+    dollar_volume = df["close"] * df["volume"]
+    rolling_dollar = dollar_volume.groupby(df["symbol"]).transform(
         lambda s: s.rolling(20, min_periods=20).mean()
     )
-    df["LIQpen"] = np.where(rolling_dollar > 0, 1.0 / rolling_dollar, np.nan)
+    liq_pen = 1.0 / rolling_dollar.replace(0.0, np.nan)
+    df["LIQpen"] = pd.Series(liq_pen, index=df.index)
 
+
+def _compute_price_features(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
+    close = grouped["close"]
+    high = grouped["high"]
+
+    rolling_high = high.transform(lambda s: s.rolling(20, min_periods=20).max())
+
+    df["TS"] = np.where(df["SMA50"].abs() > 0, df["close"] / df["SMA50"] - 1, np.nan)
+    df["MS"] = close.transform(lambda s: s.pct_change(periods=5))
+    df["BP"] = np.where(rolling_high > 0, df["close"] / rolling_high - 1, np.nan)
+    df["PT"] = np.where(df["SMA50"].abs() > 0, df["SMA9"] / df["SMA50"] - 1, np.nan)
+    df["MH"] = np.where(df["SMA100"].abs() > 0, df["SMA50"] / df["SMA100"] - 1, np.nan)
+
+    atr_pct = (df["ATR14"] / df["close"]).replace([np.inf, -np.inf], np.nan)
+    df["VCP"] = -atr_pct
+
+    prev_close = grouped["close"].shift(1)
     gap = (df["open"] - prev_close) / prev_close
     df["GAPpen"] = gap.replace([np.inf, -np.inf], np.nan).abs().fillna(0.0)
 
-    df["BP"] = np.where(df["H20"] > 0, df["close"] / df["H20"] - 1, np.nan)
-    df["PT"] = np.where(df["SMA50"] > 0, df["SMA9"] / df["SMA50"] - 1, np.nan)
-    df["MH"] = np.where(df["SMA100"] > 0, df["SMA50"] / df["SMA100"] - 1, np.nan)
+    df["RSI"] = df["RSI14"]
+
+
+def _cleanup_columns(df: pd.DataFrame) -> None:
+    for column in ["TR", "DX", "plus_dm", "minus_dm"]:
+        if column in df.columns:
+            df.drop(columns=column, inplace=True)
+
+
+def compute_all_features(bars_df: pd.DataFrame, cfg: Optional[Mapping[str, object]]) -> pd.DataFrame:
+    """Compute the full feature matrix for the screener."""
+
+    df = _prepare_bars_frame(bars_df)
+    if df.empty:
+        return _initialised_frame(ALL_FEATURE_COLUMNS)
+
+    grouped = df.groupby("symbol", group_keys=False)
+
+    _compute_moving_averages(df, grouped)
+    _compute_atr(df, grouped)
+    _compute_rsi(df, grouped)
+    _compute_adx(df, grouped)
+    _compute_aroon(df, grouped)
+    _compute_macd(df, grouped)
+    _compute_volume_features(df, grouped)
+    _compute_price_features(df, grouped)
+
+    _cleanup_columns(df)
+
+    for column in (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS):
+        if column in df.columns:
+            df[f"{column}_z"] = grouped[column].transform(robust_z)
+
+    df.replace([np.inf, -np.inf], np.nan, inplace=True)
 
     counts = grouped.cumcount() + 1
-    min_history = _get_min_history(cfg or {})
+    min_history = _get_min_history(cfg)
     if min_history > 0:
         df = df[counts >= min_history]
 
-    result = df.dropna(subset=REQUIRED_FEATURE_COLUMNS).copy()
-    keep_columns = ["symbol", "timestamp", *REQUIRED_FEATURE_COLUMNS]
-    result = result[keep_columns]
-    result.reset_index(drop=True, inplace=True)
+    df = df.dropna(subset=REQUIRED_FEATURE_COLUMNS)
 
+    result = df[["symbol", "timestamp", *ALL_FEATURE_COLUMNS]].copy()
+    result.sort_values(["symbol", "timestamp"], inplace=True)
+    result.reset_index(drop=True, inplace=True)
     return result
 
+
+__all__ = [
+    "CORE_FEATURE_COLUMNS",
+    "PENALTY_COLUMNS",
+    "INTERMEDIATE_COLUMNS",
+    "Z_SCORE_COLUMNS",
+    "REQUIRED_FEATURE_COLUMNS",
+    "ALL_FEATURE_COLUMNS",
+    "compute_all_features",
+]

--- a/scripts/ranking.py
+++ b/scripts/ranking.py
@@ -16,6 +16,8 @@ from typing import Dict, List, Mapping, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 
+from .features import compute_all_features
+
 
 DEFAULT_COMPONENT_MAP: Mapping[str, str] = {
     "trend": "TS",
@@ -355,5 +357,12 @@ def apply_gates(
     return candidates_df, gate_counts, reject_samples
 
 
-__all__ = ["score_universe", "apply_gates", "DEFAULT_COMPONENT_MAP", "DEFAULT_WEIGHTS", "DEFAULT_GATES"]
+__all__ = [
+    "score_universe",
+    "apply_gates",
+    "DEFAULT_COMPONENT_MAP",
+    "DEFAULT_WEIGHTS",
+    "DEFAULT_GATES",
+    "compute_all_features",
+]
 

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -25,7 +25,7 @@ try:  # pragma: no cover - preferred module execution path
     from .utils.models import BarData, classify_exchange, KNOWN_EQUITY
     from .utils.env import trading_base_url
     from .utils.frame_guards import ensure_symbol_column
-    from .features import compute_all_features, REQUIRED_FEATURE_COLUMNS
+    from .features import ALL_FEATURE_COLUMNS, compute_all_features, REQUIRED_FEATURE_COLUMNS
     from .ranking import (
         apply_gates,
         score_universe,
@@ -44,7 +44,11 @@ except Exception:  # pragma: no cover - fallback for direct script execution
     from scripts.utils.models import BarData, classify_exchange, KNOWN_EQUITY  # type: ignore
     from scripts.utils.env import trading_base_url  # type: ignore
     from scripts.utils.frame_guards import ensure_symbol_column  # type: ignore
-    from scripts.features import compute_all_features, REQUIRED_FEATURE_COLUMNS  # type: ignore
+    from scripts.features import (  # type: ignore
+        ALL_FEATURE_COLUMNS,
+        compute_all_features,
+        REQUIRED_FEATURE_COLUMNS,
+    )
     from scripts.ranking import (  # type: ignore
         apply_gates,
         score_universe,
@@ -1575,7 +1579,7 @@ def build_enriched_bars(bars_df: pd.DataFrame, cfg: Mapping[str, object]) -> pd.
         columns = [
             "symbol",
             "timestamp",
-            *REQUIRED_FEATURE_COLUMNS,
+            *ALL_FEATURE_COLUMNS,
             "close",
             "volume",
             "exchange",
@@ -1603,7 +1607,7 @@ def build_enriched_bars(bars_df: pd.DataFrame, cfg: Mapping[str, object]) -> pd.
         columns = [
             "symbol",
             "timestamp",
-            *REQUIRED_FEATURE_COLUMNS,
+            *ALL_FEATURE_COLUMNS,
             "close",
             "volume",
             "exchange",

--- a/tests/test_features_shapes.py
+++ b/tests/test_features_shapes.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.features import ALL_FEATURE_COLUMNS, compute_all_features
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def _make_synthetic_bars(rows: int = 220) -> pd.DataFrame:
+    symbols = ["AAA", "BBB"]
+    frames = []
+    for symbol in symbols:
+        idx = pd.date_range("2023-01-01", periods=rows, freq="B", tz="UTC")
+        base = np.linspace(10, 50, num=rows)
+        noise = np.sin(np.linspace(0, np.pi * 4, num=rows))
+        close = base + noise
+        open_ = close + np.random.default_rng(0).normal(0, 0.5, size=rows)
+        high = np.maximum(open_, close) + 0.5
+        low = np.minimum(open_, close) - 0.5
+        volume = np.linspace(100_000, 250_000, num=rows) * (1 + 0.1 * noise)
+        frames.append(
+            pd.DataFrame(
+                {
+                    "symbol": symbol,
+                    "timestamp": idx,
+                    "open": open_,
+                    "high": high,
+                    "low": low,
+                    "close": close,
+                    "volume": volume,
+                }
+            )
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
+def test_feature_columns_and_no_nan_zscores():
+    bars = _make_synthetic_bars()
+    features = compute_all_features(bars, cfg={"gates": {"min_history": 50}})
+    assert not features.empty
+
+    missing = [col for col in ALL_FEATURE_COLUMNS if col not in features.columns]
+    assert missing == []
+
+    z_columns = [col for col in features.columns if col.endswith("_z")]
+    assert z_columns, "expected at least one z-score column"
+    z_block = features[z_columns]
+    assert not z_block.isna().any().any()
+
+    assert features.groupby("symbol").size().min() > 0

--- a/tests/test_robust_z.py
+++ b/tests/test_robust_z.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.utils.stats import robust_z
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_robust_z_clips_to_range():
+    series = pd.Series(np.linspace(-10, 10, num=41))
+    clipped = robust_z(series, clip=2.5)
+    assert np.isfinite(clipped).all()
+    assert clipped.max() <= 2.5 + 1e-9
+    assert clipped.min() >= -2.5 - 1e-9
+
+
+def test_robust_z_symmetry():
+    data = pd.Series([-5.0, -1.0, 0.0, 1.0, 5.0])
+    z_scores = robust_z(data)
+    assert np.isclose(z_scores.iloc[0], -z_scores.iloc[-1])
+    assert z_scores.iloc[2] == 0


### PR DESCRIPTION
## Summary
- replace the screener feature pipeline with a vectorised implementation that emits the v1 core, penalty, intermediate and z-score columns
- expose the updated feature set through ranking and screener utilities so empty frames still carry the new schema
- add focused unit tests covering feature frame shapes and the robust z-score helper

## Testing
- pytest tests/test_features_shapes.py tests/test_robust_z.py

------
https://chatgpt.com/codex/tasks/task_e_68e6bc18e5ec8331bd53a69b5a2eb10b