### PR TITLE
Fix screener metrics consistency and readiness snapshot updates

### DIFF
--- a/dashboards/screener_health.py
+++ b/dashboards/screener_health.py
@@ -419,7 +419,9 @@ def _premarket_pill(payload: Mapping[str, Any] | None) -> html.Div:
 
     ny_now = datetime.now(ZoneInfo("America/New_York"))
     ny_label = ny_now.strftime("%Y-%m-%d %H:%M:%S %Z")
-    started = _format_probe_timestamp(info.get("started_utc"))
+    started = _format_probe_timestamp(
+        info.get("finished_utc") or info.get("started_utc")
+    )
     if started and started != "n/a":
         sub_text = f"Pre-market run: {started} • Now (NY): {ny_label}"
     else:


### PR DESCRIPTION
## Summary
- clamp and backfill screener metrics so symbols_in/with_bars stay consistent, while preserving existing timestamps
- add a premarket snapshot writer and wire the wrapper plus Screener Health card to use fresh readiness data
- expose the latest run timestamp in the readiness pill and fix the dashboard backfill logger crash

## Testing
- pytest tests/test_pipeline_metrics_sync.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a03b5770c83318948290556398f71)