### PR TITLE
Add QA plan and shipping guidelines documentation

### DIFF
--- a/docs/qa_plan.md
+++ b/docs/qa_plan.md
@@ -1,0 +1,25 @@
+# QA Plan and Definition of Done
+
+This document outlines the quality assurance expectations and release hygiene required for the new scoring pipeline rollout.
+
+## 1. QA Plan & Definition of Done
+
+### Unit Tests
+- Validate scoring math for each component (e.g., positive MACD yields a bonus, ATR% breaches apply penalties, etc.).
+- Ensure `score_breakdown` serialization to a JSON string preserves the canonical header field.
+
+### Integration Tests
+- Dry-run pipeline generates both `top_candidates.csv` and `predictions/<date>.csv` artifacts.
+- Backtest metrics include the new fields and the dashboard reads them without raising HTTP 500 errors.
+
+### Operations Acceptance (Daily)
+- `grep` inspection confirms `PIPELINE_*` tokens (and `FALLBACK_CHECK`, when used) are present.
+- `latest_candidates.csv` retains the canonical header and contains at least one row.
+- Executor logs display buy/stop events or an explicit skip, and metrics are persisted.
+- Dashboard KPIs and screener tables refresh successfully and the evidence bundle renders.
+
+## 2. Shipping Guidelines (PR Hygiene)
+
+- Deliver small PRs per milestone with unified diffs, thorough docstrings, and without breaking CLI flags or canonical headers (executor/screener).
+- Introduce feature flags `--ranker-config` and `--featureset v2` to gate the new scoring during rollout.
+- Maintain configuration file versioning to enable instant rollback of weight changes.


### PR DESCRIPTION
## Summary
- document the QA plan and definition of done for the new scoring pipeline
- capture integration and operations acceptance criteria for daily runs
- outline shipping expectations including PR hygiene, feature flags, and rollback strategy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907bc47f0048331a0d7252d1ec03dce