### PR TITLE
Refine pipeline summary parsing

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -30,7 +30,7 @@ _SUMMARY_RE = re.compile(
     r"PIPELINE_SUMMARY.*?symbols_in=(?P<symbols_in>\d+).*?"
     r"with_bars=(?P<symbols_with_bars>\d+).*?"
     r"rows=(?P<rows>\d+)"
-    r"(?:.*?bar[s]?_rows(?:_total)?=(?P<bars_rows_total>\d+))?"
+    r"(?:.*?(?:bars?_rows(?:_total)?)=(?P<bars_rows_total>\d+))?"
 )
 
 


### PR DESCRIPTION
## Summary
- update the pipeline summary regex so screener metrics capture either `bar_rows` or `bars_rows_total`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f57940892083319456bb38f76bba67