### PR TITLE
Add PythonAnywhere task wrapper for nightly pipeline

### DIFF
--- a/bin/run_pipeline_task.sh
+++ b/bin/run_pipeline_task.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Task-safe nightly pipeline launcher for PythonAnywhere.
+# No "source" or backslashes; uses venv python directly.
+BASE="/home/RasPatrick/jbravo_screener"
+VENV_PY="/home/RasPatrick/.virtualenvs/jbravo-env/bin/python"
+cd "$BASE"
+# Run pipeline with split args (avoids quoting headaches in schedulers)
+"$VENV_PY" -m scripts.run_pipeline \
+  --steps screener,backtest,metrics \
+  --screener-args-split --feed iex --dollar-vol-min 2000000 --reuse-cache true
+
+# Ensure KPIs are non-null even on strict nights (writes screener_metrics.json)
+"$VENV_PY" - <<'PY'
+from pathlib import Path
+from scripts.run_pipeline import write_complete_screener_metrics
+print(write_complete_screener_metrics(Path(".")))
+PY
+
+exit 0


### PR DESCRIPTION
## Summary
- add a standalone bash wrapper to launch the nightly pipeline via the virtualenv interpreter
- ensure screener metrics are regenerated after the pipeline run to keep KPIs populated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7c1e19d748331897009893a77cb24