### PR TITLE
Improve screener KPI fallbacks and paper badge UX

### DIFF
--- a/dashboards/utils.py
+++ b/dashboards/utils.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def safe_read_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if isinstance(payload, dict):
+            return payload
+        logger.warning("METRICS_READ_FAIL json path=%s err=%s", path, "non-object payload")
+    except FileNotFoundError:
+        logger.warning("METRICS_READ_FAIL json path=%s err=%s", path, "missing")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("METRICS_READ_FAIL json path=%s err=%s", path, exc)
+    return {}
+
+
+def safe_read_metrics_csv(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            row = next(reader, None)
+        if isinstance(row, dict):
+            return row
+    except FileNotFoundError:
+        logger.warning("METRICS_READ_FAIL csv path=%s err=%s", path, "missing")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("METRICS_READ_FAIL csv path=%s err=%s", path, exc)
+    return {}
+
+
+def parse_pipeline_summary(path: Path) -> Dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except FileNotFoundError:
+        logger.warning("PIPELINE_SUMMARY_PARSE_FAIL path=%s err=%s", path, "missing")
+        return {}
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("PIPELINE_SUMMARY_PARSE_FAIL path=%s err=%s", path, exc)
+        return {}
+
+    for line in reversed(text.splitlines()):
+        if "PIPELINE_SUMMARY" not in line:
+            continue
+        match = re.search(r"symbols_in=(\d+).+with_bars=(\d+).+rows=(\d+)", line)
+        if match:
+            return {
+                "last_run_utc": None,
+                "symbols_in": int(match.group(1)),
+                "symbols_with_bars": int(match.group(2)),
+                "rows": int(match.group(3)),
+            }
+        break
+    return {}
+
+
+def coerce_kpi_types(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key in ("symbols_in", "symbols_with_bars", "bars_rows_total", "rows"):
+        value = metrics.get(key)
+        if value in ("", None):
+            result[key] = None
+            continue
+        try:
+            result[key] = int(value)
+        except (TypeError, ValueError):
+            result[key] = None
+    result["last_run_utc"] = (
+        metrics.get("last_run_utc")
+        or metrics.get("last_run")
+        or None
+    )
+    return result

--- a/tests/test_kpi_loader.py
+++ b/tests/test_kpi_loader.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.alpaca_optional
+def test_load_kpis_infers_from_pipeline(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    data_dir = repo_root / "data"
+    logs_dir = repo_root / "logs"
+    data_dir.mkdir(parents=True)
+    logs_dir.mkdir(parents=True)
+
+    pipeline_log = logs_dir / "pipeline.log"
+    pipeline_log.write_text(
+        "2024-05-20T12:00:00Z PIPELINE_SUMMARY symbols_in=321 with_bars=300 rows=111\n"
+    )
+
+    monkeypatch.setenv("JBRAVO_HOME", str(repo_root))
+    sys.modules.pop("dashboards.screener_health", None)
+    screener_health = importlib.import_module("dashboards.screener_health")
+    try:
+        kpis = screener_health.load_kpis()
+
+        assert kpis["symbols_in"] == 321
+        assert kpis["symbols_with_bars"] == 300
+        assert kpis["rows"] == 111
+        assert kpis["source"] == "pipeline.log (inferred)"
+    finally:
+        sys.modules.pop("dashboards.screener_health", None)


### PR DESCRIPTION
## Summary
- add reusable safe loaders for dashboard metrics artifacts and pipeline log inference
- wire Screener Health KPIs to prefer JSON, then CSV, and finally pipeline log data while surfacing the data source and paper/live badge
- refresh dashboard execution/screener headers to always show environment badge and keep trades panel friendly when data files are absent
- cover pipeline log inference with a focused regression test

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f2aa8020908331bba1e03330028e2a