### PR TITLE
Add screener log handler for pipeline runs

### DIFF
--- a/scripts/logger_utils.py
+++ b/scripts/logger_utils.py
@@ -1,0 +1,20 @@
+import logging
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parents[1] / "logs"
+
+
+def make_screener_file_handler() -> logging.Handler:
+    """Create a file handler for ``logs/screener.log``.
+
+    The handler uses a simple INFO-level formatter and ensures the logs
+    directory exists before opening the file.
+    """
+
+    log_path = LOG_DIR / "screener.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_path)
+    fmt = logging.Formatter("%(asctime)s - screener - %(levelname)s - %(message)s")
+    handler.setFormatter(fmt)
+    handler.setLevel(logging.INFO)
+    return handler


### PR DESCRIPTION
## Summary
- add a reusable helper that creates a screener file handler targeting logs/screener.log
- attach the screener handler for the duration of screener runs so logs are duplicated without leaking handlers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2c0863fc833188ef4927f63ac6b3)