### PR TITLE
Fix backtest data alignment and pipeline resilience

### DIFF
--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -1944,7 +1944,9 @@ class TradeExecutor:
         path = self.config.source
         if not path.exists():
             raise CandidateLoadError(f"Candidate file not found: {path}")
-        df = pd.read_csv(path)
+        df = pd.read_csv(path, dtype={"symbol": "string"})
+        if "symbol" in df.columns:
+            df["symbol"] = df["symbol"].astype("string")
         if df.empty:
             LOGGER.info("[INFO] NO_CANDIDATES_IN_SOURCE")
             return df


### PR DESCRIPTION
## Summary
- align backtest indicator series to the price index and drop warm-up NaNs
- guard executor candidate loading by coercing symbol column to a string dtype
- filter screener results for non-tradable rows and ensure the pipeline writes failure artifacts

## Testing
- pytest tests/test_pipeline_tokens.py tests/test_run_pipeline_summary.py

------
https://chatgpt.com/codex/tasks/task_e_6907efb0e65883319d7ca3688e344e81