### PR TITLE
Fix premarket snapshot and screener logger

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -26,6 +26,8 @@ from plotly.subplots import make_subplots
 
 os.environ.setdefault("JBRAVO_HOME", "/home/oai/jbravo_screener")
 
+logger = logging.getLogger(__name__)
+
 from dashboards.screener_health import build_layout as build_screener_health
 from dashboards.screener_health import register_callbacks as register_screener_health
 from dashboards.screener_health import load_kpis as _load_screener_health_kpis


### PR DESCRIPTION
## Summary
- ensure premarket wrapper exports timestamps and updates the snapshot helper after each run, including stale-artifact exits
- add a defensive snapshot helper that logs failures without terminating the wrapper
- define the dashboards logger so screener backfill errors are logged instead of raising

## Testing
- bash -n bin/run_premarket_once.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a17f393188331b30c8d404b46899d)