### PR TITLE
Ensure pipeline artifacts and screener metrics stay consistent

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -74,13 +74,8 @@ def copy_latest_candidates() -> None:
             size = 0
         LOG.info("[INFO] refreshed latest_candidates.csv (size=%s)", size)
     else:
-        if not dst.exists():
-            dst.write_text(LATEST_HEADER)
-            LOG.warning(
-                "[INFO] top_candidates.csv missing; created header-only latest_candidates.csv"
-            )
-        else:
-            LOG.warning("[INFO] top_candidates.csv missing; retained existing latest_candidates.csv")
+        dst.write_text(LATEST_HEADER)
+        LOG.info("[INFO] top_candidates.csv missing; wrote header-only latest_candidates.csv")
 
 
 def write_metrics_summary() -> None:

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -1181,7 +1181,7 @@ def _fetch_daily_bars(
     if insufficient:
         metrics["insufficient_history"] = len(insufficient)
 
-    symbols_with_bars = len(symbols_with_history)
+    symbols_with_bars = int(combined["symbol"].nunique()) if not combined.empty else 0
     symbols_no_bars = max(len(unique_symbols) - symbols_with_bars, 0)
     bars_rows_total = int(len(combined))
     metrics.update(


### PR DESCRIPTION
## Summary
- always refresh the dashboard-facing latest_candidates.csv even when the screener fails to produce output
- report screener coverage metrics using the distinct symbol count so bars coverage reflects unique instruments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e94c1a717483319b6ba8e2a8ff111a