### PR TITLE
Enhance screener universe filters and momentum factors

### DIFF
--- a/configs/ranker_v2.yml
+++ b/configs/ranker_v2.yml
@@ -8,12 +8,13 @@ weights:
 thresholds:
   rel_vol_min: 1.8
   adx_min: 20
+  atr_pct_min: 0.01
   atr_pct_max: 0.07
   bb_bw_pctile: 0.15
 gate_policy:
   min_candidates: 6
   max_tiers: 3
   tiers:
-    - { rel_vol_min: 1.8,  adx_min: 25, atr_pct_max: 0.07, wk52_min: 0.90 }
-    - { rel_vol_min: 1.5,  adx_min: 20, atr_pct_max: 0.08, wk52_min: 0.85 }
-    - { rel_vol_min: 1.3,  adx_min: 15, atr_pct_max: 0.10, wk52_min: 0.80 }
+    - { rel_vol_min: 1.8,  adx_min: 25, atr_pct_min: 0.010, atr_pct_max: 0.07, wk52_min: 0.90 }
+    - { rel_vol_min: 1.5,  adx_min: 20, atr_pct_min: 0.009, atr_pct_max: 0.08, wk52_min: 0.85 }
+    - { rel_vol_min: 1.3,  adx_min: 15, atr_pct_min: 0.008, atr_pct_max: 0.10, wk52_min: 0.80 }


### PR DESCRIPTION
## Summary
- filter fund-like ETFs and warrant/unit symbols when building the Alpaca universe while keeping benchmark SPY bars for feature engineering
- add RS20 slope and squeeze indicators, propagating them through feature generation, scoring bonuses, and ATR% gate clamping
- tune the ranker configuration to define ATR%% minimums across the gate relaxation tiers

## Testing
- pytest tests/test_features_shapes.py tests/test_ranking.py tests/test_screener_shortlist_backtest.py tests/test_screener_unknown_exchange.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1ba259ac8331855816e04b66beec)