### PR TITLE
Normalize top candidate output and relax executor column requirements

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -66,6 +66,12 @@ def screener_cmd() -> list[str]:
     return base + extra
 
 
+def execute_cmd() -> list[str]:
+    base = [sys.executable, "-m", "scripts.execute_trades"]
+    extra = shlex.split(os.environ.get("JBR_EXEC_ARGS", "")) if os.environ.get("JBR_EXEC_ARGS") else []
+    return base + extra
+
+
 def emit(event: str, **payload: Any) -> None:
     """Append a structured event to ``logs/execute_events.jsonl``."""
 
@@ -263,7 +269,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 latest_refreshed = True
             except Exception as exc:  # pragma: no cover - defensive safeguard
                 LOG.error("[INFO] failed to refresh artifacts before EXECUTE step: %s", exc)
-        rc_exec = run_execute_step([sys.executable, "-m", "scripts.execute_trades"])
+        rc_exec = run_execute_step(execute_cmd())
         if rc_exec != 0 and rc == 0:
             rc = rc_exec
 


### PR DESCRIPTION
## Summary
- normalize the screener's top_candidates export to guarantee required trading columns and lowercase score metadata
- make the trade executor tolerate missing candidate fields by applying defaults and fetching recent close data when needed
- allow the pipeline execute step to honor custom arguments via the JBR_EXEC_ARGS environment variable

## Testing
- pytest tests/test_run_pipeline.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ed2744c4fc83319930b67c016c9d43