### PR TITLE
Improve trade execution logging and metrics safeguards

### DIFF
--- a/tests/test_metrics_no_trades_file_writes_summary.py
+++ b/tests/test_metrics_no_trades_file_writes_summary.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from scripts import metrics
 
@@ -33,6 +34,11 @@ def test_metrics_handles_missing_trades(tmp_path, monkeypatch):
 
     summary = pd.read_csv(summary_path)
     assert set(metrics.REQUIRED_COLUMNS) == set(summary.columns)
-    if summary.empty:
-        return
-    assert summary.iloc[0]["total_trades"] == 0
+    assert not summary.empty
+    row = summary.iloc[0]
+    assert row["total_trades"] == 0
+    assert row["net_pnl"] == pytest.approx(0.0)
+    assert row["win_rate"] == pytest.approx(0.0)
+    assert row["expectancy"] == pytest.approx(0.0)
+    assert row["profit_factor"] == pytest.approx(0.0)
+    assert row["max_drawdown"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add explicit [CALL] logging, warning hooks, and dry-run safeguards around trade execution API usage and metrics persistence
- harden buying power fallback, auto time window logic, trailing stop logging, and execute metrics aggregation
- keep dashboards resilient when execute metrics exist without trade logs and expand tests for dry-run execution metrics

## Testing
- python -m compileall .
- pytest tests/test_execute_trades_logging.py tests/test_metrics_no_trades_file_writes_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68f1505091888331a2716f407549aaaf