### PR TITLE
Fix Alpaca universe metrics handling

### DIFF
--- a/tests/test_universe_prefix_metrics.py
+++ b/tests/test_universe_prefix_metrics.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import pytest
+
+from scripts.screener import _write_universe_prefix_metrics
+
+
+@pytest.mark.alpaca_optional
+def test_universe_prefix_counts_updates_metrics():
+    metrics: dict[str, object] = {}
+    df = pd.DataFrame({"symbol": ["AAPL", "AMZN", "MSFT", "META", "GOOG"]})
+
+    prefix_counts = _write_universe_prefix_metrics(df, metrics)
+
+    assert set(prefix_counts.keys()) >= {"A", "M", "G"}
+    assert metrics["universe_prefix_counts"] == prefix_counts


### PR DESCRIPTION
## Summary
- update `_load_alpaca_universe` to accept a metrics mapping, reset its defaults, and delegate prefix guardrails to a reusable helper
- add `_write_universe_prefix_metrics` to populate the shared metrics dict and reuse it from the Alpaca universe loader
- cover the new helper with a unit test that ensures prefix counts are written back to the provided metrics dict

## Testing
- pytest tests/test_universe_prefix_metrics.py


------
https://chatgpt.com/codex/tasks/task_e_68e7d804fbc483319fef3168d8630324