### PR TITLE
Improve screener health metrics and badges

### DIFF
--- a/tests/test_pipeline_metrics_sync.py
+++ b/tests/test_pipeline_metrics_sync.py
@@ -36,7 +36,8 @@ def test_write_complete_screener_metrics_backfills_from_log(tmp_path):
 
     assert result["symbols_in"] == 25
     assert result["symbols_with_bars"] == 20
-    assert result["rows"] == 9
+    assert result["symbols_with_bars_raw"] == 20
+    assert result["rows"] == 2
     assert result["bars_rows_total"] == 450
     assert result["last_run_utc"] == "2024-05-20T12:00:00Z"
 


### PR DESCRIPTION
## Summary
- write explicit screener metrics that include raw bar counts, final candidate rows, and a connection health snapshot so the dashboard can always reflect the last nightly run
- extend the dashboard data loader and layout to consume the new freshness, run-type, and connectivity details with resilient fallbacks and clearer KPI cards
- update pipeline metrics tests to cover the new fields and expectations

## Testing
- pytest tests/test_pipeline_metrics_sync.py tests/test_dashboard_consistency.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69174a4210a0833193da73940748c3a4)