### PR TITLE
Improve screener hygiene and reporting

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1145,6 +1145,15 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         write_error_report(step="pipeline", detail=str(exc))
     finally:
         rows_out = metrics_rows if metrics_rows is not None else rows
+        final_rows = None
+        top_path = Path(base_dir) / "data" / "top_candidates.csv"
+        if top_path.exists():
+            try:
+                final_rows = int(pd.read_csv(top_path).shape[0])
+            except Exception as exc:
+                logger.warning("[WARN] PIPELINE_SUMMARY_ROWS_FALLBACK reason=read_error detail=%s", exc)
+        if final_rows is not None:
+            rows_out = final_rows
         screener_rc = step_rcs.get("screener") if "screener" in step_rcs else None
         backtest_rc = step_rcs.get("backtest") if "backtest" in step_rcs else None
         metrics_rc = step_rcs.get("metrics") if "metrics" in step_rcs else None

--- a/tests/test_momentum_features.py
+++ b/tests/test_momentum_features.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import pytest
+
+from scripts.features import add_wk52_and_rs
+
+
+@pytest.mark.alpaca_optional
+def test_wk52_and_rs_columns_added():
+    periods = 70
+    df = pd.DataFrame(
+        {
+            "symbol": ["A"] * periods,
+            "date": pd.date_range("2024-01-01", periods=periods, freq="D"),
+            "close": list(range(10, 10 + periods)),
+        }
+    )
+    spy = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=periods, freq="D"),
+            "close": list(range(100, 100 + periods)),
+            "symbol": ["SPY"] * periods,
+        }
+    )
+    out = add_wk52_and_rs(df.copy(), spy)
+    assert {"wk52_high", "wk52_prox", "rs20_slope"}.issubset(out.columns)
+    assert out["wk52_high"].notna().any()

--- a/tests/test_symbol_filters.py
+++ b/tests/test_symbol_filters.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import pytest
+
+from scripts.screener import _is_common_stock_like
+
+
+@pytest.mark.alpaca_optional
+def test_is_common_stock_like_filters_funds_and_warrants():
+    rows = [
+        {
+            "symbol": "SPY",
+            "exchange": "ARCA",
+            "asset_type": "EQUITY",
+            "name": "SPDR S&P 500 ETF Trust",
+        },
+        {
+            "symbol": "AAPL",
+            "exchange": "NASDAQ",
+            "asset_type": "COMMON",
+            "name": "Apple Inc.",
+        },
+        {
+            "symbol": "XYZW",
+            "exchange": "NASDAQ",
+            "asset_type": "COMMON",
+            "name": "XYZ Corp Warrant",
+        },
+    ]
+    df = pd.DataFrame(rows)
+    keep = df[df.apply(_is_common_stock_like, axis=1)]
+    assert list(keep["symbol"]) == ["AAPL"]


### PR DESCRIPTION
## Summary
- restrict the Alpaca universe to common US listings, enforce price/liquidity/ATR bands during scoring, and relax gates with a soft floor when too few names pass
- add 52-week proximity and SPY-relative momentum helpers plus dedicated scoring bonuses, and expose lower-case aliases for downstream gating
- ensure the pipeline summary reads the candidate count written by metrics and add regression tests around the new filters/features

## Testing
- pytest tests/test_symbol_filters.py tests/test_momentum_features.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173170f7ec83318ae345ac48a73606)