### PR TITLE
Add Alpaca tick rounding safeguards and premarket gate

### DIFF
--- a/scripts/ranking.py
+++ b/scripts/ranking.py
@@ -400,11 +400,9 @@ def _score_universe_v2(bars_df: pd.DataFrame, cfg: Mapping[str, object]) -> pd.D
             squeeze_threshold = np.nan
     bb_band_mask = bb_band.astype("float64").le(float(squeeze_threshold)).fillna(False)
     vol_bb_squeeze = bb_band_mask.astype("float64") * 0.5
-    vol_bb_squeeze = _shape_safe_where(
-        vol_bb_squeeze,
-        np.isfinite(squeeze_threshold),
-        0.0,
-    )
+    mask = np.isfinite(vol_bb_squeeze.to_numpy())
+    # Fix for shape-mismatch bug that caused screener to crash.
+    vol_bb_squeeze = vol_bb_squeeze.where(mask, 0.0)
 
     risk_atr_penalty = pd.Series(0.0, index=latest.index)
     if atr_pct_max is not None:

--- a/tests/test_execute_trades_rounding.py
+++ b/tests/test_execute_trades_rounding.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.alpaca_optional
+
+from scripts.execute_trades import (
+    _canonicalize_candidate_header,
+    _enforce_order_price_ticks,
+    round_to_tick,
+)
+
+
+class _DummyRequest:
+    def __init__(self, limit_price: float, stop_price: float) -> None:
+        self.limit_price = limit_price
+        self.stop_price = stop_price
+
+
+def test_round_to_tick_respects_us_equity_ticks() -> None:
+    assert round_to_tick(1.2345) == pytest.approx(1.23)
+    assert round_to_tick(0.123456) == pytest.approx(0.1234)
+
+
+def test_enforce_order_price_ticks_rounds_all_price_fields() -> None:
+    request = _DummyRequest(limit_price=1.2345, stop_price=0.456789)
+    _enforce_order_price_ticks(request)
+    assert request.limit_price == pytest.approx(1.23)
+    assert request.stop_price == pytest.approx(0.4567)
+
+
+def test_canonicalize_candidate_header_uppercases_symbol() -> None:
+    df = pd.DataFrame(
+        {
+            "Symbol": [" abc "],
+            "Price": [12.3456],
+            "ScoreBreakdown": [""],
+        }
+    )
+    result = _canonicalize_candidate_header(df, base_dir=None)
+    assert list(result["symbol"]) == ["ABC"]
+    # Score breakdown should default to a JSON object string and timestamp should be populated.
+    assert result.loc[result.index[0], "score_breakdown"] == "{}"
+    assert pd.notna(result.loc[result.index[0], "timestamp"])


### PR DESCRIPTION
## Summary
- enforce SEC Rule 612 tick rounding across execute_trades, including canonicalization availability and request price guards to avoid Alpaca 422 errors
- fix the Bollinger-band squeeze mask in the ranking pipeline with a shape-safe NumPy mask
- gate the pre-market wrapper until 07:00 NY, add candidate sanity checking, and document scheduling plus rounding updates

## Testing
- pytest tests/test_execute_trades_rounding.py tests/test_ranking.py

------
https://chatgpt.com/codex/tasks/task_e_690cb773db2c83319fb4282a840da355