### PR TITLE
Ensure pipeline artifacts refresh and improve dashboard resilience

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -72,9 +72,11 @@ def is_log_stale(log_path):
     try:
         with open(log_path) as file:
             lines = file.readlines()
+        info_tokens = ("[INFO]", "- INFO -")
+        error_tokens = ("[ERROR]", "- ERROR -")
         for line in reversed(lines):
-            is_info = ("[INFO]" in line) or ("- INFO -" in line)
-            is_error = ("[ERROR]" in line) or ("- ERROR -" in line)
+            is_info = any(token in line for token in info_tokens)
+            is_error = any(token in line for token in error_tokens)
             if is_info or is_error:
                 ts_str = line[:19]
                 ts = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S")

--- a/dashboards/screener_health.py
+++ b/dashboards/screener_health.py
@@ -40,13 +40,11 @@ def _resolve_repo_root() -> pathlib.Path:
     if env_home:
         try:
             candidate = pathlib.Path(env_home).expanduser()
-            if candidate.exists():
-                return candidate
-            LOGGER.warning(
-                "JBRAVO_HOME=%s not found; falling back to %s",
-                candidate,
-                default_root,
-            )
+            if not candidate.exists():
+                LOGGER.warning(
+                    "JBRAVO_HOME=%s not found; continuing with provided path", candidate
+                )
+            return candidate
         except Exception as exc:  # pragma: no cover - defensive
             LOGGER.warning(
                 "Failed to resolve JBRAVO_HOME=%s (%s); falling back to %s",


### PR DESCRIPTION
## Summary
- refresh latest_candidates.csv and metrics_summary.csv even when the screener step is skipped or fails, and coerce summary figures to integers
- respect the JBRAVO_HOME override for screener health assets even when the directory needs to be created
- accept [INFO] markers when checking dashboard logs for staleness

## Testing
- pytest tests/test_screener_api_mode.py


------
https://chatgpt.com/codex/tasks/task_e_68ec16310a008331a0acc8f984917b0f