### PR TITLE
Feature Engine v1: vectorized nightly features and robust z-scores

### DIFF
--- a/scripts/features.py
+++ b/scripts/features.py
@@ -1,16 +1,42 @@
-"""Feature engineering helpers for the nightly screener."""
+"""Vectorised technical feature engineering for the nightly screener."""
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, Optional, Sequence
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence
 
 import numpy as np
 import pandas as pd
 
-from .utils.stats import robust_z
+
+# --------------------------------------------------------------------------------------
+# Config & constants
+# --------------------------------------------------------------------------------------
 
 
-NUMERIC_COLUMNS: Sequence[str] = ("open", "high", "low", "close", "volume")
+@dataclass(frozen=True)
+class FeatureConfig:
+    min_history: int = 180
+    rsi_period: int = 14
+    macd_fast: int = 12
+    macd_slow: int = 26
+    macd_signal: int = 9
+    atr_period: int = 14
+    aroon_period: int = 25
+    adx_period: int = 14
+    sma_fast: int = 9
+    ema_mid: int = 20
+    sma_mid: int = 50
+    sma_slow: int = 100
+    breakout_lookback: int = 20
+    vcp_long: int = 90
+    vol_short: int = 10
+    vol_long: int = 90
+    robust_clip: float = 3.0  # z-score clip
+
+
+DEFAULT_FEATURE_CONFIG = FeatureConfig()
+
 
 CORE_FEATURE_COLUMNS: Sequence[str] = (
     "TS",
@@ -36,18 +62,24 @@ INTERMEDIATE_COLUMNS: Sequence[str] = (
     "EMA20",
     "SMA50",
     "SMA100",
-    "RSI14",
-    "MACD_HIST",
+    "H20",
+    "L20",
+    "+DI",
+    "-DI",
     "AROON_UP",
-    "ADX",
+    "AROON_DN",
+    "RSI14",
+    "MACD",
+    "MACD_SIGNAL",
+    "MACD_HIST",
+    "ADX14",
+    "AROON_DIFF",
 )
-
-Z_SCORE_COLUMNS: Sequence[str] = tuple(f"{col}_z" for col in (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS))
 
 
 def _dedupe(seq: Sequence[str]) -> Sequence[str]:
     seen: set[str] = set()
-    ordered: list[str] = []
+    ordered: List[str] = []
     for item in seq:
         if item not in seen:
             seen.add(item)
@@ -55,250 +87,345 @@ def _dedupe(seq: Sequence[str]) -> Sequence[str]:
     return tuple(ordered)
 
 
-REQUIRED_FEATURE_COLUMNS: Sequence[str] = _dedupe(
-    (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS, *INTERMEDIATE_COLUMNS)
-)
+Z_SCORE_COLUMNS: Sequence[str] = tuple(f"{col}_z" for col in (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS))
 
-ALL_FEATURE_COLUMNS: Sequence[str] = _dedupe(
-    (*REQUIRED_FEATURE_COLUMNS, *Z_SCORE_COLUMNS)
-)
+REQUIRED_FEATURE_COLUMNS: Sequence[str] = _dedupe((*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS, *INTERMEDIATE_COLUMNS))
+
+ALL_FEATURE_COLUMNS: Sequence[str] = _dedupe((*REQUIRED_FEATURE_COLUMNS, *Z_SCORE_COLUMNS))
 
 
-def _initialised_frame(columns: Iterable[str]) -> pd.DataFrame:
-    cols = ["symbol", "timestamp", *columns]
-    frame = pd.DataFrame({col: pd.Series(dtype="float64") for col in cols})
-    frame = frame.assign(
-        symbol=pd.Series(dtype="object"),
-        timestamp=pd.Series(dtype="datetime64[ns]"),
-    )
-    return frame[cols]
+# --------------------------------------------------------------------------------------
+# Utility / robust statistics
+# --------------------------------------------------------------------------------------
 
 
-def _get_min_history(cfg: Optional[Mapping[str, object]]) -> int:
-    gates = cfg.get("gates") if isinstance(cfg, Mapping) else None
-    if isinstance(gates, Mapping):
-        value = gates.get("min_history", 0)
+def _mad(x: pd.Series, eps: float = 1e-9) -> pd.Series:
+    med = x.median()
+    return (x - med).abs().median() + eps
+
+
+def robust_z(x: pd.Series, clip: float = 3.0) -> pd.Series:
+    """
+    MAD-based z-score centered at median. Clipped to [-clip, clip].
+    """
+
+    if x.empty:
+        return x.copy()
+    med = x.median()
+    mad = _mad(x)
+    if mad == 0 or not np.isfinite(mad):
+        z = x - med
     else:
-        value = 0
-    try:
-        return int(value) if int(value) > 0 else 0
-    except (TypeError, ValueError):
-        return 0
+        z = 0.6745 * (x - med) / mad
+    z = z.clip(lower=-clip, upper=clip)
+    return z
 
 
-def _prepare_bars_frame(bars_df: pd.DataFrame) -> pd.DataFrame:
-    if bars_df is None or bars_df.empty:
-        return pd.DataFrame(columns=["symbol", "timestamp", *NUMERIC_COLUMNS])
+# --------------------------------------------------------------------------------------
+# Rolling indicator helpers (vectorized)
+# NOTE: We always keep 'symbol' as a column and use groupby(..., as_index=False, group_keys=False)
+# --------------------------------------------------------------------------------------
 
-    df = bars_df.copy()
-    df["symbol"] = df["symbol"].astype("string").str.strip().str.upper()
-    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
-    for column in NUMERIC_COLUMNS:
-        df[column] = pd.to_numeric(df[column], errors="coerce")
-    df = df.dropna(subset=["symbol", "timestamp"])
-    df = df[df["symbol"] != ""]
-    df = df.sort_values(["symbol", "timestamp"]).reset_index(drop=True)
+
+def _gb(df: pd.DataFrame):
+    return df.groupby("symbol", as_index=False, group_keys=False)
+
+
+def sma(df: pd.DataFrame, col: str, n: int, out: str) -> pd.DataFrame:
+    df[out] = _gb(df)[col].transform(lambda s: s.rolling(n, min_periods=1).mean())
     return df
 
 
-def _compute_atr(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    prev_close = grouped["close"].shift(1)
-    high_low = df["high"] - df["low"]
-    high_prev = (df["high"] - prev_close).abs()
-    low_prev = (df["low"] - prev_close).abs()
-    tr = np.maximum.reduce([
-        high_low.fillna(0.0).to_numpy(),
-        high_prev.fillna(0.0).to_numpy(),
-        low_prev.fillna(0.0).to_numpy(),
-    ])
-    df["TR"] = tr
-    df["ATR14"] = grouped["TR"].transform(lambda s: s.rolling(14, min_periods=14).mean())
+def ema(df: pd.DataFrame, col: str, n: int, out: str) -> pd.DataFrame:
+    df[out] = _gb(df)[col].transform(lambda s: s.ewm(span=n, adjust=False, min_periods=1).mean())
+    return df
 
 
-def _compute_rsi(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    def _rsi(series: pd.Series) -> pd.Series:
-        delta = series.diff()
-        gain = delta.clip(lower=0.0)
-        loss = -delta.clip(upper=0.0)
-        avg_gain = gain.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
-        avg_loss = loss.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
-        rs = avg_gain / avg_loss.replace(0.0, np.nan)
-        rsi = 100 - (100 / (1 + rs))
-        rsi = rsi.where(avg_loss != 0, 100.0)
-        rsi = rsi.where(avg_gain != 0, 0.0)
-        both_zero = (avg_gain == 0) & (avg_loss == 0)
-        rsi = rsi.where(~both_zero, 50.0)
-        return rsi.clip(lower=0.0, upper=100.0)
+def rsi(df: pd.DataFrame, n: int, out: str) -> pd.DataFrame:
+    def _rsi(x: pd.Series) -> pd.Series:
+        delta = x.diff()
+        up = np.where(delta > 0, delta, 0.0)
+        dn = np.where(delta < 0, -delta, 0.0)
+        roll_up = pd.Series(up, index=x.index).ewm(alpha=1 / n, adjust=False).mean()
+        roll_dn = pd.Series(dn, index=x.index).ewm(alpha=1 / n, adjust=False).mean()
+        rs = roll_up / (roll_dn.replace(0, np.nan))
+        return 100 - (100 / (1 + rs))
 
-    rsi = grouped["close"].apply(_rsi)
-    df["RSI14"] = rsi.reset_index(level=0, drop=True)
+    df[out] = _gb(df)["close"].transform(_rsi)
+    return df
 
 
-def _compute_adx(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    high = grouped["high"]
-    low = grouped["low"]
-
-    up_move = high.diff()
-    down_move = low.shift(1) - df["low"]
-    plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
-    minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
-
-    df["plus_dm"] = plus_dm
-    df["minus_dm"] = minus_dm
-
-    plus_smoothed = grouped["plus_dm"].transform(
-        lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
+def macd(
+    df: pd.DataFrame,
+    fast: int,
+    slow: int,
+    signal: int,
+    out_macd: str,
+    out_signal: str,
+    out_hist: str,
+) -> pd.DataFrame:
+    ema_fast = _gb(df)["close"].transform(lambda s: s.ewm(span=fast, adjust=False, min_periods=1).mean())
+    ema_slow = _gb(df)["close"].transform(lambda s: s.ewm(span=slow, adjust=False, min_periods=1).mean())
+    macd_line = ema_fast - ema_slow
+    signal_line = _gb(pd.DataFrame({"symbol": df["symbol"], "macd": macd_line}))["macd"].transform(
+        lambda s: s.ewm(span=signal, adjust=False, min_periods=1).mean()
     )
-    minus_smoothed = grouped["minus_dm"].transform(
-        lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
+    df[out_macd] = macd_line
+    df[out_signal] = signal_line
+    df[out_hist] = macd_line - signal_line
+    return df
+
+
+def true_range(high: pd.Series, low: pd.Series, prev_close: pd.Series) -> pd.Series:
+    tr1 = high - low
+    tr2 = (high - prev_close).abs()
+    tr3 = (low - prev_close).abs()
+    return pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+
+
+def atr(df: pd.DataFrame, n: int, out: str) -> pd.DataFrame:
+    prev_close = _gb(df)["close"].shift(1)
+    tr = true_range(df["high"], df["low"], prev_close)
+    df[out] = _gb(pd.DataFrame({"symbol": df["symbol"], "tr": tr}))["tr"].transform(
+        lambda s: s.ewm(alpha=1 / n, adjust=False, min_periods=1).mean()
     )
+    return df
 
-    atr = df["ATR14"].replace(0.0, np.nan)
-    plus_di = 100 * (plus_smoothed / atr)
-    minus_di = 100 * (minus_smoothed / atr)
-    di_sum = plus_di + minus_di
-    dx = (plus_di - minus_di).abs() / di_sum.replace(0.0, np.nan)
-    df["DX"] = dx * 100
-    df["ADX"] = grouped["DX"].transform(
-        lambda s: s.ewm(alpha=1 / 14.0, adjust=False, min_periods=14).mean()
+
+def aroon(df: pd.DataFrame, n: int, out_up: str, out_dn: str) -> pd.DataFrame:
+    def _aroon_up(s: pd.Series) -> pd.Series:
+        return s.rolling(n, min_periods=1).apply(
+            lambda w: 100
+            * (1 - (len(w) - 1 - np.argmax(w)) / (len(w) - 1 if len(w) > 1 else 1))
+        )
+
+    def _aroon_dn(s: pd.Series) -> pd.Series:
+        return s.rolling(n, min_periods=1).apply(
+            lambda w: 100
+            * (1 - (len(w) - 1 - np.argmin(w)) / (len(w) - 1 if len(w) > 1 else 1))
+        )
+
+    df[out_up] = _gb(df)["high"].transform(_aroon_up)
+    df[out_dn] = _gb(df)["low"].transform(_aroon_dn)
+    return df
+
+
+def dmi_adx(df: pd.DataFrame, n: int, out_adx: str, out_pdi: str, out_ndi: str) -> pd.DataFrame:
+    up_move = df["high"] - _gb(df)["high"].shift(1)
+    dn_move = _gb(df)["low"].shift(1) - df["low"]
+    plus_dm = np.where((up_move > dn_move) & (up_move > 0), up_move, 0.0)
+    minus_dm = np.where((dn_move > up_move) & (dn_move > 0), dn_move, 0.0)
+
+    tr = true_range(df["high"], df["low"], _gb(df)["close"].shift(1))
+    tr_ema = _gb(pd.DataFrame({"symbol": df["symbol"], "tr": tr}))["tr"].transform(
+        lambda s: s.ewm(alpha=1 / n, adjust=False, min_periods=1).mean()
     )
-
-
-def _compute_aroon(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    period = 25
-
-    def _rolling_argmax(values: np.ndarray) -> float:
-        return float(np.argmax(values))
-
-    def _rolling_argmin(values: np.ndarray) -> float:
-        return float(np.argmin(values))
-
-    high_rank = (
-        grouped["high"].rolling(window=period, min_periods=period).apply(_rolling_argmax, raw=True)
+    pdi = 100 * _gb(pd.DataFrame({"symbol": df["symbol"], "pdm": plus_dm}))["pdm"].transform(
+        lambda s: s.ewm(alpha=1 / n, adjust=False, min_periods=1).mean()
+    ) / tr_ema.replace(0, np.nan)
+    ndi = 100 * _gb(pd.DataFrame({"symbol": df["symbol"], "mdm": minus_dm}))["mdm"].transform(
+        lambda s: s.ewm(alpha=1 / n, adjust=False, min_periods=1).mean()
+    ) / tr_ema.replace(0, np.nan)
+    dx = ((pdi - ndi).abs() / (pdi + ndi).replace(0, np.nan)) * 100
+    adx = _gb(pd.DataFrame({"symbol": df["symbol"], "dx": dx}))["dx"].transform(
+        lambda s: s.ewm(alpha=1 / n, adjust=False, min_periods=1).mean()
     )
-    low_rank = (
-        grouped["low"].rolling(window=period, min_periods=period).apply(_rolling_argmin, raw=True)
+    df[out_pdi] = pdi
+    df[out_ndi] = ndi
+    df[out_adx] = adx
+    return df
+
+
+def rolling_extrema(
+    df: pd.DataFrame, col: str, n: int, out_max: str | None = None, out_min: str | None = None
+) -> pd.DataFrame:
+    if out_max:
+        df[out_max] = _gb(df)[col].transform(lambda s: s.rolling(n, min_periods=1).max())
+    if out_min:
+        df[out_min] = _gb(df)[col].transform(lambda s: s.rolling(n, min_periods=1).min())
+    return df
+
+
+# --------------------------------------------------------------------------------------
+# Feature computation (vectorized, flat frame)
+# --------------------------------------------------------------------------------------
+
+
+def compute_all_features(
+    bars_df: pd.DataFrame,
+    cfg: Dict | FeatureConfig | None,
+    *,
+    add_intermediate: bool = True,
+) -> pd.DataFrame:
+    """
+    Compute ranking features on daily bars.
+
+    Parameters
+    ----------
+    bars_df : DataFrame
+        Columns: symbol, timestamp, open, high, low, close, volume (flat; 1 row per bar)
+    cfg : dict | FeatureConfig | None
+        Feature configuration (periods, min_history, z clipping)
+    add_intermediate : bool
+        If False, drop intermediate MA/ATR/etc. columns in the final output.
+
+    Returns
+    -------
+    DataFrame with columns:
+        symbol, timestamp,
+        TS, MS, BP, PT, RSI, MH, ADX, AROON, VCP, VOLexp,
+        GAPpen, LIQpen, TS_z, ..., LIQpen_z and optionally intermediate helpers.
+    """
+
+    if isinstance(cfg, dict):
+        base_values = {name: getattr(DEFAULT_FEATURE_CONFIG, name) for name in FeatureConfig.__dataclass_fields__}
+        for name in list(base_values):
+            if name in cfg:
+                base_values[name] = cfg[name]
+        gates = cfg.get("gates") if isinstance(cfg.get("gates"), dict) else {}
+        if "min_history" in gates:
+            try:
+                base_values["min_history"] = int(gates["min_history"])
+            except (TypeError, ValueError):
+                pass
+        fc = FeatureConfig(**base_values)
+    elif isinstance(cfg, FeatureConfig):
+        fc = cfg
+    else:
+        fc = DEFAULT_FEATURE_CONFIG
+
+    df = bars_df.copy()
+    keep = ["symbol", "timestamp", "open", "high", "low", "close", "volume"]
+    missing = [col for col in keep if col not in df.columns]
+    if missing:
+        raise KeyError(f"Missing required bar columns: {', '.join(missing)}")
+    df = df[keep].copy()
+    df["symbol"] = df["symbol"].astype(str).str.upper()
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    for col in ["open", "high", "low", "close", "volume"]:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    counts = (
+        df.dropna(subset=["timestamp"])
+        .groupby("symbol", as_index=False)["timestamp"].size()
+        .rename(columns={"size": "n"})
     )
+    valid = set(counts.loc[counts["n"] >= fc.min_history, "symbol"])
+    df = df[df["symbol"].isin(valid)].copy()
 
-    high_rank = high_rank.reset_index(level=0, drop=True)
-    low_rank = low_rank.reset_index(level=0, drop=True)
-
-    periods_since_high = (period - 1) - high_rank
-    periods_since_low = (period - 1) - low_rank
-
-    aroon_up = 100 * (period - periods_since_high) / period
-    aroon_down = 100 * (period - periods_since_low) / period
-
-    df["AROON_UP"] = aroon_up
-    df["AROON_DOWN"] = aroon_down
-    df["AROON"] = aroon_up - aroon_down
-
-
-def _compute_moving_averages(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    close = grouped["close"]
-    df["SMA9"] = close.transform(lambda s: s.rolling(9, min_periods=9).mean())
-    df["EMA20"] = close.transform(lambda s: s.ewm(span=20, adjust=False).mean())
-    df["SMA50"] = close.transform(lambda s: s.rolling(50, min_periods=50).mean())
-    df["SMA100"] = close.transform(lambda s: s.rolling(100, min_periods=100).mean())
-
-
-def _compute_macd(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    def _macd_hist(series: pd.Series) -> pd.Series:
-        ema12 = series.ewm(span=12, adjust=False).mean()
-        ema26 = series.ewm(span=26, adjust=False).mean()
-        macd_line = ema12 - ema26
-        signal = macd_line.ewm(span=9, adjust=False).mean()
-        return macd_line - signal
-
-    macd_hist = grouped["close"].apply(_macd_hist)
-    df["MACD_HIST"] = macd_hist.reset_index(level=0, drop=True)
-
-
-def _compute_volume_features(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    rolling_vol = grouped["volume"].transform(lambda s: s.rolling(20, min_periods=20).mean())
-    df["VOLexp"] = df["volume"] / rolling_vol
-
-    dollar_volume = df["close"] * df["volume"]
-    rolling_dollar = dollar_volume.groupby(df["symbol"]).transform(
-        lambda s: s.rolling(20, min_periods=20).mean()
-    )
-    liq_pen = 1.0 / rolling_dollar.replace(0.0, np.nan)
-    df["LIQpen"] = pd.Series(liq_pen, index=df.index)
-
-
-def _compute_price_features(df: pd.DataFrame, grouped: pd.core.groupby.generic.DataFrameGroupBy) -> None:
-    close = grouped["close"]
-    high = grouped["high"]
-
-    rolling_high = high.transform(lambda s: s.rolling(20, min_periods=20).max())
-
-    df["TS"] = np.where(df["SMA50"].abs() > 0, df["close"] / df["SMA50"] - 1, np.nan)
-    df["MS"] = close.transform(lambda s: s.pct_change(periods=5))
-    df["BP"] = np.where(rolling_high > 0, df["close"] / rolling_high - 1, np.nan)
-    df["PT"] = np.where(df["SMA50"].abs() > 0, df["SMA9"] / df["SMA50"] - 1, np.nan)
-    df["MH"] = np.where(df["SMA100"].abs() > 0, df["SMA50"] / df["SMA100"] - 1, np.nan)
-
-    atr_pct = (df["ATR14"] / df["close"]).replace([np.inf, -np.inf], np.nan)
-    df["VCP"] = -atr_pct
-
-    prev_close = grouped["close"].shift(1)
-    gap = (df["open"] - prev_close) / prev_close
-    df["GAPpen"] = gap.replace([np.inf, -np.inf], np.nan).abs().fillna(0.0)
-
-    df["RSI"] = df["RSI14"]
-
-
-def _cleanup_columns(df: pd.DataFrame) -> None:
-    for column in ["TR", "DX", "plus_dm", "minus_dm"]:
-        if column in df.columns:
-            df.drop(columns=column, inplace=True)
-
-
-def compute_all_features(bars_df: pd.DataFrame, cfg: Optional[Mapping[str, object]]) -> pd.DataFrame:
-    """Compute the full feature matrix for the screener."""
-
-    df = _prepare_bars_frame(bars_df)
     if df.empty:
-        return _initialised_frame(ALL_FEATURE_COLUMNS)
+        columns = ["symbol", "timestamp", *ALL_FEATURE_COLUMNS]
+        return pd.DataFrame(columns=columns)
 
-    grouped = df.groupby("symbol", group_keys=False)
+    df = df.sort_values(["symbol", "timestamp"], kind="mergesort").reset_index(drop=True)
 
-    _compute_moving_averages(df, grouped)
-    _compute_atr(df, grouped)
-    _compute_rsi(df, grouped)
-    _compute_adx(df, grouped)
-    _compute_aroon(df, grouped)
-    _compute_macd(df, grouped)
-    _compute_volume_features(df, grouped)
-    _compute_price_features(df, grouped)
+    df = sma(df, "close", fc.sma_fast, "SMA9")
+    df = ema(df, "close", fc.ema_mid, "EMA20")
+    df = sma(df, "close", fc.sma_mid, "SMA50")
+    df = sma(df, "close", fc.sma_slow, "SMA100")
+    df = atr(df, fc.atr_period, "ATR14")
+    df = rsi(df, fc.rsi_period, "RSI14")
+    df = macd(df, fc.macd_fast, fc.macd_slow, fc.macd_signal, "MACD", "MACD_SIGNAL", "MACD_HIST")
+    df = aroon(df, fc.aroon_period, "AROON_UP", "AROON_DN")
+    df = dmi_adx(df, fc.adx_period, "ADX14", "+DI", "-DI")
+    df = rolling_extrema(
+        df,
+        "close",
+        fc.breakout_lookback,
+        out_max="H20",
+        out_min="L20",
+    )
 
-    _cleanup_columns(df)
+    def _linreg_slope_r2(x: pd.Series) -> float:
+        y = np.log(x.replace(0, np.nan)).dropna()
+        if len(y) < 5:
+            return float("nan")
+        t = np.arange(len(y), dtype=float)
+        t_mean = t.mean()
+        y_mean = y.mean()
+        cov = ((t - t_mean) * (y - y_mean)).sum()
+        var = ((t - t_mean) ** 2).sum()
+        slope = cov / var if var != 0 else float("nan")
+        ss_tot = ((y - y_mean) ** 2).sum()
+        ss_res = ((y - (y_mean + slope * (t - t_mean))) ** 2).sum()
+        r2 = 1 - (ss_res / ss_tot) if ss_tot != 0 else float("nan")
+        return float(slope * r2 * 100.0)
 
-    for column in (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS):
-        if column in df.columns:
-            df[f"{column}_z"] = grouped[column].transform(robust_z)
+    TS = _gb(df)["close"].transform(
+        lambda s: s.rolling(fc.breakout_lookback, min_periods=5).apply(
+            lambda w: _linreg_slope_r2(pd.Series(w)), raw=False
+        )
+    )
+    MS = 100 * ((df["SMA9"] / df["EMA20"]) - 1.0) + 50 * ((df["EMA20"] / df["SMA50"]) - 1.0)
+    BP = (df["close"] - df["H20"]) / df["ATR14"].replace(0, np.nan)
+    PT = -((df["close"] - df["EMA20"]).abs() / df["ATR14"].replace(0, np.nan))
+    RSI_raw = df["RSI14"]
+    MH = df["MACD_HIST"] / df["ATR14"].replace(0, np.nan)
+    ADX_raw = df["ADX14"]
+    AROON_raw = df["AROON_UP"] - df["AROON_DN"]
+    VCP = -(
+        (df["ATR14"] / _gb(df)["ATR14"].transform(lambda s: s.rolling(fc.vcp_long, min_periods=1).mean()))
+        - 1.0
+    )
+    VOLexp = (
+        _gb(df)["volume"].transform(lambda s: s.rolling(fc.vol_short, min_periods=1).mean())
+        / _gb(df)["volume"].transform(lambda s: s.rolling(fc.vol_long, min_periods=1).mean())
+    ) - 1.0
+    GAPpen = (df["open"] - _gb(df)["close"].shift(1)).abs() / df["ATR14"].replace(0, np.nan)
+    adv20 = (
+        _gb(df)["close"].transform(lambda s: s.rolling(20, min_periods=1).mean())
+        * _gb(df)["volume"].transform(lambda s: s.rolling(20, min_periods=1).mean())
+    )
+    LIQpen = (1_000_000 - adv20) / 1_000_000
+    LIQpen = LIQpen.clip(lower=0)
 
-    df.replace([np.inf, -np.inf], np.nan, inplace=True)
+    features_raw = {
+        "TS": TS,
+        "MS": MS,
+        "BP": BP,
+        "PT": PT,
+        "RSI": RSI_raw,
+        "MH": MH,
+        "ADX": ADX_raw,
+        "AROON": AROON_raw,
+        "VCP": VCP,
+        "VOLexp": VOLexp,
+        "GAPpen": GAPpen,
+        "LIQpen": LIQpen,
+    }
 
-    counts = grouped.cumcount() + 1
-    min_history = _get_min_history(cfg)
-    if min_history > 0:
-        df = df[counts >= min_history]
+    for name, series in features_raw.items():
+        df[name] = pd.to_numeric(series, errors="coerce")
 
-    df = df.dropna(subset=REQUIRED_FEATURE_COLUMNS)
+    df["AROON_DIFF"] = df["AROON"]
 
-    result = df[["symbol", "timestamp", *ALL_FEATURE_COLUMNS]].copy()
-    result.sort_values(["symbol", "timestamp"], inplace=True)
-    result.reset_index(drop=True, inplace=True)
-    return result
+    z_clip = fc.robust_clip if isinstance(fc.robust_clip, (int, float)) else DEFAULT_FEATURE_CONFIG.robust_clip
+    for name in (*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS):
+        series = df[name]
+        z = robust_z(series.dropna(), clip=z_clip)
+        df[f"{name}_z"] = z.reindex(df.index).fillna(0.0)
+
+    feature_cols = [*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS, *Z_SCORE_COLUMNS]
+    df[feature_cols] = df[feature_cols].replace([np.inf, -np.inf], np.nan)
+
+    if not add_intermediate:
+        cols = ["symbol", "timestamp", *feature_cols]
+        return df[cols].copy()
+
+    intermediates = [col for col in INTERMEDIATE_COLUMNS if col in df.columns]
+    cols = ["symbol", "timestamp", *feature_cols, *intermediates]
+    return df[cols].copy()
 
 
 __all__ = [
+    "FeatureConfig",
     "CORE_FEATURE_COLUMNS",
     "PENALTY_COLUMNS",
     "INTERMEDIATE_COLUMNS",
     "Z_SCORE_COLUMNS",
     "REQUIRED_FEATURE_COLUMNS",
     "ALL_FEATURE_COLUMNS",
+    "robust_z",
     "compute_all_features",
 ]
+

--- a/tests/test_features_shapes.py
+++ b/tests/test_features_shapes.py
@@ -10,13 +10,14 @@ pytestmark = pytest.mark.alpaca_optional
 
 def _make_synthetic_bars(rows: int = 220) -> pd.DataFrame:
     symbols = ["AAA", "BBB"]
+    rng = np.random.default_rng(42)
     frames = []
     for symbol in symbols:
         idx = pd.date_range("2023-01-01", periods=rows, freq="B", tz="UTC")
         base = np.linspace(10, 50, num=rows)
         noise = np.sin(np.linspace(0, np.pi * 4, num=rows))
         close = base + noise
-        open_ = close + np.random.default_rng(0).normal(0, 0.5, size=rows)
+        open_ = close + rng.normal(0, 0.5, size=rows)
         high = np.maximum(open_, close) + 0.5
         low = np.minimum(open_, close) - 0.5
         volume = np.linspace(100_000, 250_000, num=rows) * (1 + 0.1 * noise)

--- a/tests/test_robust_z.py
+++ b/tests/test_robust_z.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.utils.stats import robust_z
+from scripts.features import robust_z
 
 
 pytestmark = pytest.mark.alpaca_optional


### PR DESCRIPTION
## Summary
- implement the nightly feature computation pipeline with vectorised indicators, MAD-clipped z-scores, and richer intermediates for gating
- expose consistent feature column constants alongside the reusable `robust_z` helper
- cover the feature frame and `robust_z` behaviour with targeted unit tests

## Testing
- pytest tests/test_robust_z.py tests/test_features_shapes.py

------
https://chatgpt.com/codex/tasks/task_e_68e6bf02a6688331ac36bc40cb6f2ad9