### PR TITLE
Use JBRAVO_HOME for dashboard path resolution

### DIFF
--- a/dashboards/screener_health.py
+++ b/dashboards/screener_health.py
@@ -7,7 +7,9 @@ from dash import html, dcc
 from dash.dash_table import DataTable
 from dash.dependencies import Input, Output
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+REPO_ROOT = pathlib.Path(
+    os.environ.get("JBRAVO_HOME", pathlib.Path(__file__).resolve().parents[1])
+)
 DATA_DIR  = REPO_ROOT / "data"
 LOG_DIR   = REPO_ROOT / "logs"
 


### PR DESCRIPTION
## Summary
- honor a JBRAVO_HOME override in the screener health dashboard so data and log paths resolve from the deployment root
- set a default JBRAVO_HOME for the dashboard app and point log paths at the same base directory
- update the log staleness detector to recognize both INFO token formats

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebe7a771d083319c7c7f3f9539a58d