### PR TITLE
Peg premarket limits to latest ask

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -19,12 +19,10 @@ print(f"[WRAPPER] AUTH_OK={r.status_code==200} buying_power={r.json().get('buyin
 PY
 
 # Ensure ≥1 candidate (robust wc)
-SRC="data/latest_candidates.csv"
-rows=0
-if [ -f "${SRC}" ]; then
-  rows=$(wc -l < "${SRC}" 2>/dev/null || echo 0)
-fi
-if [ "${rows:-0}" -lt 2 ]; then
+[ -z "${SRC:-}" ] && SRC="data/latest_candidates.csv"
+rows=$(wc -l < "${SRC}" 2>/dev/null | tr -dc '0-9')
+[ -z "${rows}" ] && rows=0
+if [ "${rows}" -lt 2 ]; then
   echo "[WRAPPER] candidates header-only; running fallback..."
   /home/RasPatrick/.virtualenvs/jbravo-env/bin/python -m scripts.fallback_candidates --top-n 3
 fi


### PR DESCRIPTION
## Summary
- fetch the latest Alpaca quote/trade in premarket to peg buy limits to the ask with a configurable buffer
- round premarket limits to penny ticks, log the price reference used, and fall back to trades when quotes are missing
- harden the premarket wrapper so candidate counting tolerates unset SRC and wc failures

## Testing
- python -m compileall scripts/execute_trades.py

------
https://chatgpt.com/codex/tasks/task_e_6904aebe378883318a91e1a277a1838a