### PR TITLE
Improve screener robustness and pipeline degrade handling

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -573,7 +573,7 @@ def run_backtest(symbols: List[str]) -> dict:
                 drawdown = cumulative - cumulative.cummax()
                 return float(drawdown.min()) if not drawdown.empty else 0.0
 
-            max_drawdowns = symbol_groups.apply(_max_drawdown)
+            max_drawdowns = symbol_groups.apply(_max_drawdown, include_groups=False)
 
             def _trade_returns(group: pd.DataFrame) -> pd.Series:
                 if {"entry_price", "qty"}.issubset(group.columns):
@@ -605,8 +605,8 @@ def run_backtest(symbols: List[str]) -> dict:
                     return 0.0
                 return float(np.sqrt(len(returns)) * returns.mean() / downside_std)
 
-            sharpes = symbol_groups.apply(_sharpe)
-            sortinos = symbol_groups.apply(_sortino)
+            sharpes = symbol_groups.apply(_sharpe, include_groups=False)
+            sortinos = symbol_groups.apply(_sortino, include_groups=False)
 
             summary_df["profit_factor"] = summary_df["symbol"].map(profit_factors)
             summary_df["max_drawdown"] = summary_df["symbol"].map(max_drawdowns)

--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -1946,7 +1946,7 @@ class TradeExecutor:
             raise CandidateLoadError(f"Candidate file not found: {path}")
         df = pd.read_csv(path, dtype={"symbol": "string"})
         if "symbol" in df.columns:
-            df["symbol"] = df["symbol"].astype("string")
+            df["symbol"] = df["symbol"].astype("string").str.upper()
         if df.empty:
             LOGGER.info("[INFO] NO_CANDIDATES_IN_SOURCE")
             return df


### PR DESCRIPTION
## Summary
- align the Bollinger squeeze mask with a shape-safe helper and prune invalid candidates before ranking
- ensure candidate CSV symbols are read as strings and uppercased for safe .str usage
- silence groupby.apply warnings and treat fallback-only runs as degraded successes in the nightly pipeline

## Testing
- python -m compileall scripts/ranking.py scripts/backtest.py scripts/execute_trades.py scripts/screener.py scripts/run_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_6908d43fd650833190c1609ccf440fa2