### PR TITLE
Add Alpaca credential validation and dashboard alert

### DIFF
--- a/tests/test_execute_trades_cli.py
+++ b/tests/test_execute_trades_cli.py
@@ -45,7 +45,9 @@ def test_load_candidates_missing_required_columns(tmp_path: Path):
         execute_trades.load_candidates(csv_path)
 
 
-def test_apply_guards_filters_by_price_and_adv(tmp_path: Path):
+def test_apply_guards_filters_by_price_and_adv(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(execute_trades, "_fetch_latest_daily_bars", lambda symbols: {})
+    monkeypatch.setattr(execute_trades, "_fetch_latest_close_from_alpaca", lambda symbol: None)
     df = pd.DataFrame(
         {
             "symbol": ["LOW", "HIGH", "LIQ"],
@@ -86,6 +88,12 @@ def test_run_executor_returns_zero_when_all_filtered(tmp_path: Path, monkeypatch
         min_adv20=200_000,
         log_json=True,
     )
+
+    monkeypatch.setenv("APCA_API_KEY_ID", "PKTEST")
+    monkeypatch.setenv("APCA_API_SECRET_KEY", "secret")
+    monkeypatch.setenv("APCA_API_BASE_URL", "https://paper-api.alpaca.markets")
+    monkeypatch.setattr(execute_trades, "_fetch_latest_daily_bars", lambda symbols: {})
+    monkeypatch.setattr(execute_trades, "_fetch_latest_close_from_alpaca", lambda symbol: None)
 
     exit_code = execute_trades.run_executor(config)
     assert exit_code == 0

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -10,7 +10,7 @@ os.environ.setdefault("APCA_API_KEY_ID", "test")
 os.environ.setdefault("APCA_API_SECRET_KEY", "test")
 os.environ.setdefault("ALPACA_KEY_ID", os.environ["APCA_API_KEY_ID"])
 os.environ.setdefault("ALPACA_SECRET_KEY", os.environ["APCA_API_SECRET_KEY"])
-os.environ.setdefault("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+os.environ.setdefault("APCA_API_BASE_URL", "https://paper-api.alpaca.markets")
 
 from scripts import run_pipeline
 
@@ -78,3 +78,5 @@ def test_pipeline_refresh_latest(tmp_path, monkeypatch):
     assert metrics.get("cache") == {"batches_hit": 0, "batches_miss": 0}
     assert metrics.get("universe_prefix_counts") == {}
     assert "timings" in metrics
+    assert metrics.get("status") == "ok"
+    assert metrics.get("auth_missing") == []

--- a/utils/env.py
+++ b/utils/env.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import csv
+import json
 import os
-from typing import Dict, Mapping, Optional, Tuple
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
 
 from dotenv import dotenv_values, find_dotenv, load_dotenv
 
@@ -12,6 +16,45 @@ _REQUIRED_KEYS: tuple[tuple[str, ...], ...] = (
     ("APCA_API_KEY_ID", "ALPACA_API_KEY_ID"),
     ("APCA_API_SECRET_KEY", "ALPACA_API_SECRET_KEY"),
 )
+
+METRICS_SUMMARY_COLUMNS: tuple[str, ...] = (
+    "last_run_utc",
+    "symbols_in",
+    "with_bars",
+    "bars_rows",
+    "candidates",
+    "status",
+    "auth_reason",
+    "auth_missing",
+    "auth_hint",
+)
+
+
+class AlpacaCredentialsError(RuntimeError):
+    """Raised when required Alpaca credentials are missing or malformed."""
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        missing: Sequence[str] | None = None,
+        whitespace: Sequence[str] | None = None,
+        sanitized: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.missing = tuple(missing or ())
+        self.whitespace = tuple(whitespace or ())
+        self.sanitized = dict(sanitized or {})
+
+
+class AlpacaUnauthorizedError(RuntimeError):
+    """Raised when Alpaca responds with HTTP 401/403."""
+
+    def __init__(self, endpoint: str, *, feed: str | None = None) -> None:
+        super().__init__("Alpaca returned 401/403")
+        self.endpoint = endpoint
+        self.feed = feed or ""
 
 
 def _normalize_apca_base_url(value: str) -> str:
@@ -99,6 +142,203 @@ def load_env() -> Dict[str, Dict[str, int]]:
     return summary
 
 
+def _resolve_env_value(primary: str, *aliases: str) -> tuple[str, str | None, bool]:
+    """Return ``(value, source_key, had_whitespace)`` for env ``primary``/aliases."""
+
+    had_whitespace = False
+    keys = (primary, *aliases)
+    for key in keys:
+        if key not in os.environ:
+            continue
+        raw = os.environ.get(key) or ""
+        trimmed = raw.strip()
+        if raw != trimmed:
+            os.environ[key] = trimmed
+            had_whitespace = True
+        if trimmed:
+            if key != primary:
+                os.environ[primary] = trimmed
+            return trimmed, key, had_whitespace
+        had_whitespace = True
+    return "", None, had_whitespace
+
+
+def _serialize_auth_hint(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, sort_keys=True)
+    except Exception:  # pragma: no cover - defensive fallback
+        return str(value)
+
+
+def write_metrics_summary_row(
+    row: Mapping[str, object],
+    *,
+    path: str | os.PathLike[str] | None = None,
+) -> None:
+    """Write ``row`` to ``metrics_summary.csv`` with consistent headers."""
+
+    summary_path = Path(path or Path("data") / "metrics_summary.csv")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    serializable: dict[str, object] = {}
+    for column in METRICS_SUMMARY_COLUMNS:
+        value = row.get(column, "") if isinstance(row, Mapping) else ""
+        if column in {"symbols_in", "with_bars", "bars_rows", "candidates"}:
+            try:
+                value = int(value) if value not in ("", None) else 0
+            except Exception:
+                value = 0
+        elif column == "auth_hint":
+            value = _serialize_auth_hint(value)
+        else:
+            value = "" if value is None else value
+        serializable[column] = value
+
+    with summary_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=METRICS_SUMMARY_COLUMNS)
+        writer.writeheader()
+        writer.writerow(serializable)
+
+
+def write_auth_error_artifacts(
+    *,
+    reason: str,
+    sanitized: Mapping[str, object],
+    missing: Iterable[str] = (),
+    metrics_path: str | os.PathLike[str],
+    summary_path: str | os.PathLike[str],
+) -> None:
+    """Persist artifacts marking an authentication failure for dashboards."""
+
+    metrics_file = Path(metrics_path)
+    metrics_file.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict[str, object] = {}
+    if metrics_file.exists():
+        try:
+            payload = json.loads(metrics_file.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                existing.update(payload)
+        except Exception:  # pragma: no cover - defensive parsing
+            existing = {}
+
+    missing_list = sorted({str(item) for item in missing if str(item).strip()})
+
+    existing.update(
+        {
+            "status": "auth_error",
+            "auth_reason": reason,
+            "auth_missing": missing_list,
+            "auth_hint": dict(sanitized),
+        }
+    )
+
+    metrics_file.write_text(
+        json.dumps(existing, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+    summary_row = {
+        "last_run_utc": existing.get("last_run_utc", ""),
+        "symbols_in": existing.get("symbols_in", 0),
+        "with_bars": existing.get("symbols_with_bars", 0),
+        "bars_rows": existing.get("bars_rows_total", 0),
+        "candidates": existing.get("rows", 0),
+        "status": "auth_error",
+        "auth_reason": reason,
+        "auth_missing": ",".join(missing_list),
+        "auth_hint": dict(sanitized),
+    }
+    write_metrics_summary_row(summary_row, path=summary_path)
+
+
+def assert_alpaca_creds() -> dict[str, object]:
+    """Validate Alpaca credentials and return a sanitized snapshot."""
+
+    key, key_source, key_ws = _resolve_env_value("APCA_API_KEY_ID", "ALPACA_API_KEY_ID")
+    secret, secret_source, secret_ws = _resolve_env_value(
+        "APCA_API_SECRET_KEY", "ALPACA_API_SECRET_KEY"
+    )
+    trading_base, trading_source, trading_ws = _resolve_env_value(
+        "APCA_API_BASE_URL", "ALPACA_API_BASE_URL"
+    )
+    data_base, data_source, data_ws = _resolve_env_value(
+        "APCA_DATA_API_BASE_URL",
+        "APCA_API_DATA_URL",
+        "ALPACA_API_DATA_URL",
+    )
+
+    missing: list[str] = []
+    whitespace: list[str] = []
+    if key_ws:
+        whitespace.append(key_source or "APCA_API_KEY_ID")
+    if secret_ws:
+        whitespace.append(secret_source or "APCA_API_SECRET_KEY")
+    if trading_ws:
+        whitespace.append(trading_source or "APCA_API_BASE_URL")
+    if data_ws and data_base:
+        whitespace.append(data_source or "APCA_DATA_API_BASE_URL")
+
+    if not key:
+        missing.append("APCA_API_KEY_ID")
+    if not secret:
+        missing.append("APCA_API_SECRET_KEY")
+    if not trading_base:
+        missing.append("APCA_API_BASE_URL")
+    if not data_base:
+        data_base = "https://data.alpaca.markets"
+
+    sanitized = {
+        "key_prefix": (key[:4] + "…") if key else "",
+        "secret_len": len(secret),
+        "base_urls": {
+            "trading": trading_base,
+            "data": data_base,
+        },
+    }
+
+    if missing:
+        raise AlpacaCredentialsError(
+            "missing",
+            missing=missing,
+            whitespace=whitespace,
+            sanitized=sanitized,
+        )
+
+    if whitespace:
+        raise AlpacaCredentialsError(
+            "whitespace",
+            missing=missing,
+            whitespace=whitespace,
+            sanitized=sanitized,
+        )
+
+    key_prefix = key.upper()[:2]
+    if key_prefix not in {"PK", "AK"}:
+        raise AlpacaCredentialsError(
+            "invalid_prefix",
+            sanitized=sanitized,
+        )
+
+    if trading_base:
+        parsed = urlparse(trading_base)
+        host = parsed.netloc.lower()
+        is_paper_host = "paper" in host
+        if key_prefix == "PK" and not is_paper_host:
+            raise AlpacaCredentialsError(
+                "base-url mismatch",
+                sanitized=sanitized,
+            )
+        if key_prefix == "AK" and is_paper_host:
+            raise AlpacaCredentialsError(
+                "base-url mismatch",
+                sanitized=sanitized,
+            )
+
+    return sanitized
+
+
 def get_alpaca_creds() -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Return Alpaca credentials from the environment with sensible fallbacks."""
     key = os.getenv("APCA_API_KEY_ID") or os.getenv("ALPACA_API_KEY_ID")
@@ -106,3 +346,15 @@ def get_alpaca_creds() -> Tuple[Optional[str], Optional[str], Optional[str], Opt
     base = os.getenv("APCA_API_BASE_URL") or os.getenv("ALPACA_API_BASE_URL")
     feed = os.getenv("ALPACA_DATA_FEED", "iex")
     return key, secret, base, feed
+
+
+__all__ = [
+    "AlpacaCredentialsError",
+    "AlpacaUnauthorizedError",
+    "assert_alpaca_creds",
+    "load_env",
+    "get_alpaca_creds",
+    "write_auth_error_artifacts",
+    "write_metrics_summary_row",
+    "METRICS_SUMMARY_COLUMNS",
+]


### PR DESCRIPTION
## Summary
- add strict Alpaca credential validation with sanitized logging utilities
- fail fast across pipeline, screener, and executor when credentials are missing or unauthorized and persist auth status artifacts
- surface credential health alerts on the screener dashboard from metrics summary/logs

## Testing
- pytest tests/test_env_loader.py tests/test_run_pipeline.py tests/test_execute_trades_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ed9bbf8678833180170b879144e5db