### PR TITLE
Improve screener health metrics and dashboard APIs

### DIFF
--- a/tests/_data_io_helpers.py
+++ b/tests/_data_io_helpers.py
@@ -1,0 +1,11 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def reload_data_io(monkeypatch: pytest.MonkeyPatch, base_dir: Path):
+    monkeypatch.setenv("JBRAVO_HOME", str(base_dir))
+    import dashboards.data_io as data_io  # local import for reload
+
+    return importlib.reload(data_io)

--- a/tests/test_connection_health_precedence.py
+++ b/tests/test_connection_health_precedence.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tests._data_io_helpers import reload_data_io
+
+
+def test_connection_health_json_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_dir = tmp_path / "data"
+    logs_dir = tmp_path / "logs"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+
+    pd.DataFrame([{"symbol": "AAA"}]).to_csv(data_dir / "top_candidates.csv", index=False)
+    (data_dir / "screener_metrics.json").write_text(json.dumps({"symbols_in": 1}), encoding="utf-8")
+
+    conn_payload = {
+        "trading_ok": True,
+        "data_ok": True,
+        "trading_status": 200,
+        "data_status": 200,
+        "feed": "iex",
+        "timestamp": "2024-01-01T00:00:00+00:00",
+    }
+    (data_dir / "connection_health.json").write_text(json.dumps(conn_payload), encoding="utf-8")
+
+    log_lines = [
+        "2024-01-01 [INFO] HEALTH trading_ok=False data_ok=False trading_status=503 data_status=204",
+        "2024-01-01 [INFO] PIPELINE_END rc=1",
+    ]
+    (logs_dir / "pipeline.log").write_text("\n".join(log_lines), encoding="utf-8")
+
+    data_io = reload_data_io(monkeypatch, tmp_path)
+    snapshot = data_io.screener_health()
+
+    assert snapshot["trading_ok"] is True
+    assert snapshot["data_ok"] is True
+    assert snapshot["trading_status"] == 200
+    assert snapshot["data_status"] == 200

--- a/tests/test_kpi_tiles_csv_fallback.py
+++ b/tests/test_kpi_tiles_csv_fallback.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tests._data_io_helpers import reload_data_io
+
+
+def test_metrics_summary_snapshot_prefers_data_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_dir = tmp_path / "data"
+    logs_dir = tmp_path / "logs"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+
+    df = pd.DataFrame(
+        [
+            {"profit_factor": 1.1, "expectancy": 0.5, "win_rate": 50.0, "net_pnl": 1000.0, "max_drawdown": -200.0, "sharpe": 0.8, "sortino": 1.2, "last_run_utc": "2024-01-01T00:00:00+00:00"},
+            {"profit_factor": 1.8, "expectancy": 0.9, "win_rate": 65.0, "net_pnl": 2500.0, "max_drawdown": -150.0, "sharpe": 1.1, "sortino": 1.6, "last_run_utc": "2024-01-02T00:00:00+00:00"},
+        ]
+    )
+    df.to_csv(data_dir / "metrics_summary.csv", index=False)
+
+    data_io = reload_data_io(monkeypatch, tmp_path)
+    snapshot = data_io.metrics_summary_snapshot()
+
+    assert snapshot["profit_factor"] == 1.8
+    assert snapshot["expectancy"] == 0.9
+    assert snapshot["net_pnl"] == 2500.0
+    assert snapshot["last_run_utc"] == "2024-01-02T00:00:00+00:00"
+
+
+def test_metrics_summary_snapshot_missing_file_returns_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "data").mkdir()
+    (tmp_path / "logs").mkdir()
+    data_io = reload_data_io(monkeypatch, tmp_path)
+
+    snapshot = data_io.metrics_summary_snapshot()
+    assert snapshot == {}

--- a/tests/test_metrics_split_backcompat.py
+++ b/tests/test_metrics_split_backcompat.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tests._data_io_helpers import reload_data_io
+
+
+def _write_top_candidates(data_dir: Path, rows: int = 2) -> None:
+    df = pd.DataFrame(
+        [{"symbol": f"SYM{i}"} for i in range(rows)]
+    )
+    df.to_csv(data_dir / "top_candidates.csv", index=False)
+
+
+def test_screener_health_backcompat(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_dir = tmp_path / "data"
+    logs_dir = tmp_path / "logs"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+    (logs_dir / "pipeline.log").write_text("2024-01-01 [INFO] PIPELINE_END rc=0\n", encoding="utf-8")
+    _write_top_candidates(data_dir, rows=3)
+
+    legacy_metrics = {
+        "symbols_in": 100,
+        "symbols_with_bars": 80,
+        "bars_rows_total": 2500,
+        "rows": 1,
+        "latest_source": "fallback",
+    }
+    (data_dir / "screener_metrics.json").write_text(json.dumps(legacy_metrics), encoding="utf-8")
+    data_io = reload_data_io(monkeypatch, tmp_path)
+
+    legacy_snapshot = data_io.screener_health()
+    assert legacy_snapshot["symbols_with_bars_fetch"] == 80
+    assert legacy_snapshot["bars_rows_total_fetch"] == 2500
+    assert legacy_snapshot["rows_final"] == 3
+    assert legacy_snapshot["source"] == "fallback"
+
+    split_metrics = {
+        "symbols_in": 120,
+        "symbols_with_bars_fetch": 90,
+        "symbols_with_bars_post": 45,
+        "bars_rows_total_fetch": 4000,
+        "bars_rows_total_post": 2000,
+        "rows": 5,
+        "latest_source": "screener",
+    }
+    (data_dir / "screener_metrics.json").write_text(json.dumps(split_metrics), encoding="utf-8")
+
+    split_snapshot = data_io.screener_health()
+    assert split_snapshot["symbols_with_bars_fetch"] == 90
+    assert split_snapshot["symbols_with_bars_post"] == 45
+    assert split_snapshot["bars_rows_total_fetch"] == 4000
+    assert split_snapshot["bars_rows_total_post"] == 2000
+    assert split_snapshot["source"] == "screener"


### PR DESCRIPTION
## Summary
- ensure the nightly pipeline writes split coverage counts alongside an Alpaca connectivity snapshot and logs the authoritative row counts
- update the dashboard data loader and Screener tab so it reads the new artifacts first, exposes `/api/health` and `/api/candidates`, and renders KPI tiles straight from `data/metrics_summary.csv`
- add regression tests that cover legacy metrics JSONs, connection-health precedence, and the KPI fallback so the Screener Health tab always has data

## Testing
- pytest tests/test_health_loader.py tests/test_metrics_split_backcompat.py tests/test_connection_health_precedence.py tests/test_kpi_tiles_csv_fallback.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691764ffe4cc8331aae598eba612ece2)