### PR TITLE
Fix screener symbol plumbing

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1173,12 +1173,15 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 if candidate is not None:
                     bars_rows_total = candidate
                     break
+        summary_source = latest_source
+        if screener_rc not in (0, None) and (summary_rows or 0) > 0:
+            summary_source = "fallback"
         summary = SimpleNamespace(
             symbols_in=symbols_in,
             with_bars=symbols_with_bars,
             rows=summary_rows,
             bars_rows_total=bars_rows_total,
-            source=latest_source,
+            source=summary_source,
         )
         t = SimpleNamespace(
             fetch=fetch_secs,

--- a/tests/test_symbol_plumbing.py
+++ b/tests/test_symbol_plumbing.py
@@ -1,0 +1,11 @@
+import pandas as pd
+import pytest
+
+from scripts.screener import _to_symbol_list
+
+
+@pytest.mark.alpaca_optional
+def test_to_symbol_list_df_and_list():
+    df = pd.DataFrame({"symbol": [" aapl ", "MSFT", None, "msft", ""]})
+    assert _to_symbol_list(df) == ["AAPL", "MSFT"]
+    assert _to_symbol_list(["spy", " SPY ", None]) == ["SPY"]


### PR DESCRIPTION
## Summary
- add a reusable `_to_symbol_list` helper and rework `_fetch_daily_bars` to demand explicit symbol lists instead of referencing the undefined `fetch_symbols`
- pass the filtered Alpaca universe into `_fetch_daily_bars`, guard empty universes, and handle empty shortlists in the nightly runner
- ensure the pipeline summary reports fallback as the source when the screener fails and add a regression test for the symbol normalizer

## Testing
- pytest tests/test_symbol_plumbing.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f12b47ac8331b32094959182e18c)