### PR TITLE
Improve executor hydration and logging

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -221,13 +221,15 @@ def latest_candidates_has_rows(path: pathlib.Path) -> bool:
 
 def run_execute_step(cmd: list[str]) -> int:
     latest_path = pathlib.Path("data") / "latest_candidates.csv"
+    cmd_str = " ".join(shlex.quote(part) for part in cmd)
+    start = time.time()
+    LOG.info("[INFO] START EXECUTE %s", cmd_str)
     if not latest_candidates_has_rows(latest_path):
-        LOG.info("[INFO] START EXECUTE (skipped: NO CANDIDATES)")
-        LOG.info("[INFO] END EXECUTE rc=0 duration=0.0s (skipped)")
+        duration = time.time() - start
+        LOG.info("[INFO] EXECUTE SKIPPED: NO CANDIDATES")
+        LOG.info("[INFO] END EXECUTE rc=0 duration=%.1fs", duration)
         return 0
 
-    LOG.info("[INFO] START EXECUTE %s", " ".join(shlex.quote(part) for part in cmd))
-    start = time.time()
     result = subprocess.run(cmd, capture_output=True, text=True)
     duration = time.time() - start
     LOG.info("[INFO] END EXECUTE rc=%s duration=%.1fs", result.returncode, duration)

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -3866,19 +3866,17 @@ def write_outputs(
             "batches_total": _coerce_int(fetch_payload.get("batches_total", 0)),
         }
     )
-    symbol_count = 0
     if isinstance(scored_df, pd.DataFrame) and "symbol" in scored_df.columns:
         try:
-            symbol_count = int(scored_df["symbol"].dropna().astype(str).nunique())
+            symbol_count = int(scored_df["symbol"].astype("string").dropna().nunique())
         except Exception:
-            try:
-                symbol_count = int(scored_df["symbol"].nunique())
-            except Exception:
-                symbol_count = 0
+            symbol_count = int(scored_df["symbol"].nunique())
+    else:
+        symbol_count = 0
     rows_total = int(scored_df.shape[0]) if isinstance(scored_df, pd.DataFrame) else 0
-    metrics["symbols_with_bars"] = symbol_count
-    metrics["bars_rows_total"] = rows_total
-    metrics["symbols_no_bars"] = max(int(metrics.get("symbols_in", 0)) - symbol_count, 0)
+    metrics["symbols_with_bars"] = int(symbol_count)
+    metrics["bars_rows_total"] = int(rows_total)
+    metrics["symbols_no_bars"] = max(int(metrics.get("symbols_in", 0)) - int(symbol_count), 0)
     prefix_counts_payload = fetch_payload.get("universe_prefix_counts")
     if isinstance(prefix_counts_payload, dict):
         metrics["universe_prefix_counts"] = {


### PR DESCRIPTION
## Summary
- Add batch daily bar fetching and enhanced optional field hydration with explicit logging and skip reason aliasing in the trade executor.
- Log market time evaluation, extend the CLI with a --market-tz alias, and enrich lifecycle logs and metrics persistence for submissions and skips.
- Improve pipeline execute-step logging/skip handling and ensure screener metrics expose integer counts for dashboard cards.

## Testing
- pytest tests/test_execute_trades_cli.py tests/test_execute_trades_logging.py tests/test_run_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68ed578d186083319f992f5ded16a9ad