### PR TITLE
Add detailed Why tooltips to Screener Health top candidates

### DIFF
--- a/dashboards/assets/screener_tooltips.css
+++ b/dashboards/assets/screener_tooltips.css
@@ -1,0 +1,7 @@
+/***** Dash DataTable tooltip tweaks *****/
+.dash-table-tooltip {
+  white-space: pre-wrap;
+  max-width: 520px;
+  font-size: 12px;
+  line-height: 1.35;
+}


### PR DESCRIPTION
## Summary
- add tooltip configuration to the Screener Health top candidates table and build markdown payloads with composite score, contributor list, and raw indicator values
- extend scored candidates merge logic so raw indicator columns (RSI14, ADX, AROON, MACD_HIST, ATR14, ADV20) are available when missing in the top candidates feed
- style Dash tooltips for improved readability of the multi-line content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e70e3ab2ac8331ba7ba18ca13bd21b