### PR TITLE
Harden pipeline summary and executor logging

### DIFF
--- a/scripts/utils/ny_window.py
+++ b/scripts/utils/ny_window.py
@@ -1,0 +1,70 @@
+"""Utility to display the U.S. equities pre-market window in multiple zones."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+
+PREMARKET_START = time(4, 0)
+PREMARKET_END = time(9, 30)
+NY_TZ = ZoneInfo("America/New_York")
+CHICAGO_TZ = ZoneInfo("America/Chicago")
+
+
+def _resolve_reference_date(raw: str) -> datetime:
+    raw = (raw or "now").strip().lower()
+    if raw in {"", "now", "today"}:
+        return datetime.now(tz=NY_TZ)
+    try:
+        parsed = datetime.fromisoformat(raw)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=NY_TZ)
+        return parsed.astimezone(NY_TZ)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid --when value '{raw}': {exc}")
+
+
+def compute_window(reference: datetime) -> dict[str, tuple[datetime, datetime]]:
+    ref_date = reference.astimezone(NY_TZ).date()
+    start_ny = datetime.combine(ref_date, PREMARKET_START, tzinfo=NY_TZ)
+    end_ny = datetime.combine(ref_date, PREMARKET_END, tzinfo=NY_TZ)
+    start_utc = start_ny.astimezone(timezone.utc)
+    end_utc = end_ny.astimezone(timezone.utc)
+    start_chi = start_ny.astimezone(CHICAGO_TZ)
+    end_chi = end_ny.astimezone(CHICAGO_TZ)
+    return {
+        "New York": (start_ny, end_ny),
+        "Chicago": (start_chi, end_chi),
+        "UTC": (start_utc, end_utc),
+    }
+
+
+def format_window(name: str, window: tuple[datetime, datetime]) -> str:
+    start, end = window
+    return f"{name}: {start.isoformat()} -> {end.isoformat()}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Show pre-market window timing")
+    parser.add_argument(
+        "--when",
+        default="now",
+        help="Reference point (ISO date or 'now', default: now)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    reference = _resolve_reference_date(args.when)
+    windows = compute_window(reference)
+    print(f"[INFO] PREMARKET_REFERENCE {reference.date().isoformat()}")
+    for label, window in windows.items():
+        print(f"[INFO] {format_window(label, window)}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_run_pipeline_summary.py
+++ b/tests/test_run_pipeline_summary.py
@@ -1,0 +1,69 @@
+import json
+import logging
+
+import pytest
+
+from scripts import run_pipeline
+
+
+@pytest.mark.alpaca_optional
+def test_pipeline_summary_emitted(tmp_path, monkeypatch, caplog):
+    data_dir = tmp_path / "data"
+    logs_dir = tmp_path / "logs"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+    top_csv = data_dir / "top_candidates.csv"
+    top_csv.write_text(
+        "timestamp,symbol,score,exchange,close,volume,universe_count,score_breakdown\n"
+        "2024-05-01T12:00:00Z,AAPL,3.2,NASDAQ,175.0,1000000,50,{}\n",
+        encoding="utf-8",
+    )
+    metrics_path = data_dir / "screener_metrics.json"
+    metrics_path.write_text(
+        json.dumps({"symbols_in": 5, "symbols_with_bars": 4, "rows": 0}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PYTHONANYWHERE_DOMAIN", "")
+
+    monkeypatch.setattr(run_pipeline, "load_env", lambda: None)
+    monkeypatch.setattr(run_pipeline, "assert_alpaca_creds", lambda: {"mode": "paper"})
+    monkeypatch.setattr(run_pipeline, "_record_health", lambda stage: {})
+
+    called_steps: list[str] = []
+
+    def fake_run_cmd(cmd, name):
+        called_steps.append(name)
+        return 0
+
+    monkeypatch.setattr(run_pipeline, "run_cmd", fake_run_cmd)
+
+    emitted: list[tuple[str, int]] = []
+
+    def fake_emit_metric(name, value):
+        emitted.append((name, value))
+
+    monkeypatch.setattr(run_pipeline, "emit_metric", fake_emit_metric)
+
+    caplog.set_level(logging.INFO, logger="pipeline")
+
+    rc = run_pipeline.main(["--steps", "screener"])
+    assert rc == 0
+    assert called_steps == ["SCREENER"]
+    assert emitted == [("CANDIDATE_ROWS", 1)]
+
+    summary_line = ""
+    for record in caplog.records:
+        message = record.getMessage()
+        if "PIPELINE_SUMMARY" in message:
+            summary_line = message
+    assert summary_line, "PIPELINE_SUMMARY log not found"
+    assert "symbols_in=5" in summary_line
+    assert "with_bars=4" in summary_line
+    assert "rows=1" in summary_line
+    assert "durations={\"screener\":" in summary_line
+    assert "step_rcs={\"screener\":0}" in summary_line
+
+    latest_path = data_dir / "latest_candidates.csv"
+    assert latest_path.exists()


### PR DESCRIPTION
## Summary
- emit candidate row metrics during the pipeline, skip execution when no rows are available, and record a structured PIPELINE_SUMMARY line for dashboards
- tighten execute_trades logging with a single-line header, clear time window skip reporting, and standardized trailing-stop submission tokens
- surface pipeline status and skip reasons on the screener dashboard, add a reusable pre-market window helper, and cover the new behaviour with focused tests

## Testing
- pytest tests/test_execute_trades_logging.py tests/test_run_pipeline_summary.py
- python -m scripts.utils.ny_window --when now

------
https://chatgpt.com/codex/tasks/task_e_68ee76a71aec83318f2a2ee1048161a4