### PR TITLE
Improve screener caching and diagnostics

### DIFF
--- a/scripts/features.py
+++ b/scripts/features.py
@@ -408,6 +408,36 @@ def compute_all_features(
     feature_cols = [*CORE_FEATURE_COLUMNS, *PENALTY_COLUMNS, *Z_SCORE_COLUMNS]
     df[feature_cols] = df[feature_cols].replace([np.inf, -np.inf], np.nan)
 
+    float32_cols = [
+        "SMA9",
+        "EMA20",
+        "SMA50",
+        "SMA100",
+        "ATR14",
+        "MACD",
+        "MACD_SIGNAL",
+        "MACD_HIST",
+        "AROON_UP",
+        "AROON_DN",
+        "+DI",
+        "-DI",
+        "TS",
+        "MS",
+        "BP",
+        "PT",
+        "RSI",
+        "MH",
+        "ADX",
+        "AROON",
+        "VCP",
+        "VOLexp",
+        "GAPpen",
+        "LIQpen",
+    ]
+    for col in float32_cols:
+        if col in df.columns:
+            df[col] = df[col].astype("float32")
+
     if not add_intermediate:
         cols = ["symbol", "timestamp", *feature_cols]
         return df[cols].copy()

--- a/scripts/ranking.py
+++ b/scripts/ranking.py
@@ -174,7 +174,9 @@ def score_universe(bars_df: pd.DataFrame, cfg: Optional[Mapping[str, object]] = 
     standardized_df = standardized_df.reindex(columns=aligned_weights.index, fill_value=0.0)
 
     contributions = standardized_df.multiply(aligned_weights, axis=1)
-    score_series = contributions.sum(axis=1)
+    if contributions.isna().any().any():
+        contributions = contributions.fillna(0.0)
+    score_series = contributions.sum(axis=1).fillna(0.0)
 
     breakdown_strings = standardized_df.apply(
         lambda row: json.dumps({k: round(float(v), 4) for k, v in sorted(row.items())}),

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -59,6 +59,19 @@ def _configure_logger() -> logging.Logger:
 LOGGER = _configure_logger()
 
 
+class T:
+    def __init__(self) -> None:
+        self.t = time.time()
+        self.m: dict[str, float] = {}
+
+    def lap(self, key: str) -> float:
+        now = time.time()
+        elapsed = round(now - self.t, 3)
+        self.m[key] = elapsed
+        self.t = time.time()
+        return elapsed
+
+
 def _coerce_int(value: Any) -> int:
     try:
         return int(value)

--- a/tests/test_screener_unknown_exchange.py
+++ b/tests/test_screener_unknown_exchange.py
@@ -80,6 +80,7 @@ def test_screener_skips_unknown_exchanges(tmp_path):
         reject_samples,
         gate_counters,
         ranker_cfg,
+        timings,
     ) = screener.run_screener(
         df,
         top_n=5,
@@ -105,12 +106,18 @@ def test_screener_skips_unknown_exchanges(tmp_path):
         fetch_metrics={},
         asset_metrics={},
         ranker_cfg=ranker_cfg,
+        timings=timings,
     )
 
     top_path = tmp_path / "data" / "top_candidates.csv"
     scored_path = tmp_path / "data" / "scored_candidates.csv"
+    diag_dir = tmp_path / "data" / "diagnostics"
+    diag_csv = diag_dir / f"top10_{now.date().isoformat()}.csv"
+    diag_json = diag_dir / f"top10_{now.date().isoformat()}.json"
     assert top_path.exists()
     assert scored_path.exists()
+    assert diag_csv.exists()
+    assert diag_json.exists()
 
     metrics = json.loads(metrics_path.read_text())
     assert metrics["rows"] == scored_df.shape[0]
@@ -118,6 +125,7 @@ def test_screener_skips_unknown_exchanges(tmp_path):
     assert metrics["status"] == "ok"
     assert "reject_samples" in metrics
     assert "gate_fail_counts" in metrics
+    assert "timings" in metrics
     expected_gate_keys = {
         "failed_sma_stack",
         "failed_rsi",


### PR DESCRIPTION
## Summary
- add per-batch parquet caching with a --reuse-cache toggle, progress logging, and enhanced HTTP rate limiting/backoff for screener fetches
- capture stage timings, cast heavy feature columns to float32, and emit diagnostics/metrics including top-10 feature snapshots
- extend tests to cover the new diagnostics outputs and timings metadata

## Testing
- pytest tests/test_screener_unknown_exchange.py

------
https://chatgpt.com/codex/tasks/task_e_68e6c281c0788331aa4b7e85538ab936