### PR TITLE
Harden dashboard resiliency and clarify screener metrics

### DIFF
--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -3700,6 +3700,19 @@ def write_outputs(
             "batches_total": _coerce_int(fetch_payload.get("batches_total", 0)),
         }
     )
+    symbol_count = 0
+    if isinstance(scored_df, pd.DataFrame) and "symbol" in scored_df.columns:
+        try:
+            symbol_count = int(scored_df["symbol"].dropna().astype(str).nunique())
+        except Exception:
+            try:
+                symbol_count = int(scored_df["symbol"].nunique())
+            except Exception:
+                symbol_count = 0
+    rows_total = int(scored_df.shape[0]) if isinstance(scored_df, pd.DataFrame) else 0
+    metrics["symbols_with_bars"] = symbol_count
+    metrics["bars_rows_total"] = rows_total
+    metrics["symbols_no_bars"] = max(int(metrics.get("symbols_in", 0)) - symbol_count, 0)
     prefix_counts_payload = fetch_payload.get("universe_prefix_counts")
     if isinstance(prefix_counts_payload, dict):
         metrics["universe_prefix_counts"] = {


### PR DESCRIPTION
## Summary
- guard the screener health dashboard against missing artifacts, render safe "n/a" tooltips, and ensure pie charts avoid empty-data failures
- derive ATR% and "Why" values with explicit fallbacks so empty data shows as "n/a" instead of zeroes
- compute screener metrics for symbols_with_bars and bars_rows_total directly from the ranked dataframe for clearer KPIs

## Testing
- python -m compileall dashboards/screener_health.py scripts/run_pipeline.py scripts/screener.py

------
https://chatgpt.com/codex/tasks/task_e_68ec1121b4e48331a4eed5b7c08d615c