### PR TITLE
Add pipeline KPI backfill, evidence export, and premarket telemetry

### DIFF
--- a/tests/test_pipeline_metrics_sync.py
+++ b/tests/test_pipeline_metrics_sync.py
@@ -24,7 +24,7 @@ def test_write_complete_screener_metrics_backfills_from_log(tmp_path):
 
     log_lines = [
         "2024-05-20T11:59:59Z [INFO] PIPELINE_START steps=screener,metrics",
-        "2024-05-20T12:00:02Z [INFO] PIPELINE_SUMMARY symbols_in=25 with_bars=20 rows=9 bar_rows=450",
+        "2024-05-20T12:00:02Z [INFO] PIPELINE_SUMMARY symbols_in=25 with_bars=20 rows=9 fetch_secs=1.0 feature_secs=2.0 rank_secs=3.0 gate_secs=4.0 bars_rows_total=450 source=screener",
         "2024-05-20T12:00:03Z [INFO] PIPELINE_END rc=0 duration=4.0s",
     ]
     _write(logs_dir / "pipeline.log", "\n".join(log_lines))


### PR DESCRIPTION
## Summary
- backfill screener KPI nulls directly from the latest PIPELINE_SUMMARY and emit bars_rows_total/source in the summary log for downstream parsers
- tighten the premarket wrapper by validating candidate headers, recording auth/run telemetry, and writing last_premarket_run.json with skip counts and window status
- expand the dashboard consistency check to parse execution tokens, merge precise skip reasons, and offer an evidence bundle CLI flag with log and metrics snapshots

## Testing
- pytest tests/test_dashboard_consistency.py tests/test_pipeline_metrics_sync.py

------
https://chatgpt.com/codex/tasks/task_e_6907b023a93c83319e36eeb382debfc7