### PR TITLE
Ensure latest candidates remain canonical across pipeline and executor

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -20,9 +20,8 @@ PY
 
 # Ensure ≥1 candidate (robust wc)
 SRC="data/latest_candidates.csv"
-rows="$(wc -l < "${SRC}" 2>/dev/null || echo 0)"
-rows="${rows:-0}"
-if [ "${rows}" -lt 2 ]; then
+rows=$(wc -l < "${SRC}" 2>/dev/null || echo 0)
+if [ "${rows:-0}" -lt 2 ]; then
   echo "[WRAPPER] candidates header-only; running fallback..."
   /home/RasPatrick/.virtualenvs/jbravo-env/bin/python -m scripts.fallback_candidates --top-n 3
 fi

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -49,7 +49,10 @@ def test_log_event_appends_and_valid_json(tmp_path, monkeypatch):
 def test_pipeline_refresh_latest(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    (data_dir / "top_candidates.csv").write_text("symbol\nAAPL\n", encoding="utf-8")
+    (data_dir / "top_candidates.csv").write_text(
+        "symbol,score,close\nAAPL,5,123.45\n",
+        encoding="utf-8",
+    )
     metrics_path = data_dir / "screener_metrics.json"
     metrics_path.write_text("{}", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add safe canonicalization helpers in the pipeline so `latest_candidates.csv` is only overwritten when price data is available and otherwise reuse or rebuild canonical output
- enrich the executor's candidate loader to repair missing price fields from `entry_price` or `scored_candidates.csv` before validating requirements
- harden the premarket wrapper row-count guard and refresh pipeline test fixture data to use canonical top rows

## Testing
- `pytest tests/test_run_pipeline.py`
- `pytest tests/test_candidates_schema.py`
- `pytest tests/test_execute_trades_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68ff9463666c83319954e9caeaef5f47