### PR TITLE
Restore fetch_symbols helper for screener

### DIFF
--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -32,6 +32,57 @@ import numpy as np
 import pandas as pd
 import requests
 
+try:  # pragma: no cover - allow reuse if helper moved to features module
+    from scripts.features import fetch_symbols as _external_fetch_symbols
+except Exception:  # pragma: no cover - fallback to local helper definition
+    _external_fetch_symbols = None
+
+
+def fetch_symbols(
+    feed: str = "iex",
+    dollar_vol_min: int = 2_000_000,
+    reuse_cache: bool = True,
+):
+    """Return a DataFrame of actively tradable US equities."""
+
+    if _external_fetch_symbols is not None:
+        return _external_fetch_symbols(
+            feed=feed, dollar_vol_min=dollar_vol_min, reuse_cache=reuse_cache
+        )
+
+    # Local fallback mirrors historical helper behaviour: rely on Alpaca REST.
+    try:
+        from alpaca_trade_api.rest import REST  # type: ignore
+    except Exception as exc:  # pragma: no cover - alpaca package optional in tests
+        raise RuntimeError("alpaca_trade_api is required to fetch symbols") from exc
+
+    api = REST()
+    assets = api.list_assets(status="active")
+    rows: list[dict[str, object]] = []
+    for asset in assets:
+        if asset.tradable and asset.exchange in {"NYSE", "NASDAQ", "AMEX"}:
+            rows.append(
+                {
+                    "symbol": asset.symbol,
+                    "exchange": asset.exchange,
+                    "class_": asset.asset_class,
+                    "status": asset.status,
+                }
+            )
+
+    df = pd.DataFrame(rows)
+    cache_path = Path("data") / "universe_cache.csv"
+    if reuse_cache and cache_path.exists():
+        try:
+            return pd.read_csv(cache_path)
+        except Exception:
+            # Fall back to freshly fetched data if cache is unreadable.
+            pass
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(cache_path, index=False)
+    return df
+
 try:  # pragma: no cover - preferred module execution path
     from .indicators import adx, aroon, macd, obv, rsi
     from .utils.normalize import to_bars_df, BARS_COLUMNS
@@ -678,7 +729,7 @@ def _fetch_daily_bars(
     start_dt = _parse_iso(start_iso)
     end_dt = _parse_iso(end_iso)
 
-    unique_symbols = [str(sym or "").strip().upper() for sym in fetch_symbols if sym]
+    unique_symbols = [str(sym or "").strip().upper() for sym in symbols if sym]
     unique_symbols = list(dict.fromkeys(unique_symbols))
     metrics: dict[str, Any] = {
         "batches_total": 0,
@@ -4615,6 +4666,9 @@ def main(
 
     def _run() -> int:
         mode = getattr(args, "mode", "screener")
+
+        if "fetch_symbols" not in globals() or not callable(globals().get("fetch_symbols")):
+            raise RuntimeError("fetch_symbols() helper missing or not imported correctly")
 
         if mode == "build-symbol-stats":
             return run_build_symbol_stats(args, base_dir)


### PR DESCRIPTION
## Summary
- restore the `fetch_symbols` helper with a local fallback when the shared implementation is unavailable
- ensure daily bar fetching normalizes the provided symbol list and add a guard that fails fast when the helper is missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e232402bc83319803f9ea290780a4)