### PR TITLE
Tighten dashboard health checks and tests

### DIFF
--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+def _prepare_dashboard_data(base: Path) -> None:
+    data_dir = base / "data"
+    logs_dir = base / "logs"
+    reports_dir = base / "reports"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics = {
+        "symbols_in": 12,
+        "symbols_with_bars_fetch": 10,
+        "bars_rows_total_fetch": 240,
+        "rows": 3,
+        "last_run_utc": "2024-01-01T00:00:00Z",
+    }
+    (data_dir / "screener_metrics.json").write_text(json.dumps(metrics))
+
+    pd.DataFrame(
+        [
+            {"symbol": "AAA"},
+            {"symbol": "BBB"},
+            {"symbol": "CCC"},
+        ]
+    ).to_csv(data_dir / "top_candidates.csv", index=False)
+
+    conn_payload = {"trading_ok": True, "data_ok": True}
+    (data_dir / "connection_health.json").write_text(json.dumps(conn_payload))
+
+    (logs_dir / "pipeline.log").write_text("2024-01-01 PIPELINE_END rc=0\n")
+
+
+def _reload_dashboard_app(monkeypatch: pytest.MonkeyPatch, base: Path):
+    monkeypatch.setenv("JBRAVO_HOME", str(base))
+    monkeypatch.setenv("APCA_API_KEY_ID", "test-key")
+    monkeypatch.setenv("APCA_API_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("APCA_API_BASE_URL", "https://paper-api.alpaca.markets")
+    monkeypatch.setenv("ALPACA_DATA_FEED", "iex")
+    monkeypatch.setenv("JBR_EXEC_PAPER", "1")
+
+    import alpaca.trading.client as alpaca_client
+
+    class _DummyTradingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(alpaca_client, "TradingClient", _DummyTradingClient)
+
+    sys.modules.pop("dashboards.data_io", None)
+    sys.modules.pop("dashboards.dashboard_app", None)
+    module = importlib.import_module("dashboards.dashboard_app")
+    return module
+
+
+def test_connection_badge_color(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _prepare_dashboard_data(tmp_path)
+    module = _reload_dashboard_app(monkeypatch, tmp_path)
+
+    assert module.connection_badge_color({"trading_ok": True, "data_ok": True}) == "success"
+    assert module.connection_badge_color({"trading_ok": False, "data_ok": True}) == "danger"
+
+
+def test_api_health_matches_loader(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _prepare_dashboard_data(tmp_path)
+    module = _reload_dashboard_app(monkeypatch, tmp_path)
+
+    expected = module.load_screener_health()
+    client = module.app.server.test_client()
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    payload = json.loads(response.data.decode("utf-8"))
+    assert payload == expected

--- a/tests/test_health_loader.py
+++ b/tests/test_health_loader.py
@@ -88,6 +88,79 @@ def test_screener_health_fallbacks_when_files_missing(tmp_path: Path, monkeypatc
     assert snapshot["rows_final"] == 2
     assert snapshot["source"] == "fallback"
     assert snapshot["pipeline_rc"] == 2
-    assert snapshot["trading_ok"] is False
-    assert snapshot["data_ok"] is False
+    assert snapshot["trading_ok"] is None
+    assert snapshot["data_ok"] is None
     assert snapshot["symbols_with_bars_fetch"] == 9
+
+
+def test_screener_health_rows_final_from_top(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_dir = tmp_path / "data"
+    logs_dir = tmp_path / "logs"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+
+    metrics = {
+        "symbols_in": 30,
+        "symbols_with_bars_fetch": 20,
+        "bars_rows_total_fetch": 400,
+        "rows": 4,
+        "last_run_utc": "2024-01-01T00:00:00Z",
+    }
+    (data_dir / "screener_metrics.json").write_text(json.dumps(metrics))
+
+    top_rows = [{"symbol": f"SYM{i}"} for i in range(6)]
+    pd.DataFrame(top_rows).to_csv(data_dir / "top_candidates.csv", index=False)
+
+    conn_payload = {"trading_ok": True, "data_ok": True}
+    (data_dir / "connection_health.json").write_text(json.dumps(conn_payload))
+
+    (logs_dir / "pipeline.log").write_text("2024-01-01 PIPELINE_END rc=0\n")
+
+    data_io = reload_data_io(monkeypatch, tmp_path)
+    snapshot = data_io.screener_health()
+
+    assert snapshot["rows_final"] == 6
+    assert snapshot["rows_premetrics"] == 6
+
+
+def test_health_history_tracks_coverage_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_dir = tmp_path / "data"
+    logs_dir = tmp_path / "logs"
+    reports_dir = tmp_path / "reports"
+    data_dir.mkdir()
+    logs_dir.mkdir()
+    reports_dir.mkdir()
+
+    metrics = {
+        "symbols_in": 10,
+        "symbols_with_bars_fetch": 8,
+        "bars_rows_total_fetch": 320,
+        "rows": 3,
+        "last_run_utc": "2024-01-01T00:00:00Z",
+    }
+    (data_dir / "screener_metrics.json").write_text(json.dumps(metrics))
+
+    pd.DataFrame([{"symbol": "AAA"}, {"symbol": "BBB"}]).to_csv(
+        data_dir / "top_candidates.csv", index=False
+    )
+
+    conn_payload = {"trading_ok": True, "data_ok": True}
+    (data_dir / "connection_health.json").write_text(json.dumps(conn_payload))
+
+    (logs_dir / "pipeline.log").write_text("2024-01-01 PIPELINE_END rc=0\n")
+
+    data_io = reload_data_io(monkeypatch, tmp_path)
+    first_snapshot = data_io.screener_health()
+    assert first_snapshot["coverage_drift"] is None
+
+    metrics.update({"symbols_with_bars_fetch": 10, "last_run_utc": "2024-01-01T01:00:00Z"})
+    (data_dir / "screener_metrics.json").write_text(json.dumps(metrics))
+
+    second_snapshot = data_io.screener_health()
+    assert second_snapshot["coverage_drift"] == 2
+
+    history_path = reports_dir / "health_history.json"
+    assert history_path.exists()
+    history = json.loads(history_path.read_text())
+    assert len(history) == 2
+    assert history[-1]["coverage_drift"] == 2


### PR DESCRIPTION
## Summary
- enforce parity, field presence, connection, and API equality assertions in the dashboard consistency checker so runs fail when key artifacts drift
- update the health loader/app to rely on connection_health.json, capture coverage drift history, align /api/health with the loader payload, and improve the Alpaca badge + counter labels
- add fast tests covering loader parity/drift behavior and the dashboard API health endpoint

## Testing
- `APCA_API_KEY_ID=test APCA_API_SECRET_KEY=test pytest tests/test_health_loader.py tests/test_connection_health_precedence.py tests/test_dashboard_api.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691773bbaaa483319895a9b5fc621f11)