### PR TITLE
Improve gating robustness and NA-safe scoring

### DIFF
--- a/configs/ranker_v2.yml
+++ b/configs/ranker_v2.yml
@@ -10,3 +10,10 @@ thresholds:
   adx_min: 20
   atr_pct_max: 0.07
   bb_bw_pctile: 0.15
+gate_policy:
+  min_candidates: 6
+  max_tiers: 3
+  tiers:
+    - { rel_vol_min: 1.8,  adx_min: 25, atr_pct_max: 0.07, wk52_min: 0.90 }
+    - { rel_vol_min: 1.5,  adx_min: 20, atr_pct_max: 0.08, wk52_min: 0.85 }
+    - { rel_vol_min: 1.3,  adx_min: 15, atr_pct_max: 0.10, wk52_min: 0.80 }


### PR DESCRIPTION
## Summary
- add a tiered `gate_policy` to the v2 ranker configuration
- harden ranking masks to be NA-safe and update v2 gates to support tiered fallbacks
- provide default Alpaca endpoint/feed values during CLI bootstrap to ease testing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690b6472b8fc83318c231e0cea321e75