### PR TITLE
Harden executor skip handling and orchestrator logging

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -222,7 +222,8 @@ def latest_candidates_has_rows(path: pathlib.Path) -> bool:
 def run_execute_step(cmd: list[str]) -> int:
     latest_path = pathlib.Path("data") / "latest_candidates.csv"
     if not latest_candidates_has_rows(latest_path):
-        LOG.info("[INFO] EXECUTE SKIPPED: NO CANDIDATES")
+        LOG.info("[INFO] START EXECUTE (skipped: NO CANDIDATES)")
+        LOG.info("[INFO] END EXECUTE rc=0 duration=0.0s (skipped)")
         return 0
 
     LOG.info("[INFO] START EXECUTE %s", " ".join(shlex.quote(part) for part in cmd))

--- a/tests/test_execute_trades_logging.py
+++ b/tests/test_execute_trades_logging.py
@@ -129,7 +129,13 @@ def test_execute_flow_attaches_trailing_stop(tmp_path):
         ]
     )
     frame.to_csv(csv_path, index=False)
-    config = ExecutorConfig(source=csv_path, cancel_after_min=1, allocation_pct=0.5)
+    config = ExecutorConfig(
+        source=csv_path,
+        cancel_after_min=1,
+        allocation_pct=0.5,
+        time_window="any",
+        extended_hours=True,
+    )
     metrics = ExecutionMetrics()
     client = StubTradingClient()
     executor = TradeExecutor(config, client, metrics, sleep_fn=lambda *_: None)


### PR DESCRIPTION
## Summary
- add defensive defaults for missing candidate columns and hydrate optional fields with warning logs
- log skip reasons, update execution metrics schema, and surface dry-run/time-window status
- ensure the pipeline execute step logs explicit start/end markers and keep tests aligned with the new window controls

## Testing
- pytest tests/test_execute_trades_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68ed4996616483318818ca650b882871