### PR TITLE
Add nightly ranker label, evaluation, and autotuning pipeline

### DIFF
--- a/configs/ranker_v2_changelog.md
+++ b/configs/ranker_v2_changelog.md
@@ -1,0 +1,7 @@
+# Ranker v2 Weight Changelog
+
+This file is appended by `scripts/ranker_autotune.py` whenever a new configuration
+passes the walk-forward guardrails and is accepted. Each section records the
+baseline performance, the candidate uplift, and the resulting weight vector.
+
+_No updates have been recorded yet._

--- a/scripts/labels/__init__.py
+++ b/scripts/labels/__init__.py
@@ -1,0 +1,5 @@
+"""Label generation utilities for nightly ranker evaluation."""
+
+from .make_nextday_labels import main as make_nextday_labels
+
+__all__ = ["make_nextday_labels"]

--- a/scripts/labels/make_nextday_labels.py
+++ b/scripts/labels/make_nextday_labels.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+from utils.io_utils import atomic_write_bytes
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+@dataclass
+class LabelJob:
+    predictions_path: Path
+    prices_path: Path
+    output_dir: Path
+    horizon: int = 1
+    as_of: Optional[datetime] = None
+
+    def resolve_as_of(self) -> datetime:
+        if self.as_of is not None:
+            return self.as_of
+        try:
+            return datetime.strptime(self.predictions_path.stem, DATE_FORMAT)
+        except ValueError:
+            raise SystemExit(
+                "Unable to infer as-of date. Pass --date explicitly when the predictions "
+                "filename does not follow YYYY-MM-DD.csv."
+            )
+
+
+def _coerce_date(value: str) -> datetime:
+    return datetime.strptime(value, DATE_FORMAT)
+
+
+def _load_predictions(path: Path, as_of: datetime) -> pd.DataFrame:
+    if not path.exists():
+        raise SystemExit(f"Predictions file not found: {path}")
+
+    frame = pd.read_csv(path)
+    if frame.empty:
+        raise SystemExit(f"Predictions file {path} is empty")
+
+    frame = frame.copy()
+    as_of_date = as_of.date()
+    frame["symbol"] = frame.get("symbol", "").astype(str).str.upper()
+
+    if "timestamp" in frame.columns:
+        timestamp = pd.to_datetime(frame["timestamp"], errors="coerce")
+        frame["as_of_date"] = timestamp.dt.date
+        frame.loc[frame["as_of_date"].isna(), "as_of_date"] = as_of_date
+    else:
+        frame["as_of_date"] = as_of_date
+
+    if "Score" not in frame.columns and "score" in frame.columns:
+        frame["Score"] = pd.to_numeric(frame["score"], errors="coerce")
+
+    frame["as_of_date"] = frame["as_of_date"].astype("datetime64[ns]").dt.date
+    return frame
+
+
+def _load_price_history(prices_path: Path) -> pd.DataFrame:
+    if not prices_path.exists():
+        raise SystemExit(f"Price history not found: {prices_path}")
+
+    def _read_csv(candidate: Path) -> pd.DataFrame:
+        frame = pd.read_csv(candidate)
+        frame = frame.rename(columns={c: c.lower() for c in frame.columns})
+        if "symbol" not in frame.columns:
+            frame["symbol"] = candidate.stem.upper()
+        frame["symbol"] = frame["symbol"].astype(str).str.upper()
+        if "date" in frame.columns:
+            frame["date"] = pd.to_datetime(frame["date"], errors="coerce")
+        elif "timestamp" in frame.columns:
+            frame["date"] = pd.to_datetime(frame["timestamp"], errors="coerce")
+        else:
+            frame["date"] = pd.NaT
+        frame = frame.dropna(subset=["date"])
+        frame["date"] = frame["date"].dt.tz_localize(None)
+        if "close" not in frame.columns:
+            raise SystemExit(
+                f"Required column 'close' missing from {candidate}. Available columns: {list(frame.columns)}"
+            )
+        return frame[["symbol", "date", "close"]]
+
+    if prices_path.is_file():
+        history = _read_csv(prices_path)
+    else:
+        frames: list[pd.DataFrame] = []
+        for child in sorted(prices_path.glob("*.csv")):
+            if child.name.startswith("."):
+                continue
+            frames.append(_read_csv(child))
+        if not frames:
+            raise SystemExit(f"No CSV files found in {prices_path}")
+        history = pd.concat(frames, ignore_index=True)
+
+    history["date"] = history["date"].dt.date
+    history.sort_values(["symbol", "date"], inplace=True)
+    return history
+
+
+def _prepare_returns(history: pd.DataFrame, horizon: int) -> pd.DataFrame:
+    grouped = history.groupby("symbol", group_keys=False)
+    forward_close = grouped["close"].shift(-horizon)
+    returns = (forward_close - history["close"]) / history["close"]
+    prepared = history.assign(next_close=forward_close, nextday_ret=returns)
+    prepared.rename(columns={"date": "as_of_date"}, inplace=True)
+    return prepared[["symbol", "as_of_date", "close", "next_close", "nextday_ret"]]
+
+
+def _merge_predictions(predictions: pd.DataFrame, returns: pd.DataFrame) -> pd.DataFrame:
+    merged = predictions.merge(
+        returns,
+        how="left",
+        on=["symbol", "as_of_date"],
+        validate="m:1",
+    )
+    merged["nextday_ret"] = pd.to_numeric(merged["nextday_ret"], errors="coerce")
+    merged["win_>0"] = np.where(merged["nextday_ret"].gt(0), 1, 0)
+    merged.rename(columns={"close": "close_price", "next_close": "future_close"}, inplace=True)
+    return merged
+
+
+def _write_output(df: pd.DataFrame, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+    atomic_write_bytes(output_path, csv_bytes)
+
+
+def run(job: LabelJob) -> Path:
+    as_of = job.resolve_as_of()
+    predictions = _load_predictions(job.predictions_path, as_of)
+    history = _load_price_history(job.prices_path)
+    returns = _prepare_returns(history, job.horizon)
+    merged = _merge_predictions(predictions, returns)
+
+    missing = merged["nextday_ret"].isna().sum()
+    if missing:
+        symbols = ", ".join(sorted(set(merged.loc[merged["nextday_ret"].isna(), "symbol"])))
+        print(
+            f"Warning: {missing} rows are missing price data for forward returns. Symbols: {symbols}",
+        )
+
+    date_str = as_of.strftime(DATE_FORMAT)
+    output_path = job.output_dir / f"realized_{date_str}.csv"
+    _write_output(merged, output_path)
+    return output_path
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Join predictions with realized next-day returns.")
+    parser.add_argument(
+        "predictions",
+        type=Path,
+        help="Path to the nightly predictions CSV (e.g. data/predictions/2025-01-15.csv)",
+    )
+    parser.add_argument(
+        "--prices",
+        type=Path,
+        default=Path("data") / "daily_prices.csv",
+        help="CSV file or directory containing daily OHLC data.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data") / "labels",
+        help="Directory where the realized label CSV will be written.",
+    )
+    parser.add_argument(
+        "--horizon",
+        type=int,
+        default=1,
+        help="Forward horizon in trading days for realized return.",
+    )
+    parser.add_argument(
+        "--date",
+        type=_coerce_date,
+        help="Override the as-of date when the predictions filename does not encode it.",
+    )
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> Path:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    job = LabelJob(
+        predictions_path=args.predictions,
+        prices_path=args.prices,
+        output_dir=args.output_dir,
+        horizon=args.horizon,
+        as_of=args.date,
+    )
+    return run(job)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ranker_autotune.py
+++ b/scripts/ranker_autotune.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Optional
+
+import numpy as np
+import pandas as pd
+
+from utils.io_utils import atomic_write_bytes
+
+DATE_FORMAT = "%Y-%m-%d"
+DEFAULT_PF_THRESHOLD = 1.2
+DEFAULT_DRAWDOWN_CAP = 0.15
+
+
+@dataclass
+class AutotuneConfig:
+    labels_dir: Path
+    config_path: Path
+    output_dir: Path
+    lookback_days: int = 120
+    splits: int = 4
+    top_quantile: float = 0.1
+    pf_threshold: float = DEFAULT_PF_THRESHOLD
+    max_drawdown: float = DEFAULT_DRAWDOWN_CAP
+    min_sample: int = 50
+    as_of: Optional[datetime] = None
+    changelog_path: Optional[Path] = None
+
+
+@dataclass
+class FoldMetrics:
+    expectancy: float
+    profit_factor: float
+    max_drawdown: float
+    sample_size: int
+
+
+@dataclass
+class CandidateResult:
+    weights: Dict[str, float]
+    fold_metrics: list[FoldMetrics]
+    aggregate_expectancy: float
+    aggregate_profit_factor: float
+    aggregate_drawdown: float
+    total_sample: int
+
+
+class AutotuneError(RuntimeError):
+    pass
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.strptime(value, DATE_FORMAT)
+
+
+def _read_config(path: Path) -> dict:
+    if not path.exists():
+        raise AutotuneError(f"Config file not found: {path}")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except OSError as exc:
+        raise AutotuneError(f"Unable to read config file: {exc}") from exc
+
+    data: dict[str, dict[str, float]] = {}
+    section: Optional[str] = None
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith(":" ) and not line.startswith("-"):
+            section = line[:-1]
+            if section not in data:
+                data[section] = {}
+            continue
+        if ":" in line:
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            try:
+                numeric = float(value)
+            except ValueError:
+                continue
+            if section:
+                data.setdefault(section, {})[key] = numeric
+            else:
+                data[key] = numeric
+    return data
+
+
+def _write_config(path: Path, weights: Dict[str, float], base: dict) -> None:
+    thresholds = base.get("thresholds", {})
+    version = int(base.get("version", 2))
+    lines = [f"version: {version}", "weights:"]
+    for key, value in weights.items():
+        lines.append(f"  {key}: {value:.6f}")
+    if thresholds:
+        lines.append("thresholds:")
+        for key, value in thresholds.items():
+            lines.append(f"  {key}: {value}")
+    content = "\n".join(lines) + "\n"
+    atomic_write_bytes(path, content.encode("utf-8"))
+
+
+def _load_labels(cfg: AutotuneConfig, feature_keys: list[str]) -> pd.DataFrame:
+    files = []
+    for path in sorted(cfg.labels_dir.glob("realized_*.csv")):
+        try:
+            dt = _parse_date(path.stem.replace("realized_", ""))
+        except ValueError:
+            continue
+        files.append((dt, path))
+    if not files:
+        raise AutotuneError(f"No realized label files found in {cfg.labels_dir}")
+
+    end_date = cfg.as_of or files[-1][0]
+    start_date = end_date - timedelta(days=cfg.lookback_days - 1)
+    selected = [(dt, path) for dt, path in files if start_date <= dt <= end_date]
+    if not selected:
+        raise AutotuneError("No realized label files fall within the requested window")
+
+    frames: list[pd.DataFrame] = []
+    for dt, path in selected:
+        frame = pd.read_csv(path)
+        if frame.empty:
+            continue
+        frame = frame.copy()
+        frame["as_of"] = dt.date()
+        frames.append(frame)
+
+    if not frames:
+        raise AutotuneError("Label files are empty for tuning window")
+
+    combined = pd.concat(frames, ignore_index=True)
+    combined["nextday_ret"] = pd.to_numeric(combined.get("nextday_ret"), errors="coerce")
+    combined.dropna(subset=["nextday_ret"], inplace=True)
+    if combined.empty:
+        raise AutotuneError("No realized returns available for tuning")
+
+    missing_features = [key for key in feature_keys if key not in combined.columns]
+    if missing_features:
+        raise AutotuneError(
+            "Feature columns missing from labels: " + ", ".join(missing_features)
+        )
+
+    for key in feature_keys:
+        combined[key] = pd.to_numeric(combined[key], errors="coerce")
+    combined.dropna(subset=feature_keys, inplace=True)
+    if combined.empty:
+        raise AutotuneError("Feature columns contain only NaN values")
+
+    combined.sort_values(["as_of"], inplace=True)
+    combined.reset_index(drop=True, inplace=True)
+    return combined
+
+
+def _walk_forward_splits(dates: pd.Series, splits: int, min_train: int = 3) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    unique_dates = np.array(sorted(pd.to_datetime(dates.dropna().unique())))
+    if unique_dates.size < (min_train + 1):
+        return iter([])
+
+    step = max(1, math.floor((unique_dates.size - min_train) / max(1, splits)))
+    for idx in range(splits):
+        train_end = min_train + idx * step
+        if train_end >= unique_dates.size:
+            break
+        test_end = min(unique_dates.size, train_end + step)
+        train_mask = dates.isin(unique_dates[:train_end])
+        test_mask = dates.isin(unique_dates[train_end:test_end])
+        if not test_mask.any():
+            continue
+        yield train_mask.to_numpy(), test_mask.to_numpy()
+
+
+def _standardise(train: pd.DataFrame, test: pd.DataFrame, feature_keys: list[str]) -> tuple[pd.DataFrame, pd.DataFrame]:
+    mean = train[feature_keys].mean()
+    std = train[feature_keys].std(ddof=0).replace(0, 1.0)
+    train_scaled = (train[feature_keys] - mean) / std
+    test_scaled = (test[feature_keys] - mean) / std
+    return train_scaled, test_scaled
+
+
+def _score_frame(scaled: pd.DataFrame, weights: Dict[str, float], feature_keys: list[str]) -> pd.Series:
+    ordered = np.array([weights[key] for key in feature_keys])
+    return scaled.to_numpy() @ ordered
+
+
+def _profit_factor(returns: pd.Series) -> float:
+    gains = returns[returns > 0].sum()
+    losses = returns[returns < 0].sum()
+    if losses == 0:
+        return float("inf") if gains > 0 else 0.0
+    return gains / abs(losses)
+
+
+def _max_drawdown(returns: pd.Series, dates: pd.Series) -> float:
+    frame = pd.DataFrame({"date": pd.to_datetime(dates), "ret": returns})
+    frame.sort_values("date", inplace=True)
+    equity = (1 + frame["ret"].fillna(0.0)).cumprod()
+    running_max = equity.cummax()
+    drawdown = (equity / running_max) - 1
+    return float(drawdown.min())
+
+
+def _evaluate_candidate(
+    df: pd.DataFrame,
+    weights: Dict[str, float],
+    feature_keys: list[str],
+    cfg: AutotuneConfig,
+) -> CandidateResult:
+    fold_metrics: list[FoldMetrics] = []
+    collected_returns: list[pd.Series] = []
+
+    for train_mask, test_mask in _walk_forward_splits(df["as_of"], cfg.splits):
+        train = df.loc[train_mask]
+        test = df.loc[test_mask]
+        if len(train) < len(feature_keys) or test.empty:
+            continue
+        train_scaled, test_scaled = _standardise(train, test, feature_keys)
+        test_scores = _score_frame(test_scaled, weights, feature_keys)
+        threshold = np.quantile(test_scores, 1 - cfg.top_quantile)
+        selected = test_scores >= threshold
+        selected_returns = test.loc[selected, "nextday_ret"].astype(float)
+        if selected_returns.empty:
+            continue
+        pf = _profit_factor(selected_returns)
+        dd = _max_drawdown(selected_returns, test.loc[selected, "as_of"])
+        expectancy = float(selected_returns.mean())
+        fold_metrics.append(
+            FoldMetrics(
+                expectancy=expectancy,
+                profit_factor=float(pf),
+                max_drawdown=float(dd),
+                sample_size=int(selected_returns.size),
+            )
+        )
+        collected_returns.append(selected_returns)
+
+    if not fold_metrics:
+        raise AutotuneError("Unable to evaluate candidate; insufficient folds")
+
+    combined_returns = pd.concat(collected_returns).sort_index()
+    aggregate_expectancy = float(combined_returns.mean())
+    aggregate_profit_factor = float(_profit_factor(combined_returns))
+    aggregate_drawdown = float(_max_drawdown(combined_returns, df.loc[combined_returns.index, "as_of"]))
+    total_sample = int(combined_returns.size)
+
+    return CandidateResult(
+        weights=weights,
+        fold_metrics=fold_metrics,
+        aggregate_expectancy=aggregate_expectancy,
+        aggregate_profit_factor=aggregate_profit_factor,
+        aggregate_drawdown=aggregate_drawdown,
+        total_sample=total_sample,
+    )
+
+
+def _generate_candidates(base_weights: Dict[str, float]) -> Iterator[Dict[str, float]]:
+    keys = list(base_weights.keys())
+    multipliers = [0.8, 1.0, 1.2]
+    for combo in np.array(np.meshgrid(*([multipliers] * len(keys)))).T.reshape(-1, len(keys)):
+        weights = {key: round(base_weights[key] * float(multiplier), 6) for key, multiplier in zip(keys, combo)}
+        yield weights
+
+
+def _guardrails_pass(result: CandidateResult, cfg: AutotuneConfig) -> bool:
+    if result.total_sample < cfg.min_sample:
+        return False
+    if not math.isfinite(result.aggregate_profit_factor) or result.aggregate_profit_factor < cfg.pf_threshold:
+        return False
+    if result.aggregate_drawdown < -cfg.max_drawdown:
+        return False
+    return True
+
+
+def _append_changelog(path: Path, as_of: datetime, baseline: CandidateResult, candidate: CandidateResult) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"## {as_of.strftime('%Y-%m-%d')}",
+        "", "Baseline:",
+        f"- Expectancy: {baseline.aggregate_expectancy:.6f}",
+        f"- Profit Factor: {baseline.aggregate_profit_factor:.3f}",
+        f"- Max Drawdown: {baseline.aggregate_drawdown:.3f}",
+        "", "Candidate:",
+        f"- Expectancy: {candidate.aggregate_expectancy:.6f}",
+        f"- Profit Factor: {candidate.aggregate_profit_factor:.3f}",
+        f"- Max Drawdown: {candidate.aggregate_drawdown:.3f}",
+        "", "Weights:",
+    ]
+    for key, value in candidate.weights.items():
+        lines.append(f"- {key}: {value:.6f}")
+    lines.append("")
+
+    content = "\n".join(lines)
+    if path.exists():
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(content + "\n")
+    else:
+        atomic_write_bytes(path, (content + "\n").encode("utf-8"))
+
+
+def autotune(cfg: AutotuneConfig) -> Optional[Path]:
+    base = _read_config(cfg.config_path)
+    base_weights = base.get("weights")
+    if not base_weights:
+        raise AutotuneError("Config missing 'weights' section")
+
+    feature_keys = list(base_weights.keys())
+    df = _load_labels(cfg, feature_keys)
+
+    baseline_result = _evaluate_candidate(df, base_weights, feature_keys, cfg)
+
+    best_result = baseline_result
+    best_weights = base_weights
+
+    for candidate_weights in _generate_candidates(base_weights):
+        result = _evaluate_candidate(df, candidate_weights, feature_keys, cfg)
+        if result.aggregate_expectancy > best_result.aggregate_expectancy + 1e-6 and _guardrails_pass(result, cfg):
+            best_result = result
+            best_weights = candidate_weights
+
+    if best_result is baseline_result or not _guardrails_pass(best_result, cfg):
+        print("Guardrails not met or no improvement; keeping existing configuration.")
+        return None
+
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+
+    as_of = cfg.as_of or max(pd.to_datetime(df["as_of"]))
+    version_name = f"ranker_v2_{as_of.strftime('%Y%m%d')}"
+    output_path = cfg.output_dir / f"{version_name}.yml"
+    _write_config(output_path, best_weights, base)
+
+    current_link = cfg.output_dir / "ranker_v2_current.yml"
+    if current_link.exists() or current_link.is_symlink():
+        current_link.unlink()
+    current_link.symlink_to(output_path.name)
+
+    if cfg.changelog_path:
+        _append_changelog(cfg.changelog_path, as_of, baseline_result, best_result)
+
+    metadata = {
+        "generated_at_utc": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "as_of": as_of.strftime(DATE_FORMAT),
+        "output": str(output_path),
+        "weights": best_weights,
+        "baseline_expectancy": baseline_result.aggregate_expectancy,
+        "candidate_expectancy": best_result.aggregate_expectancy,
+        "candidate_profit_factor": best_result.aggregate_profit_factor,
+        "candidate_drawdown": best_result.aggregate_drawdown,
+        "sample_size": best_result.total_sample,
+    }
+    atomic_write_bytes(
+        (cfg.output_dir / f"{version_name}.json"),
+        json.dumps(metadata, indent=2).encode("utf-8"),
+    )
+    return output_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Walk-forward autotuning for the ranker weights.")
+    parser.add_argument(
+        "--labels-dir",
+        type=Path,
+        default=Path("data") / "labels",
+        help="Directory containing realized label CSVs.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs") / "ranker_v2.yml",
+        help="Path to the base ranker configuration.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("configs"),
+        help="Directory where tuned configurations should be written.",
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=120,
+        help="Number of days to include in the training window.",
+    )
+    parser.add_argument(
+        "--splits",
+        type=int,
+        default=4,
+        help="Number of walk-forward splits to evaluate.",
+    )
+    parser.add_argument(
+        "--top-quantile",
+        type=float,
+        default=0.1,
+        help="Top quantile of scores to evaluate for expectancy.",
+    )
+    parser.add_argument(
+        "--pf-threshold",
+        type=float,
+        default=DEFAULT_PF_THRESHOLD,
+        help="Minimum profit factor required to accept a candidate.",
+    )
+    parser.add_argument(
+        "--max-drawdown",
+        type=float,
+        default=DEFAULT_DRAWDOWN_CAP,
+        help="Maximum allowable drawdown (absolute value).",
+    )
+    parser.add_argument(
+        "--min-sample",
+        type=int,
+        default=50,
+        help="Minimum number of validation samples required to accept a candidate.",
+    )
+    parser.add_argument(
+        "--as-of",
+        type=_parse_date,
+        help="Override the as-of date used for filtering realized labels.",
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=Path("configs") / "ranker_v2_changelog.md",
+        help="Path to the changelog file that records accepted updates.",
+    )
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> Optional[Path]:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    cfg = AutotuneConfig(
+        labels_dir=args.labels_dir,
+        config_path=args.config,
+        output_dir=args.output_dir,
+        lookback_days=args.lookback_days,
+        splits=args.splits,
+        top_quantile=args.top_quantile,
+        pf_threshold=args.pf_threshold,
+        max_drawdown=args.max_drawdown,
+        min_sample=args.min_sample,
+        as_of=args.as_of,
+        changelog_path=args.changelog,
+    )
+    return autotune(cfg)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AutotuneError as exc:
+        raise SystemExit(str(exc))

