### PR TITLE
Ensure pipeline fallback and executor sizing resilience

### DIFF
--- a/dashboards/assets/screener_health.css
+++ b/dashboards/assets/screener_health.css
@@ -79,3 +79,18 @@
   overflow: auto;
   white-space: pre-wrap;
 }
+
+.sh-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.sh-badge-fallback {
+  background: rgba(43, 34, 58, 0.92);
+  border: 1px solid rgba(244, 217, 255, 0.45);
+  color: #f4d9ff;
+}

--- a/scripts/fallback_candidates.py
+++ b/scripts/fallback_candidates.py
@@ -74,6 +74,8 @@ _RENAME_MAP = {
     "atrp": "atrp",
     "ATR_pct": "atrp",
     "atr_percent": "atrp",
+    "ATR": "atrp",
+    "atr": "atrp",
     "exchange": "exchange",
     "primary_exchange": "exchange",
     "Primary Exchange": "exchange",
@@ -87,9 +89,9 @@ _RENAME_MAP = {
 
 _DEFAULT_ROW = {
     "timestamp": "",
-    "symbol": "AAPL",
+    "symbol": "",
     "score": 0.0,
-    "exchange": "UNKNOWN",
+    "exchange": "",
     "close": 0.0,
     "volume": 0,
     "universe_count": 0,
@@ -98,6 +100,21 @@ _DEFAULT_ROW = {
     "adv20": 0.0,
     "atrp": 0.0,
     "source": "fallback",
+}
+
+_STATIC_FALLBACK_ROW = {
+    "timestamp": "",
+    "symbol": "AAPL",
+    "score": 0.0,
+    "exchange": "NASDAQ",
+    "close": 175.0,
+    "volume": 0,
+    "universe_count": 0,
+    "score_breakdown": "fallback",
+    "entry_price": 175.0,
+    "adv20": 5_000_000.0,
+    "atrp": 0.02,
+    "source": "fallback:static",
 }
 
 
@@ -115,10 +132,16 @@ def _safe_read_csv(path: Path) -> pd.DataFrame:
 
 
 def _latest_prediction_frame(predictions_dir: Path) -> pd.DataFrame:
+    latest_path = predictions_dir / "latest.csv"
+    frame = _safe_read_csv(latest_path)
+    if not frame.empty:
+        return frame
     if not predictions_dir.exists():
         return pd.DataFrame()
     candidates: list[Tuple[float, Path]] = []
     for csv_path in predictions_dir.glob("*.csv"):
+        if csv_path.name == "latest.csv":
+            continue
         try:
             stat = csv_path.stat()
         except OSError:
@@ -141,65 +164,74 @@ def _canonicalize_columns(columns: Iterable[object]) -> dict[object, str]:
 
 def _canonical_frame(df: Optional[pd.DataFrame], now_ts: Optional[str] = None) -> pd.DataFrame:
     now_value = now_ts or _now_iso()
-    frame = df.copy() if isinstance(df, pd.DataFrame) else pd.DataFrame()
-    if frame.empty and not isinstance(df, pd.DataFrame):
-        frame = pd.DataFrame()
+    source_frame = df.copy() if isinstance(df, pd.DataFrame) else pd.DataFrame()
+    if source_frame.empty and not isinstance(df, pd.DataFrame):
+        source_frame = pd.DataFrame()
 
-    if not frame.empty:
-        frame = frame.rename(columns=_canonicalize_columns(frame.columns))
-        frame.columns = [str(col).strip().lower() for col in frame.columns]
-        if frame.columns.duplicated().any():
-            frame = frame.loc[:, ~frame.columns.duplicated()]
+    if not source_frame.empty:
+        source_frame = source_frame.rename(columns=_canonicalize_columns(source_frame.columns))
+        source_frame.columns = [str(col).strip().lower() for col in source_frame.columns]
+        if source_frame.columns.duplicated().any():
+            source_frame = source_frame.loc[:, ~source_frame.columns.duplicated()]
 
-    for column in CANONICAL_COLUMNS:
-        if column not in frame.columns:
-            default_value = _DEFAULT_ROW[column]
-            frame[column] = default_value
+    out = pd.DataFrame(index=source_frame.index.copy())
 
-    if "timestamp" in frame.columns:
-        frame["timestamp"] = (
-            frame["timestamp"].astype("string").fillna("").str.strip().replace({"": now_value})
+    ts_series = source_frame.get("timestamp")
+    if ts_series is not None:
+        out["timestamp"] = (
+            ts_series.astype("string").fillna("").str.strip().replace({"": now_value})
         )
     else:
-        frame["timestamp"] = now_value
+        out["timestamp"] = now_value
 
-    if "symbol" in frame.columns:
-        frame["symbol"] = frame["symbol"].astype("string").str.strip()
+    out["symbol"] = (
+        source_frame.get("symbol", pd.Series(index=out.index, dtype="string"))
+        .astype("string")
+        .fillna("")
+        .str.strip()
+        .str.upper()
+    )
 
-    if "entry_price" in frame.columns and "close" in frame.columns:
-        entry_numeric = pd.to_numeric(frame["entry_price"], errors="coerce")
-        close_numeric = pd.to_numeric(frame["close"], errors="coerce")
-        frame["entry_price"] = entry_numeric.where(entry_numeric > 0, close_numeric)
-        frame["entry_price"] = frame["entry_price"].fillna(close_numeric).fillna(0.0)
+    exchange_series = source_frame.get("exchange", pd.Series(index=out.index, dtype="string"))
+    out["exchange"] = (
+        exchange_series.astype("string").fillna("").str.strip().str.upper()
+    )
 
-    for column in _NUMERIC_COLUMNS:
-        if column in frame.columns:
-            frame[column] = pd.to_numeric(frame[column], errors="coerce").fillna(_DEFAULT_ROW[column])
+    for column in ("score", "close", "volume", "universe_count", "entry_price", "adv20", "atrp"):
+        values = source_frame.get(column)
+        out[column] = pd.to_numeric(values, errors="coerce") if values is not None else pd.Series(
+            _DEFAULT_ROW[column], index=out.index
+        )
+        out[column] = out[column].fillna(_DEFAULT_ROW[column])
 
-    frame["score_breakdown"] = frame["score_breakdown"].astype("string").fillna("fallback")
-    frame["exchange"] = frame["exchange"].astype("string").fillna("UNKNOWN").replace({"": "UNKNOWN"})
-    frame["source"] = "fallback"
+    out["volume"] = out["volume"].clip(lower=0)
+    out["universe_count"] = out["universe_count"].clip(lower=0)
 
-    frame = frame[list(CANONICAL_COLUMNS)]
-    frame = frame.dropna(subset=["symbol", "close", "score"], how="any")
-    frame = frame[frame["symbol"].astype("string").str.len() > 0]
-    frame = frame.drop_duplicates(subset=["symbol"])
+    score_breakdown = source_frame.get("score_breakdown", pd.Series(index=out.index, dtype="string"))
+    out["score_breakdown"] = (
+        score_breakdown.astype("string").fillna("").str.strip().replace({"": "fallback"})
+    )
 
-    if frame.empty:
-        fallback = pd.DataFrame([_DEFAULT_ROW.copy()])
-        fallback["timestamp"] = now_value
-        return fallback
+    out["entry_price"] = out["entry_price"].where(out["entry_price"] > 0, out["close"])
+    out["entry_price"] = out["entry_price"].where(out["entry_price"] > 0, _DEFAULT_ROW["entry_price"])
 
-    if (frame["adv20"] > 0).any():
-        frame = frame.sort_values(["adv20", "score"], ascending=[False, False])
-    elif (frame["score"].notna()).any():
-        frame = frame.sort_values(["score", "volume"], ascending=[False, False])
-    elif (frame["volume"] > 0).any():
-        frame = frame.sort_values("volume", ascending=False)
+    out["adv20"] = out["adv20"].clip(lower=0)
+    out["atrp"] = out["atrp"].clip(lower=0)
+
+    source_series = source_frame.get("source")
+    if source_series is not None:
+        out["source"] = source_series.astype("string").fillna("fallback")
     else:
-        frame = frame.sort_values("symbol", ascending=True)
+        out["source"] = _DEFAULT_ROW["source"]
 
-    return frame.reset_index(drop=True)
+    out = out[list(CANONICAL_COLUMNS)]
+    out["timestamp"] = out["timestamp"].replace({"": now_value})
+    out["timestamp"] = out["timestamp"].fillna(now_value)
+
+    mask_symbol = out["symbol"].astype("string").str.len() > 0
+    out = out.loc[mask_symbol]
+    out = out.reset_index(drop=True)
+    return out
 
 
 def normalize_candidate_df(df: Optional[pd.DataFrame], now_ts: Optional[str] = None) -> pd.DataFrame:
@@ -208,25 +240,47 @@ def normalize_candidate_df(df: Optional[pd.DataFrame], now_ts: Optional[str] = N
     return _canonical_frame(df, now_ts)
 
 
+def _guard_fallback_candidates(frame: pd.DataFrame) -> pd.DataFrame:
+    if frame.empty:
+        return frame
+
+    close_numeric = pd.to_numeric(frame["close"], errors="coerce")
+    exchange_series = frame["exchange"].astype("string").fillna("").str.strip()
+    adv_numeric = pd.to_numeric(frame["adv20"], errors="coerce")
+    symbol_series = frame["symbol"].astype("string").fillna("").str.strip()
+
+    adv_mask = adv_numeric.isna() | (adv_numeric <= 0) | (adv_numeric >= 2_000_000)
+    mask = (close_numeric > 0) & (exchange_series != "") & adv_mask & (symbol_series != "")
+
+    guarded = frame.loc[mask].copy()
+    if guarded.empty:
+        return guarded
+
+    guarded["timestamp"] = _now_iso()
+    guarded = guarded.drop_duplicates(subset=["symbol"])
+
+    guarded = guarded.sort_values(
+        by=["score", "adv20", "volume", "symbol"],
+        ascending=[False, False, False, True],
+    )
+    return guarded.reset_index(drop=True)
+
+
+def _write_latest(data_dir: Path, frame: pd.DataFrame) -> None:
+    latest_path = data_dir / "latest_candidates.csv"
+    write_csv_atomic(str(latest_path), frame[list(CANONICAL_COLUMNS)])
+    LOGGER.info(
+        "[INFO] FALLBACK_OUT rows=%d path=%s",
+        len(frame.index),
+        os.path.relpath(latest_path, start=PROJECT_ROOT),
+    )
+
+
 def _write_candidates(base_dir: Path, prepared: pd.DataFrame) -> None:
     data_dir = base_dir / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
     top_path = data_dir / "top_candidates.csv"
-    write_csv_atomic(str(top_path), prepared)
-    latest_path = data_dir / "latest_candidates.csv"
-    if not latest_path.exists():
-        write_csv_atomic(str(latest_path), prepared)
-
-
-def generate_candidates(base_dir: Path, *, max_rows: int = 3) -> Tuple[pd.DataFrame, str]:
-    frame, source = build_latest_candidates(base_dir, max_rows=max_rows)
-    return frame.head(max_rows), source
-
-
-def _tag_source(frame: pd.DataFrame, source: str) -> pd.DataFrame:
-    tagged = frame.copy()
-    tagged["source"] = source
-    return tagged
+    write_csv_atomic(str(top_path), prepared[list(prepared.columns)])
 
 
 def build_latest_candidates(base_dir: Path | None = None, *, max_rows: int = 1) -> tuple[pd.DataFrame, str]:
@@ -236,38 +290,37 @@ def build_latest_candidates(base_dir: Path | None = None, *, max_rows: int = 1) 
     data_dir = base / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
 
-    now_value = _now_iso()
-
     scored = _safe_read_csv(data_dir / "scored_candidates.csv")
     if not scored.empty:
-        prepared = _canonical_frame(scored, now_value).head(max_rows)
-        if not prepared.empty:
-            prepared = _tag_source(prepared, "fallback:scored")
+        canonical = _canonical_frame(scored)
+        canonical["source"] = "fallback:scored"
+        guarded = _guard_fallback_candidates(canonical)
+        if not guarded.empty:
+            prepared = guarded.head(max_rows)
             _write_latest(data_dir, prepared)
             return prepared, "scored"
 
     predictions = _latest_prediction_frame(data_dir / "predictions")
     if not predictions.empty:
-        prepared = _canonical_frame(predictions, now_value).head(max_rows)
-        if not prepared.empty:
-            prepared = _tag_source(prepared, "fallback:predictions")
+        canonical = _canonical_frame(predictions)
+        canonical["source"] = "fallback:predictions"
+        guarded = _guard_fallback_candidates(canonical)
+        if not guarded.empty:
+            prepared = guarded.head(max_rows)
             _write_latest(data_dir, prepared)
             return prepared, "predictions"
 
-    fallback = _canonical_frame(pd.DataFrame([_DEFAULT_ROW.copy()]), now_value).head(max_rows)
-    fallback = _tag_source(fallback, "fallback:static")
-    _write_latest(data_dir, fallback)
-    return fallback, "static"
+    fallback = _canonical_frame(pd.DataFrame([_STATIC_FALLBACK_ROW.copy()]))
+    fallback["source"] = "fallback:static"
+    fallback["timestamp"] = _now_iso()
+    prepared = fallback.head(max_rows)
+    _write_latest(data_dir, prepared)
+    return prepared, "static"
 
 
-def _write_latest(data_dir: Path, frame: pd.DataFrame) -> None:
-    latest_path = data_dir / "latest_candidates.csv"
-    write_csv_atomic(str(latest_path), frame)
-    LOGGER.info(
-        "[INFO] FALLBACK_OUT rows=%d path=%s",
-        len(frame.index),
-        os.path.relpath(latest_path, start=PROJECT_ROOT),
-    )
+def generate_candidates(base_dir: Path, *, max_rows: int = 3) -> Tuple[pd.DataFrame, str]:
+    frame, source = build_latest_candidates(base_dir, max_rows=max_rows)
+    return frame.head(max_rows), source
 
 
 def ensure_min_candidates(

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -227,19 +227,22 @@ def _reload_dashboard(enabled: bool) -> None:
         LOG.info("[INFO] DASH_RELOAD method=pa rc=0 domain=%s", domain or "(default)")
         return
     except FileNotFoundError:
-        LOG.info("[INFO] DASH_RELOAD method=pa rc=ERR detail=missing_tool")
+        LOG.info("[INFO] DASH_RELOAD method=pa rc=missing_tool domain=%s", domain or "(default)")
     except subprocess.CalledProcessError as exc:
         LOG.info(
-            "[INFO] DASH_RELOAD method=pa rc=ERR detail=rc%s", exc.returncode
+            "[INFO] DASH_RELOAD method=pa rc=%s domain=%s",
+            exc.returncode,
+            domain or "(default)",
         )
     except Exception as exc:  # pragma: no cover - defensive guard
-        LOG.info("[INFO] DASH_RELOAD method=pa rc=ERR detail=%s", exc)
+        LOG.info(
+            "[INFO] DASH_RELOAD method=pa rc=ERR domain=%s detail=%s",
+            domain or "(default)",
+            exc,
+        )
 
     target = domain.replace(".", "_") if domain else ""
-    if target:
-        path = Path(f"/var/www/{target}_wsgi.py")
-    else:
-        path = DEFAULT_WSGI_PATH
+    path = Path(f"/var/www/{target}_wsgi.py") if target else DEFAULT_WSGI_PATH
     try:
         path.touch()
         LOG.info("[INFO] DASH_RELOAD method=touch rc=0 path=%s", path)
@@ -282,7 +285,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             symbols_with_bars = int(metrics.get("symbols_with_bars", 0) or 0)
             top_frame = _load_top_candidates()
             if top_frame.empty:
-                frame, source = build_latest_candidates(PROJECT_ROOT)
+                frame, source = build_latest_candidates(PROJECT_ROOT, max_rows=1)
                 write_csv_atomic(str(TOP_CANDIDATES), frame)
                 rows = int(len(frame.index))
                 LOG.info(

--- a/tests/test_executor_sizing.py
+++ b/tests/test_executor_sizing.py
@@ -1,0 +1,82 @@
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts.execute_trades import ExecutionMetrics, ExecutorConfig, TradeExecutor
+
+
+@pytest.mark.alpaca_optional
+def test_sizing_bumps_to_one_share(monkeypatch, caplog, tmp_path: Path):
+    config = ExecutorConfig(
+        source=tmp_path / "candidates.csv",
+        allocation_pct=0.01,
+        min_order_usd=150.0,
+        allow_bump_to_one=True,
+        dry_run=True,
+        time_window="any",
+    )
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": "BUMP",
+                "close": 300.0,
+                "entry_price": 300.0,
+                "score": 2.0,
+                "universe_count": 10,
+                "score_breakdown": "{}",
+            }
+        ]
+    )
+    metrics = ExecutionMetrics()
+    executor = TradeExecutor(config, None, metrics)
+    monkeypatch.setattr(executor, "fetch_buying_power", lambda: 1000.0)
+    monkeypatch.setattr(executor, "evaluate_time_window", lambda log=True: (True, "ok"))
+
+    caplog.set_level(logging.DEBUG, logger="execute_trades")
+    caplog.clear()
+
+    rc = executor.execute(df, prefiltered=df.to_dict("records"))
+    assert rc == 0
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("[INFO] BUMP_TO_ONE symbol=BUMP" in msg for msg in messages)
+    assert any("CALC symbol=BUMP" in msg and "qty=1" in msg for msg in messages)
+    assert metrics.skipped_reasons.get("ZERO_QTY", 0) == 0
+
+
+@pytest.mark.alpaca_optional
+def test_min_order_floor_sets_quantity(monkeypatch, caplog, tmp_path: Path):
+    config = ExecutorConfig(
+        source=tmp_path / "candidates.csv",
+        allocation_pct=0.01,
+        min_order_usd=500.0,
+        allow_bump_to_one=False,
+        dry_run=True,
+        time_window="any",
+    )
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": "FLOOR",
+                "close": 95.0,
+                "entry_price": 95.0,
+                "score": 2.0,
+                "universe_count": 10,
+                "score_breakdown": "{}",
+            }
+        ]
+    )
+    metrics = ExecutionMetrics()
+    executor = TradeExecutor(config, None, metrics)
+    monkeypatch.setattr(executor, "fetch_buying_power", lambda: 2000.0)
+    monkeypatch.setattr(executor, "evaluate_time_window", lambda log=True: (True, "ok"))
+
+    caplog.set_level(logging.DEBUG, logger="execute_trades")
+    caplog.clear()
+
+    rc = executor.execute(df, prefiltered=df.to_dict("records"))
+    assert rc == 0
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("CALC symbol=FLOOR" in msg and "qty=5" in msg for msg in messages)
+    assert metrics.skipped_reasons.get("ZERO_QTY", 0) == 0


### PR DESCRIPTION
## Summary
- trigger fallback candidate generation when the screener emits zero rows and log dashboard reload attempts consistently
- rebuild the fallback candidate normalizer and metrics writer to guard inputs and always populate downstream CSV artifacts
- update trade execution sizing with minimum order targets, optional bump-to-one shares, richer skip summaries, and surface fallback status in the dashboard
- expand tests for fallback building, pipeline tokens, executor sizing, and metrics behaviour

## Testing
- pytest tests/test_fallback_candidates.py tests/test_pipeline_tokens.py tests/test_execute_trades_logging.py tests/test_executor_sizing.py tests/test_metrics_no_trades_file_writes_summary.py


------
https://chatgpt.com/codex/tasks/task_e_68efaa786b588331b295fd0bef1cb211