### PR TITLE
Normalize Alpaca limit prices to valid ticks

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -20,7 +20,10 @@ PY
 
 # Ensure ≥1 candidate (robust wc)
 SRC="data/latest_candidates.csv"
-rows=$(wc -l < "${SRC}" 2>/dev/null || echo 0)
+rows=0
+if [ -f "${SRC}" ]; then
+  rows=$(wc -l < "${SRC}" 2>/dev/null || echo 0)
+fi
 if [ "${rows:-0}" -lt 2 ]; then
   echo "[WRAPPER] candidates header-only; running fallback..."
   /home/RasPatrick/.virtualenvs/jbravo-env/bin/python -m scripts.fallback_candidates --top-n 3


### PR DESCRIPTION
## Summary
- normalize limit order prices to Alpaca MPV ticks and log raw versus submitted limits
- retry limit submissions that hit sub-penny errors with a one-tick adjustment
- harden the premarket wrapper when counting candidate rows

## Testing
- python -m compileall scripts/execute_trades.py

------
https://chatgpt.com/codex/tasks/task_e_6900e6749b1c8331afaee53b2427426a