### PR TITLE
Ensure screener metrics stay consistent across pipeline

### DIFF
--- a/dashboards/utils.py
+++ b/dashboards/utils.py
@@ -51,14 +51,20 @@ def parse_pipeline_summary(path: Path) -> Dict[str, Any]:
     for line in reversed(text.splitlines()):
         if "PIPELINE_SUMMARY" not in line:
             continue
-        match = re.search(r"symbols_in=(\d+).+with_bars=(\d+).+rows=(\d+)", line)
+        match = re.search(
+            r"symbols_in=(\d+)\s+with_bars=(\d+)\s+rows=(\d+)(?:[^\n\r]*?(?:\sbar_rows|\sbars_rows_total)=(\d+))?",
+            line,
+        )
         if match:
-            return {
+            payload = {
                 "last_run_utc": None,
                 "symbols_in": int(match.group(1)),
                 "symbols_with_bars": int(match.group(2)),
                 "rows": int(match.group(3)),
             }
+            if match.group(4):
+                payload["bars_rows_total"] = int(match.group(4))
+            return payload
         break
     return {}
 

--- a/scripts/fallback_wrapper.sh
+++ b/scripts/fallback_wrapper.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -a
+if [ -f "$HOME/.config/jbravo/.env" ]; then
+  . "$HOME/.config/jbravo/.env"
+fi
+set +a
 rows=$(wc -l < data/latest_candidates.csv 2>/dev/null || echo 0)
 if [ "$rows" -lt 2 ]; then
   python -m scripts.fallback_candidates --top-n 3 --min-order-usd 300 || true

--- a/tests/test_kpi_loader.py
+++ b/tests/test_kpi_loader.py
@@ -26,6 +26,7 @@ def test_load_kpis_infers_from_pipeline(tmp_path, monkeypatch):
         assert kpis["symbols_in"] == 321
         assert kpis["symbols_with_bars"] == 300
         assert kpis["rows"] == 111
-        assert kpis["source"] == "pipeline.log (inferred)"
+        assert kpis["source"] == "pipeline summary (recovered)"
+        assert kpis["_kpi_inferred_from_log"] is True
     finally:
         sys.modules.pop("dashboards.screener_health", None)

--- a/tests/test_pipeline_metrics_sync.py
+++ b/tests/test_pipeline_metrics_sync.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import run_pipeline
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.mark.alpaca_optional
+def test_write_complete_screener_metrics_backfills_from_log(tmp_path):
+    base_dir = tmp_path
+    data_dir = base_dir / "data"
+    logs_dir = base_dir / "logs"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+
+    metrics_path = data_dir / "screener_metrics.json"
+    metrics_path.write_text(json.dumps({"last_run_utc": "2024-05-20T12:00:00Z"}), encoding="utf-8")
+
+    log_lines = [
+        "2024-05-20T11:59:59Z [INFO] PIPELINE_START steps=screener,metrics",
+        "2024-05-20T12:00:02Z [INFO] PIPELINE_SUMMARY symbols_in=25 with_bars=20 rows=9 bar_rows=450",
+        "2024-05-20T12:00:03Z [INFO] PIPELINE_END rc=0 duration=4.0s",
+    ]
+    _write(logs_dir / "pipeline.log", "\n".join(log_lines))
+
+    top_candidates = data_dir / "top_candidates.csv"
+    top_candidates.write_text("symbol,score\nAAPL,1.0\nMSFT,2.0\n", encoding="utf-8")
+
+    result = run_pipeline.write_complete_screener_metrics(base_dir)
+
+    assert result["symbols_in"] == 25
+    assert result["symbols_with_bars"] == 20
+    assert result["rows"] == 9
+    assert result["bars_rows_total"] == 450
+    assert result["last_run_utc"] == "2024-05-20T12:00:00Z"
+
+    written = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert written == result
+
+
+@pytest.mark.alpaca_optional
+def test_write_complete_screener_metrics_counts_rows_when_missing(tmp_path):
+    base_dir = tmp_path
+    data_dir = base_dir / "data"
+    logs_dir = base_dir / "logs"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+
+    metrics_path = data_dir / "screener_metrics.json"
+    metrics_path.write_text(json.dumps({}), encoding="utf-8")
+
+    top_candidates = data_dir / "top_candidates.csv"
+    top_candidates.write_text(
+        "symbol,score\nAAPL,1.0\nMSFT,2.0\nNVDA,3.0\n", encoding="utf-8"
+    )
+
+    result = run_pipeline.write_complete_screener_metrics(base_dir)
+
+    assert result["rows"] == 3
+    assert result["last_run_utc"]
+    assert json.loads(metrics_path.read_text(encoding="utf-8")) == result


### PR DESCRIPTION
## Summary
- add a metrics backfill helper to the pipeline so every run rewrites a complete `screener_metrics.json`
- harden the dashboard KPI loader to recover missing counts from pipeline logs, CSV summaries, or candidate CSVs
- preserve numeric metrics when fallback utilities run and load scheduler environment before invoking them
- add regression tests covering the KPI sync helper and dashboard backfill behaviour

## Testing
- pytest tests/test_pipeline_metrics_sync.py tests/test_kpi_loader.py tests/test_dashboard_consistency.py


------
https://chatgpt.com/codex/tasks/task_e_68f2bf40b3748331bddb9d303014b788