### PR TITLE
Harden premarket wrapper and improve auth diagnostics

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -1,86 +1,57 @@
 #!/usr/bin/env bash
-# Robust shell settings
-set -euo pipefail
-IFS=$'\n\t'
+set -Eeuo pipefail
 
-# Load venv + .env
-# (assumes PA tasks call this script directly)
-export TZ="${TZ:-UTC}"
+# Force New York timezone in this shell so hhmm comparisons are unambiguous
+export TZ="America/New_York"
+
 cd /home/RasPatrick/jbravo_screener
-source /home/RasPatrick/.virtualenvs/jbravo-env/bin/activate || true
-set -a
-. ~/.config/jbravo/.env
-set +a
+# venv + .env
+source /home/RasPatrick/.virtualenvs/jbravo-env/bin/activate
+set -a; . ~/.config/jbravo/.env; set +a
 
-# --- helper: print NY time for logs
-NY_NOW="$(python - <<'PY'
-from datetime import datetime
-import pytz
-ny = pytz.timezone("America/New_York")
-print(datetime.now(ny).strftime("%Y-%m-%d %H:%M:%S %Z"))
-PY
-)"
+log(){ echo "[WRAPPER] $*"; }
 
-# Probe Alpaca auth quickly
-python - <<'PY'
-import os
-import requests
+# 1) Probe Alpaca auth
+resp=$(python - <<'PY'
+import os,requests
 from urllib.parse import urljoin
-
-base = os.getenv("APCA_API_BASE_URL")
-key = os.getenv("APCA_API_KEY_ID")
-secret = os.getenv("APCA_API_SECRET_KEY")
-resp = requests.get(
-    urljoin(base, "/v2/account"),
-    headers={
-        "APCA-API-KEY-ID": key,
-        "APCA-API-SECRET-KEY": secret,
-    },
-    timeout=10,
+b=os.environ["APCA_API_BASE_URL"].rstrip("/")
+k=os.environ["APCA_API_KEY_ID"]; s=os.environ["APCA_API_SECRET_KEY"]
+r=requests.get(urljoin(b,"/v2/account"),
+               headers={"APCA-API-KEY-ID":k,"APCA-API-SECRET-KEY":s}, timeout=10)
+print(r.status_code, (r.json().get("buying_power") if r.ok else "0"))
+PY
 )
-ok = resp.status_code == 200
-buying_power = "0"
-if ok:
-    try:
-        payload = resp.json() or {}
-    except ValueError:
-        payload = {}
-    buying_power = payload.get("buying_power", "0")
-print(f"[WRAPPER] AUTH_OK={ok} buying_power={buying_power}")
-PY
+status=${resp%% *}; bp=${resp#* }
+log "AUTH_OK=$([ "$status" = "200" ] && echo true || echo false) buying_power=${bp}"
 
-# If today's pipeline missing, run it (best-effort)
-python - <<'PY' || true
-from pathlib import Path
-
-log_path = Path("logs/pipeline.log")
-need = True
-if log_path.exists():
-    tail = log_path.read_text(encoding="utf-8")[-8000:]
-    need = "PIPELINE_END rc=0" not in tail
-print("[WRAPPER] PIPELINE_DONE_TODAY=", str(not need))
-PY
-
-# Ensure ≥1 candidate row
-SRC="data/latest_candidates.csv"
-rows="$(wc -l < "$SRC" 2>/dev/null || echo 0)"
-if ! [[ "$rows" =~ ^[0-9]+$ ]]; then
-  rows=0
-fi
-if [ "$rows" -lt 2 ]; then
-  python -m scripts.fallback_candidates --top-n 3 || true
+# 2) Ensure we have ≥1 candidate row (header+row)
+CAND="data/latest_candidates.csv"
+rows=$( (wc -l < "$CAND" 2>/dev/null) || echo 0 )
+if [[ "${rows:-0}" -lt 2 ]]; then
+  log "No candidates (rows=${rows:-0}); running fallback..."
+  /home/RasPatrick/.virtualenvs/jbravo-env/bin/python -m scripts.fallback_candidates --top-n 3
 fi
 
-# Execute (auto resolves by NY time); extended-hours on
-# Optional env to widen premarket window (defaults to 07:00–09:30)
-#   JBRAVO_PREMARKET_START=0400
-#   JBRAVO_PREMARKET_END=0930
-echo "[WRAPPER] NY_NOW=${NY_NOW}"
-python -m scripts.execute_trades \
-  --source data/latest_candidates.csv \
-  --allocation-pct 0.06 --min-order-usd 300 --max-positions 4 \
-  --trailing-percent 3 --time-window auto --extended-hours true \
-  --cancel-after-min 35 --limit-buffer-pct 1.0 || true
+# 3) Gate on New York pre-market window (07:00–09:30 ET)
+hhmm=$(date +%H%M)   # NY time due to TZ above
+if [[ "$hhmm" -ge 0700 && "$hhmm" -lt 0930 ]]; then
+  log "NY hhmm=$hhmm → premarket; launching executor"
+  /home/RasPatrick/.virtualenvs/jbravo-env/bin/python -m scripts.execute_trades \
+    --source "$CAND" \
+    --allocation-pct 0.06 --min-order-usd 300 --max-positions 4 \
+    --trailing-percent 3 --limit-buffer-pct 1.0 \
+    --time-window premarket --extended-hours true --cancel-after-min 35
+else
+  log "NY hhmm=$hhmm → outside premarket; skip (no-op)"
+fi
 
-echo "[WRAPPER] done."
-
+# 4) Refresh dashboard + status stamp
+touch /var/www/raspatrick_pythonanywhere_com_wsgi.py
+python - <<'PY'
+import json, pathlib, datetime as dt
+path=pathlib.Path("data/last_premarket_run.json")
+path.write_text(json.dumps({"ts":dt.datetime.utcnow().isoformat()+"Z"}, indent=2))
+print(str(path))
+PY
+log "done."


### PR DESCRIPTION
## Summary
- force the pre-market wrapper to operate in New York time, harden candidate backstop handling, and streamline status logging
- probe Alpaca auth before execution, reusing the results so AUTH_STATUS always reports real buying power even when skipping for time windows

## Testing
- pytest tests/test_execute_trades_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68fa2ec1a42883319882213dfbec9148