### PR TITLE
Add env normalization and Alpaca connectivity monitoring

### DIFF
--- a/raspatrick_pythonanywhere_com_wsgi.py
+++ b/raspatrick_pythonanywhere_com_wsgi.py
@@ -1,0 +1,36 @@
+"""PythonAnywhere WSGI entry point for the JBRAVO dashboard."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+env_path = ROOT / ".env"
+if env_path.exists():
+    load_dotenv(env_path)
+
+os.environ.setdefault("JBRAVO_HOME", str(ROOT))
+
+from dashboards.dashboard_app import app as dash_app  # noqa: E402
+
+application = dash_app.server
+
+LOGGER = logging.getLogger("jbravo.wsgi")
+if not LOGGER.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+    LOGGER.addHandler(handler)
+LOGGER.setLevel(logging.INFO)
+
+if not getattr(LOGGER, "_jbravo_logged", False):
+    LOGGER.info("[WSGI] JBRAVO_HOME=%s venv ok", os.environ.get("JBRAVO_HOME", ""))
+    LOGGER._jbravo_logged = True  # type: ignore[attr-defined]

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,51 +1,179 @@
-import os
-import time
+"""Connectivity health probe for Alpaca trading and data APIs."""
+
+from __future__ import annotations
+
+import json
 import logging
-from datetime import datetime
-from logging.handlers import RotatingFileHandler
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join(BASE_DIR, 'data')
-LOG_DIR = os.path.join(BASE_DIR, 'logs')
-os.makedirs(LOG_DIR, exist_ok=True)
+import requests
 
-logger = logging.getLogger('health_check')
-logger.setLevel(logging.INFO)
-handler = RotatingFileHandler(os.path.join(LOG_DIR, 'health_check.log'), maxBytes=2_000_000, backupCount=5)
-handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] %(message)s'))
-logger.addHandler(handler)
-
-FILES = [
-    'trades_log.csv',
-    'executed_trades.csv',
-    'metrics_summary.csv',
-    'open_positions.csv',
-]
-
-THRESHOLD_MINUTES = int(os.getenv('HEALTHCHECK_THRESHOLD', '15'))
+from scripts.utils.env import market_data_base_url, trading_base_url
+from utils.env import get_alpaca_creds, load_env
 
 
-def file_age_minutes(path: str) -> float:
-    if not os.path.exists(path):
-        return float('inf')
-    mtime = os.path.getmtime(path)
-    return (time.time() - mtime) / 60
+LOG = logging.getLogger("health_check")
+
+CONNECTIVITY_PATH = os.path.join("data", "health", "connectivity.json")
+_PROBE_SYMBOLS = ("AAPL", "MSFT", "SPY")
 
 
-def run_check():
-    alerts = []
-    for name in FILES:
-        path = os.path.join(DATA_DIR, name)
-        age = file_age_minutes(path)
-        if age == float('inf'):
-            alerts.append(f"{name} missing")
-        elif age > THRESHOLD_MINUTES:
-            alerts.append(f"{name} stale ({int(age)} min old)")
-    if alerts:
-        logger.warning('Data health issue: %s', ' | '.join(alerts))
+def _alpaca_headers() -> Dict[str, str]:
+    key, secret, _, _ = get_alpaca_creds()
+    headers: Dict[str, str] = {}
+    if key:
+        headers["APCA-API-KEY-ID"] = key.strip()
+    if secret:
+        headers["APCA-API-SECRET-KEY"] = secret.strip()
+    return headers
+
+
+def _error_message(response: requests.Response, url: str) -> str:
+    snippet = ""
+    try:
+        snippet = response.text.strip()
+    except Exception:  # pragma: no cover - defensive
+        snippet = ""
+    if not snippet:
+        try:
+            payload = response.json()
+        except Exception:  # pragma: no cover - defensive
+            payload = None
+        if isinstance(payload, Mapping):
+            snippet = json.dumps(payload)
+        elif payload is not None:
+            snippet = str(payload)
+    snippet = " ".join(str(snippet).split())
+    reason = response.reason or "error"
+    return f"GET {url} -> {response.status_code} {reason}: {snippet}".strip()
+
+
+def _probe_trading(session: requests.Session, headers: Mapping[str, str]) -> Dict[str, Any]:
+    url = f"{trading_base_url().rstrip('/')}/v2/account"
+    if "APCA-API-KEY-ID" not in headers or "APCA-API-SECRET-KEY" not in headers:
+        return {
+            "ok": False,
+            "status": 0,
+            "message": "missing APCA_API_KEY_ID/APCA_API_SECRET_KEY",
+        }
+    try:
+        resp = session.get(url, headers=headers, timeout=10)
+    except Exception as exc:  # pragma: no cover - network errors
+        return {"ok": False, "status": 0, "message": f"GET {url} -> {exc}"}
+
+    if resp.ok:
+        message = ""
+        try:
+            payload = resp.json()
+        except Exception:  # pragma: no cover - non JSON
+            payload = None
+        if isinstance(payload, Mapping):
+            message = str(payload.get("status") or payload.get("account_status") or "ok")
+        else:
+            message = resp.text.strip() or resp.reason or "ok"
     else:
-        logger.info('All CSV files fresh')
+        message = _error_message(resp, url)
+
+    return {"ok": resp.ok, "status": resp.status_code, "message": message}
 
 
-if __name__ == '__main__':
-    run_check()
+def _probe_data(
+    session: requests.Session, headers: Mapping[str, str], feed: str
+) -> Dict[str, Any]:
+    base = market_data_base_url().rstrip("/")
+    url = f"{base}/v2/stocks/bars"
+    params = {
+        "symbols": ",".join(_PROBE_SYMBOLS),
+        "timeframe": "1Day",
+        "limit": 252,
+        "feed": feed or "iex",
+    }
+    try:
+        resp = session.get(url, headers=headers, params=params, timeout=10)
+    except Exception as exc:  # pragma: no cover - network errors
+        return {"ok": False, "status": 0, "message": f"GET {url} -> {exc}"}
+
+    if resp.ok:
+        message = ""
+        try:
+            payload = resp.json()
+        except Exception:  # pragma: no cover - non JSON
+            payload = None
+        if isinstance(payload, Mapping):
+            bars = payload.get("bars")
+            if isinstance(bars, Mapping):
+                parts = []
+                for symbol in _PROBE_SYMBOLS:
+                    series = bars.get(symbol)
+                    count = len(series) if isinstance(series, list) else 0
+                    parts.append(f"{symbol}:{count}")
+                message = ",".join(parts)
+            else:
+                message = json.dumps(payload)[:200]
+        else:
+            message = resp.text.strip() or resp.reason or "ok"
+    else:
+        message = _error_message(resp, f"{url}?symbols={params['symbols']}&feed={params['feed']}")
+
+    return {"ok": resp.ok, "status": resp.status_code, "message": message}
+
+
+def run_health_check(*, write: bool = True) -> Dict[str, Any]:
+    """Run connectivity probes and optionally persist their outcome."""
+
+    load_env()
+    headers = _alpaca_headers()
+    _, _, _, feed = get_alpaca_creds()
+
+    session = requests.Session()
+    try:
+        trading = _probe_trading(session, headers)
+        data = _probe_data(session, headers, (feed or "iex").lower())
+    finally:
+        session.close()
+
+    report: Dict[str, Any] = {
+        "ts_utc": datetime.now(timezone.utc).isoformat(),
+        "trading": trading,
+        "data": data,
+    }
+
+    if write:
+        os.makedirs(os.path.dirname(CONNECTIVITY_PATH), exist_ok=True)
+        with open(CONNECTIVITY_PATH, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True)
+
+    return report
+
+
+def probe_trading_only() -> Dict[str, Any]:
+    """Run only the trading probe (without writing artifacts)."""
+
+    load_env()
+    headers = _alpaca_headers()
+    session = requests.Session()
+    try:
+        return _probe_trading(session, headers)
+    finally:
+        session.close()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    report = run_health_check(write=True)
+    trading = report.get("trading", {})
+    data = report.get("data", {})
+    LOG.info(
+        "[INFO] HEALTH trading_ok=%s data_ok=%s trading_status=%s data_status=%s",
+        trading.get("ok"),
+        data.get("ok"),
+        trading.get("status"),
+        data.get("status"),
+    )
+    return 0 if trading.get("ok") and data.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -71,6 +71,7 @@ except Exception:  # pragma: no cover - fallback for direct script execution
     )
     from scripts.backtest import compute_recent_performance  # type: ignore
 
+from scripts.health_check import probe_trading_only
 from utils.env import load_env, get_alpaca_creds
 from utils.io_utils import atomic_write_bytes
 
@@ -4177,6 +4178,14 @@ def main(
     if not api_key or not api_secret:
         LOGGER.error("Missing Alpaca credentials; set APCA_API_KEY_ID and APCA_API_SECRET_KEY.")
         return 2
+
+    trading_probe = probe_trading_only()
+    if trading_probe.get("status") == 401:
+        LOGGER.error(
+            "[ERROR] Alpaca auth failed (401). Check: (1) paper vs live base URL, "
+            "(2) fresh key/secret, (3) whitespace/CRLF in .env."
+        )
+        raise SystemExit(2)
 
     if mode == "delta-update":
         return _run_delta_update(args, base_dir)

--- a/tests/test_env_loader.py
+++ b/tests/test_env_loader.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from utils.env import load_env
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    keys = [
+        "APCA_API_KEY_ID",
+        "APCA_API_SECRET_KEY",
+        "ALPACA_API_KEY_ID",
+        "ALPACA_API_SECRET_KEY",
+        "APCA_API_BASE_URL",
+        "ALPACA_API_BASE_URL",
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+    yield
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write_env(tmp_path: Path, contents: str) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(contents, encoding="utf-8")
+
+
+def test_load_env_strips_crlf_and_spaces(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_env(
+        tmp_path,
+        "APCA_API_KEY_ID= key123   \r\n"
+        "APCA_API_SECRET_KEY= secret456\r\n",
+    )
+
+    summary = load_env()
+
+    assert os.environ["APCA_API_KEY_ID"] == "key123"
+    assert os.environ["APCA_API_SECRET_KEY"] == "secret456"
+    assert summary["APCA_API_KEY_ID"] == {"present": True, "len": 6}
+    assert summary["APCA_API_SECRET_KEY"] == {"present": True, "len": 9}
+
+
+def test_load_env_handles_quoted_values(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_env(
+        tmp_path,
+        'APCA_API_KEY_ID="quoted-key"\nAPCA_API_SECRET_KEY="quoted-secret"\n',
+    )
+
+    summary = load_env()
+
+    assert os.environ["APCA_API_KEY_ID"] == "quoted-key"
+    assert os.environ["APCA_API_SECRET_KEY"] == "quoted-secret"
+    assert summary["APCA_API_KEY_ID"]["len"] == len("quoted-key")
+    assert summary["APCA_API_SECRET_KEY"]["len"] == len("quoted-secret")
+
+
+def test_load_env_trims_v2_suffix(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_env(
+        tmp_path,
+        "APCA_API_KEY_ID=abc\n"
+        "APCA_API_SECRET_KEY=def\n"
+        "APCA_API_BASE_URL=https://paper-api.alpaca.markets/v2/\n",
+    )
+
+    summary = load_env()
+
+    assert os.environ["APCA_API_BASE_URL"] == "https://paper-api.alpaca.markets"
+    assert summary["APCA_API_BASE_URL"] == {
+        "present": True,
+        "len": len("https://paper-api.alpaca.markets"),
+    }

--- a/utils/env.py
+++ b/utils/env.py
@@ -3,17 +3,100 @@
 from __future__ import annotations
 
 import os
-from typing import Optional, Tuple
+from typing import Dict, Mapping, Optional, Tuple
 
-from dotenv import load_dotenv, find_dotenv
+from dotenv import dotenv_values, find_dotenv, load_dotenv
 
 
-def load_env() -> None:
-    """Load project and user-level environment variables if available."""
-    load_dotenv(find_dotenv(usecwd=True))
+_REQUIRED_KEYS: tuple[tuple[str, ...], ...] = (
+    ("APCA_API_KEY_ID", "ALPACA_API_KEY_ID"),
+    ("APCA_API_SECRET_KEY", "ALPACA_API_SECRET_KEY"),
+)
+
+
+def _normalize_apca_base_url(value: str) -> str:
+    """Return ``value`` without trailing ``/v2`` or slashes."""
+
+    trimmed = value.strip()
+    if not trimmed:
+        return ""
+    trimmed = trimmed.rstrip("/")
+    if trimmed.endswith("/v2"):
+        trimmed = trimmed[: -len("/v2")]
+    return trimmed.rstrip("/")
+
+
+def load_env() -> Dict[str, Dict[str, int]]:
+    """Load environment files and normalize common Alpaca variables.
+
+    Returns a mapping describing which variables were populated during the
+    loading process. Each entry tracks whether the variable is present and the
+    length of the normalized value.
+    """
+
+    summary: Dict[str, Dict[str, int]] = {}
+
+    loaded_paths: list[str] = []
+    primary = find_dotenv(usecwd=True)
+    if primary:
+        load_dotenv(primary)
+        loaded_paths.append(primary)
+
     alt = os.path.expanduser("~/.config/jbravo/.env")
     if os.path.exists(alt):
         load_dotenv(alt, override=False)
+        loaded_paths.append(alt)
+
+    tracked: set[str] = set()
+    for path in loaded_paths:
+        try:
+            values: Mapping[str, str | None] = dotenv_values(path)
+        except Exception:
+            continue
+        tracked.update(key for key, value in values.items() if value is not None)
+
+    tracked.update({"APCA_API_BASE_URL", "ALPACA_API_BASE_URL"})
+    for keys in _REQUIRED_KEYS:
+        tracked.update(keys)
+
+    for key in tracked:
+        raw = os.environ.get(key)
+        if raw is None:
+            summary[key] = {"present": False, "len": 0}
+            continue
+        normalized = raw.strip()
+        if key == "APCA_API_BASE_URL":
+            normalized = _normalize_apca_base_url(normalized)
+        if normalized != raw:
+            os.environ[key] = normalized
+        summary[key] = {"present": bool(normalized), "len": len(normalized)}
+
+    for primary_key, *aliases in _REQUIRED_KEYS:
+        canon_value = os.environ.get(primary_key, "").strip()
+        if canon_value:
+            summary.setdefault(primary_key, {"present": True, "len": len(canon_value)})
+            continue
+        fallback_value = ""
+        fallback_key = None
+        for alias in aliases:
+            alias_val = os.environ.get(alias, "").strip()
+            if alias_val:
+                fallback_value = alias_val
+                fallback_key = alias
+                break
+        if fallback_value:
+            os.environ[primary_key] = fallback_value
+            summary[primary_key] = {"present": True, "len": len(fallback_value)}
+            if fallback_key:
+                summary.setdefault(
+                    fallback_key, {"present": True, "len": len(fallback_value)}
+                )
+        else:
+            summary.setdefault(primary_key, {"present": False, "len": 0})
+            for alias in aliases:
+                summary.setdefault(alias, {"present": False, "len": 0})
+
+    return summary
 
 
 def get_alpaca_creds() -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:


### PR DESCRIPTION
## Summary
- normalize `.env` loading by trimming whitespace, stripping `/v2`, and reporting presence metadata
- add an Alpaca connectivity health probe with pipeline/screener guardrails and WSGI sentinel logging
- surface trading/data connectivity status on the Screener Health dashboard with warning banner
- add regression tests covering the environment loader edge cases

## Testing
- `pytest tests/test_env_loader.py`
- `pytest tests/test_run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68ed845a4a4c8331bfeeb9bf1c88c91a