### PR TITLE
Ensure pipeline KPIs and logs stay consistent

### DIFF
--- a/scripts/fallback_candidates.py
+++ b/scripts/fallback_candidates.py
@@ -582,6 +582,15 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Minimum 20-day average dollar volume threshold",
     )
     parser.add_argument(
+        "--min-order-usd",
+        type=float,
+        default=None,
+        help=(
+            "Optional compatibility flag; ignored because order sizing is handled "
+            "by scripts.execute_trades."
+        ),
+    )
+    parser.add_argument(
         "--min-price",
         type=float,
         default=2.0,
@@ -613,6 +622,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - fallback - %(message)s")
 
     base_dir = Path(args.base_dir)
+    if args.min_order_usd is not None:
+        LOGGER.info(
+            "fallback_candidates: ignoring --min-order-usd=%s (compat)",
+            args.min_order_usd,
+        )
     scored_path = Path(SCORED_CANDIDATES)
     latest_path = Path(LATEST_CANDIDATES)
     top_path = latest_path.parent / "top_candidates.csv"


### PR DESCRIPTION
## Summary
- ensure the pipeline writes fully populated screener_metrics.json values by parsing the summary log and falling back to CSV counts
- fix the dashboard stale-log detector so it recognizes both [INFO] and " - INFO - " messages
- tolerate the --min-order-usd flag in fallback_candidates for CLI compatibility

## Testing
- pytest tests/test_pipeline_metrics_sync.py


------
https://chatgpt.com/codex/tasks/task_e_68f57531104c83319f4e72baac899a94