### PR TITLE
Improve pipeline logging and dashboard visibility for zero candidates

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -1339,6 +1339,11 @@ class TradeExecutor:
             trail_display = str(int(trail_value))
         else:
             trail_display = f"{trail_value:g}"
+        LOGGER.info(
+            "[INFO] TRAIL_SUBMIT symbol=%s trail_pct=%s route=trailing_stop",
+            symbol,
+            trail_display,
+        )
         self.log_event(
             "TRAIL_SUBMIT",
             symbol=symbol,


### PR DESCRIPTION
## Summary
- add a deterministic PIPELINE_SUMMARY log with timing fields and skip the execute step when no candidates are produced
- clarify executor logging around run start, time-window skips, and trailing-stop submissions
- enhance the screener health dashboard to surface pipeline timing/skip details and highlight zero-candidate mornings
- cover the new logging expectations with targeted pipeline and executor tests

## Testing
- pytest tests/test_run_pipeline_summary.py tests/test_execute_trades_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68ee8dee76848331b9278f4ec16068b2