### PR TITLE
Add optional PythonAnywhere reload to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ automatically:
 python scripts/run_pipeline.py
 ```
 
+Set `PYTHONANYWHERE_DOMAIN` (e.g., `RasPatrick.pythonanywhere.com`) or `PA_WSGI_PATH` to enable the automatic web reload.
+Disable it per-run via `--reload-web false`.
+
 When creating a scheduled task for `execute_trades.py` on PythonAnywhere make
 sure the working directory is set to the project root so logs and CSV files are
 written in the correct location:


### PR DESCRIPTION
## Summary
- add an auto-reload helper that touches the PythonAnywhere web app after the pipeline finishes, with CLI opt-out
- wire the `--reload-web` flag into the pipeline runner and document the environment variables that control reload behavior

## Testing
- python -m compileall scripts/run_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e72892dab083319473b43c1fe195b2