--- a/scripts/ranker_eval.py
+++ b/scripts/ranker_eval.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+from utils.io_utils import atomic_write_bytes
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+@dataclass
+class EvalConfig:
+    labels_dir: Path
+    output_dir: Path
+    days: int = 60
+    score_column: str = "Score"
+    as_of: Optional[datetime] = None
+
+
+@dataclass
+class EvalOutputs:
+    summary_path: Path
+    deciles_path: Path
+
+
+class EvaluationError(RuntimeError):
+    pass
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.strptime(value, DATE_FORMAT)
+
+
+def _list_label_files(directory: Path) -> list[tuple[datetime, Path]]:
+    files: list[tuple[datetime, Path]] = []
+    for path in sorted(directory.glob("realized_*.csv")):
+        try:
+            date_value = _parse_date(path.stem.replace("realized_", ""))
+        except ValueError:
+            continue
+        files.append((date_value, path))
+    return files
+
+
+def _load_window(cfg: EvalConfig) -> pd.DataFrame:
+    if not cfg.labels_dir.exists():
+        raise EvaluationError(f"Labels directory not found: {cfg.labels_dir}")
+
+    files = _list_label_files(cfg.labels_dir)
+    if not files:
+        raise EvaluationError(f"No realized label files found in {cfg.labels_dir}")
+
+    end_date = cfg.as_of or files[-1][0]
+    start_date = end_date - timedelta(days=cfg.days - 1)
+
+    selected = [(dt, path) for dt, path in files if start_date <= dt <= end_date]
+    if not selected:
+        raise EvaluationError("No realized label files fall within the requested window")
+
+    frames: list[pd.DataFrame] = []
+    for dt, path in selected:
+        frame = pd.read_csv(path)
+        if frame.empty:
+            continue
+        frame = frame.copy()
+        frame["as_of"] = dt.date()
+        frames.append(frame)
+
+    if not frames:
+        raise EvaluationError("Label files are empty for the requested window")
+
+    combined = pd.concat(frames, ignore_index=True)
+    combined["nextday_ret"] = pd.to_numeric(combined.get("nextday_ret"), errors="coerce")
+    combined["win_>0"] = pd.to_numeric(combined.get("win_>0"), errors="coerce")
+    combined.dropna(subset=["nextday_ret"], inplace=True)
+
+    if combined.empty:
+        raise EvaluationError("No realized returns available after dropping missing values")
+
+    score_column = None
+    for candidate in [cfg.score_column, "Score", "score"]:
+        if candidate in combined.columns:
+            score_column = candidate
+            break
+    if score_column is None:
+        combined["__score"] = -combined.get("rank", pd.Series([], dtype=float))
+        score_column = "__score"
+    combined["__score_column"] = score_column
+    combined["__score_values"] = pd.to_numeric(combined[score_column], errors="coerce")
+
+    combined = combined.dropna(subset=["__score_values"])
+    if combined.empty:
+        raise EvaluationError("Score column is missing or entirely non-numeric")
+
+    combined.rename(columns={score_column: "score"}, inplace=True)
+    if score_column != "score":
+        combined.drop(columns=[score_column], inplace=True, errors="ignore")
+    return combined
+
+
+def _profit_factor(returns: pd.Series) -> float:
+    gains = returns[returns > 0].sum()
+    losses = returns[returns < 0].sum()
+    if losses == 0:
+        return float("inf") if gains > 0 else 0.0
+    return gains / abs(losses)
+
+
+def _max_drawdown(returns: pd.Series) -> float:
+    equity = (1 + returns.fillna(0.0)).cumprod()
+    running_max = equity.cummax()
+    drawdown = (equity / running_max) - 1
+    return drawdown.min()
+
+
+def _decile_frame(df: pd.DataFrame) -> pd.DataFrame:
+    deciles = pd.qcut(df["score"], q=10, labels=range(1, 11), duplicates="drop")
+    df = df.assign(decile=deciles)
+    grouped = (
+        df.groupby("decile")
+        .agg(
+            count=("symbol", "size"),
+            avg_return=("nextday_ret", "mean"),
+            hit_rate=("win_>0", "mean"),
+            avg_score=("score", "mean"),
+        )
+        .reset_index()
+    )
+    overall_hit_rate = df["win_>0"].mean() or np.nan
+    if overall_hit_rate and np.isfinite(overall_hit_rate) and overall_hit_rate != 0:
+        grouped["lift"] = grouped["hit_rate"] / overall_hit_rate
+    else:
+        grouped["lift"] = np.nan
+    return grouped
+
+
+def _calibration_points(df: pd.DataFrame, bins: int = 10) -> list[dict[str, float]]:
+    binned = pd.qcut(df["score"], q=min(bins, df["score"].nunique()), duplicates="drop")
+    grouped = (
+        df.groupby(binned)
+        .agg(avg_score=("score", "mean"), hit_rate=("win_>0", "mean"), count=("score", "size"))
+        .reset_index(drop=True)
+    )
+    return grouped.to_dict("records")
+
+
+def _stability(df: pd.DataFrame) -> list[dict[str, float]]:
+    if "as_of" not in df.columns:
+        return []
+    df = df.copy()
+    df["as_of"] = pd.to_datetime(df["as_of"], errors="coerce")
+    df.dropna(subset=["as_of"], inplace=True)
+    if df.empty:
+        return []
+    df["month"] = df["as_of"].dt.to_period("M").astype(str)
+    grouped = (
+        df.groupby("month")
+        .agg(
+            samples=("symbol", "size"),
+            hit_rate=("win_>0", "mean"),
+            expectancy=("nextday_ret", "mean"),
+        )
+        .reset_index()
+    )
+    grouped["profit_factor"] = df.groupby("month").apply(
+        lambda frame: _profit_factor(frame["nextday_ret"])
+    ).reset_index(drop=True)
+    return grouped.to_dict("records")
+
+
+def evaluate(cfg: EvalConfig) -> EvalOutputs:
+    combined = _load_window(cfg)
+
+    deciles = _decile_frame(combined)
+    deciles_output = deciles.copy()
+    deciles_output["hit_rate"] = deciles_output["hit_rate"].round(4)
+    deciles_output["avg_return"] = deciles_output["avg_return"].round(6)
+
+    returns = combined["nextday_ret"].astype(float)
+    hits = combined["win_>0"].astype(float)
+
+    expectancy = float(returns.mean())
+    hit_rate = float(hits.mean())
+    pf = float(_profit_factor(returns))
+    sharpe = float("nan")
+    std = returns.std(ddof=0)
+    if std and std > 0:
+        sharpe = float(expectancy / std * np.sqrt(252))
+
+    as_of_date = cfg.as_of or max(pd.to_datetime(combined["as_of"]))
+    decile_path = cfg.output_dir / f"deciles_{as_of_date.strftime(DATE_FORMAT)}.csv"
+    summary_path = cfg.output_dir / "summary.json"
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+
+    atomic_write_bytes(decile_path, deciles_output.to_csv(index=False).encode("utf-8"))
+
+    summary_payload = {
+        "generated_at_utc": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "as_of": as_of_date.strftime(DATE_FORMAT),
+        "window_days": cfg.days,
+        "sample_size": int(len(combined)),
+        "metrics": {
+            "hit_rate": hit_rate,
+            "expectancy": expectancy,
+            "profit_factor": pf,
+            "sharpe": sharpe,
+        },
+        "calibration": _calibration_points(combined),
+        "stability": _stability(combined),
+    }
+    atomic_write_bytes(summary_path, json.dumps(summary_payload, indent=2).encode("utf-8"))
+
+    return EvalOutputs(summary_path=summary_path, deciles_path=decile_path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Evaluate nightly ranker performance.")
+    parser.add_argument(
+        "--labels-dir",
+        type=Path,
+        default=Path("data") / "labels",
+        help="Directory containing realized label CSV files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("ranker_eval"),
+        help="Directory for evaluation artefacts.",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=60,
+        help="Number of days to include in the rolling evaluation window.",
+    )
+    parser.add_argument(
+        "--score-column",
+        type=str,
+        default="Score",
+        help="Column containing the model score (defaults to 'Score').",
+    )
+    parser.add_argument(
+        "--as-of",
+        type=_parse_date,
+        help="Evaluate up to this date (inclusive). Defaults to the latest available label.",
+    )
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> EvalOutputs:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    cfg = EvalConfig(
+        labels_dir=args.labels_dir,
+        output_dir=args.output_dir,
+        days=args.days,
+        score_column=args.score_column,
+        as_of=args.as_of,
+    )
+    return evaluate(cfg)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except EvaluationError as exc:
+        raise SystemExit(str(exc))


### PR DESCRIPTION
## Summary
- add a label generation CLI that joins nightly predictions with realized forward returns
- add ranker evaluation and guarded autotuning utilities that emit nightly artefacts
- surface the latest predictions and evaluation outputs in the dashboard and refresh ranking docs

## Testing
- python -m compileall scripts/labels/make_nextday_labels.py scripts/ranker_eval.py scripts/ranker_autotune.py dashboards/dashboard_app.py

------
https://chatgpt.com/codex/tasks/task_e_6907add49f9483318c9d1a03fb8e21cb