### PR TITLE
Improve trade execution safeguards and pipeline fallback

### DIFF
--- a/tests/test_execute_sizing.py
+++ b/tests/test_execute_sizing.py
@@ -1,0 +1,44 @@
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts.execute_trades import ExecutionMetrics, ExecutorConfig, TradeExecutor
+
+
+@pytest.mark.alpaca_optional
+def test_zero_qty_prevented_by_min_order(monkeypatch, caplog, tmp_path: Path) -> None:
+    config = ExecutorConfig(
+        source=tmp_path / "candidates.csv",
+        allocation_pct=0.02,
+        min_order_usd=200.0,
+        allow_bump_to_one=True,
+        dry_run=True,
+        time_window="any",
+    )
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": "LIMIT",
+                "close": 310.0,
+                "entry_price": 310.0,
+                "score": 5.0,
+                "universe_count": 50,
+                "score_breakdown": "{}",
+            }
+        ]
+    )
+    metrics = ExecutionMetrics()
+    executor = TradeExecutor(config, None, metrics)
+    monkeypatch.setattr(executor, "fetch_buying_power", lambda: 1000.0)
+    monkeypatch.setattr(executor, "evaluate_time_window", lambda log=True: (True, "ok", "any"))
+
+    caplog.set_level(logging.INFO, logger="execute_trades")
+    caplog.clear()
+
+    rc = executor.execute(df, prefiltered=df.to_dict("records"))
+    assert rc == 0
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("ZERO_QTY_AFTER_BUMP" in msg for msg in messages)
+    assert metrics.skipped_reasons.get("ZERO_QTY", 0) == 1

--- a/tests/test_execute_trades_logging.py
+++ b/tests/test_execute_trades_logging.py
@@ -176,7 +176,7 @@ def test_time_window_skip_logs_summary(tmp_path, monkeypatch, caplog):
     caplog.clear()
 
     def fake_window(self):
-        return False, "outside premarket (NY)"
+        return False, "outside premarket (NY)", "premarket"
 
     monkeypatch.setattr(execute_mod.TradeExecutor, "evaluate_time_window", fake_window)
     rc = executor.execute(df)

--- a/tests/test_orchestrator_logging.py
+++ b/tests/test_orchestrator_logging.py
@@ -31,7 +31,6 @@ def test_fallback_and_summary_logged_once(tmp_path: Path, monkeypatch, caplog):
     monkeypatch.setattr(run_pipeline, "BASE_DIR", tmp_path)
     monkeypatch.setattr(run_pipeline, "load_env", lambda *a, **k: ([], []))
     monkeypatch.setattr(run_pipeline, "configure_logging", lambda: None)
-    monkeypatch.setattr(run_pipeline, "assert_alpaca_creds", lambda: {"id": "ok"})
     monkeypatch.setattr(run_pipeline, "_record_health", lambda stage: {})
     monkeypatch.setattr(run_pipeline, "run_cmd", lambda cmd, name: 0)
     monkeypatch.setattr(run_pipeline, "emit_metric", lambda *a, **k: None)

--- a/tests/test_run_pipeline_summary.py
+++ b/tests/test_run_pipeline_summary.py
@@ -31,7 +31,6 @@ def test_pipeline_summary_zero_candidates(tmp_path, monkeypatch, caplog):
 
     monkeypatch.setattr(run_pipeline, "load_env", lambda *a, **k: ([], []))
     monkeypatch.setattr(run_pipeline, "configure_logging", lambda: None)
-    monkeypatch.setattr(run_pipeline, "assert_alpaca_creds", lambda: {"id": "ok"})
     monkeypatch.setattr(run_pipeline, "_record_health", lambda stage: {})
     monkeypatch.setattr(run_pipeline, "run_cmd", lambda cmd, name: 0)
     monkeypatch.setattr(run_pipeline, "emit_metric", lambda *a, **k: None)

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -23,7 +23,7 @@ def test_sizing_produces_positive_quantities(monkeypatch):
     monkeypatch.setattr(executor, "fetch_existing_positions", lambda: set())
     monkeypatch.setattr(executor, "fetch_open_order_symbols", lambda: set())
     monkeypatch.setattr(executor, "fetch_buying_power", lambda: 10000.0)
-    monkeypatch.setattr(executor, "evaluate_time_window", lambda log=True: (True, "ok"))
+    monkeypatch.setattr(executor, "evaluate_time_window", lambda log=True: (True, "ok", "any"))
 
     captured: list[dict] = []
 

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -33,8 +33,9 @@ def test_premarket_window_allows_with_timezone_fallback(monkeypatch, caplog):
     monkeypatch.setattr(execute_trades, "datetime", frozen)
     caplog.set_level("INFO", logger="execute_trades")
 
-    allowed, message = executor.evaluate_time_window()
+    allowed, message, resolved = executor.evaluate_time_window()
 
     assert allowed is True
     assert "premarket window open" in message
+    assert resolved == "premarket"
     assert any("invalid market timezone" in msg for msg in caplog.messages)

--- a/tests/test_timewindow.py
+++ b/tests/test_timewindow.py
@@ -30,7 +30,8 @@ def test_premarket_window_handles_7am(monkeypatch):
     frozen = _FrozenDateTime(datetime(2024, 3, 1, 12, 0, tzinfo=timezone.utc))
     monkeypatch.setattr(execute_trades, "datetime", frozen)
 
-    allowed, message = executor.evaluate_time_window()
+    allowed, message, resolved = executor.evaluate_time_window()
 
     assert allowed is True
     assert "premarket window open" in message
+    assert resolved == "premarket"


### PR DESCRIPTION
## Summary
- enforce auto-resolved market windows, deterministic sizing, and fail-fast Alpaca auth checks in `scripts/execute_trades.py`
- ensure fallback generator always writes canonical tradeable rows with CLI filters and log the source in `scripts/fallback_candidates.py`
- harden pipeline orchestration with fallback summaries, metrics safeguards, dashboard reload warnings, and auto time-window injection

## Testing
- pytest tests/test_execute_sizing.py tests/test_executor_sizing.py tests/test_time_window.py tests/test_timewindow.py tests/test_pipeline_tokens.py tests/test_orchestrator_logging.py -q
- pytest tests/test_run_pipeline_summary.py -q
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68f119455ee083318a04b0b0c59a7c34