### PR TITLE
Improve execute_trades logging and clock guard

### DIFF
--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -31,7 +31,7 @@ def test_sizing_produces_positive_quantities(monkeypatch):
         if event == "DRY_RUN_ORDER":
             captured.append(payload)
 
-    monkeypatch.setattr(executor, "log_event", capture_event)
+    monkeypatch.setattr(executor, "log_info", capture_event)
 
     records = [
         {


### PR DESCRIPTION
## Summary
- replace legacy log_event/log_call usage with a shared log_info helper and add a guarded Alpaca clock probe
- enforce min order sizing math, guard metrics persistence, and enhance run_executor logging/clock handling
- adjust executor logging tests to cover new helpers and prevent NameError regressions

## Testing
- `pytest tests/test_execute_trades_logging.py tests/test_sizing.py`


------
https://chatgpt.com/codex/tasks/task_e_68f2a3658edc83319f6802ed57daa238