### PR TITLE
Add nightly ranker evaluation reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Pipeline options worth knowing:
 * `--reload-web true` triggers a PythonAnywhere reload when the pipeline finishes. If the `pa_reload_webapp` CLI is not available the runner falls back to touching `/var/www/raspatrick_pythonanywhere_com_wsgi.py` so the dashboard still refreshes automatically.
 * When the screener emits zero rows the pipeline now logs `FALLBACK_CHECK …` and invokes `scripts.fallback_candidates` to guarantee at least one canonical candidate row (columns: `timestamp,symbol,score,exchange,close,volume,universe_count,score_breakdown,entry_price,adv20,atrp,source`). Both `data/top_candidates.csv` and `data/latest_candidates.csv` are rewritten with these safe defaults.
 * `scripts.metrics` tolerates a missing or empty `data/trades_log.csv`, allowing fresh installs (before the first live trade) to produce `data/metrics_summary.csv` without manual scaffolding.
+* Nightly ranker evaluation runs by default via the `ranker_eval` pipeline step, writing `data/ranker_eval/latest.json` for the Screener Health decile charts. Temporarily skip it with `--steps screener,backtest,metrics` if needed.
 
 The Bollinger-band squeeze component now applies a shape-safe mask so the ranking pass no longer crashes with NumPy shape mismatch errors.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,7 +2,7 @@
 
 ## Nightly pipeline
 
-* Use `python -m scripts.run_pipeline --steps screener,backtest,metrics` in scheduled tasks. Pass additional screener flags via `--screener-args "..."` when you need to tweak liquidity thresholds without editing the wrapper script.
+* Use `python -m scripts.run_pipeline --steps screener,backtest,metrics,ranker_eval` in scheduled tasks. Pass additional screener flags via `--screener-args "..."` when you need to tweak liquidity thresholds without editing the wrapper script.
 * After each screener run the pipeline inspects `data/top_candidates.csv`. If there are no rows it invokes `scripts.fallback_candidates`, logs `[INFO] FALLBACK_CHECK reason=no_candidates rows_out=<N> source=<scored|predictions|static>`, and rewrites `data/latest_candidates.csv` with canonical headers (`timestamp,symbol,score,exchange,close,volume,universe_count,score_breakdown,entry_price,adv20,atrp,source`). This ensures the executor and dashboard always have at least one row to render.
 * PythonAnywhere deployments now log `[INFO] DASH_RELOAD method=<pa|touch> rc=<0|ERR>` at the end of each pipeline run. The pipeline first tries `pa_reload_webapp $PYTHONANYWHERE_DOMAIN`; when unavailable it touches `/var/www/${PYTHONANYWHERE_DOMAIN//./_}_wsgi.py` instead.
 * `scripts.metrics` can be scheduled before the first trade executes; both the pipeline and the metrics script tolerate a missing `data/trades_log.csv`, creating an empty header stub and still writing `data/metrics_summary.csv` with zeroed metrics.

--- a/data/ranker_eval/latest.json
+++ b/data/ranker_eval/latest.json
@@ -1,0 +1,7 @@
+{
+  "deciles": [],
+  "label_horizon_days": 5,
+  "reason": "no labeled samples",
+  "run_utc": "2025-11-29T00:10:19.795253+00:00",
+  "sample_size": 0
+}

--- a/scripts/ranker_eval.py
+++ b/scripts/ranker_eval.py
@@ -1,308 +1,348 @@
+"""Evaluate ranker decile performance from historical predictions and trades.
+
+This module ingests prediction snapshots and realised trade outcomes to
+compute forward returns by decile. The resulting summary is written to
+``data/ranker_eval/latest.json`` for dashboard consumption, with an optional
+append-only history CSV for longitudinal tracking.
+"""
+
 from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
+import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Any, Mapping
 
-import numpy as np
 import pandas as pd
 
-from utils.io_utils import atomic_write_bytes
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BASE_DIR))
 
-DATE_FORMAT = "%Y-%m-%d"
+from utils import write_csv_atomic  # noqa: E402
+from utils.env import load_env  # noqa: E402
+
+
+load_env()
+
+LOG = logging.getLogger("ranker_eval")
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] [%(levelname)s]: %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
 
 
 @dataclass
 class EvalConfig:
-    labels_dir: Path
-    output_dir: Path = Path("data") / "ranker_eval"
-    days: int = 60
-    score_column: str = "Score"
-    as_of: Optional[datetime] = None
+    label_horizon: int = 5
+    predictions_dir: Path = BASE_DIR / "data" / "predictions"
+    executed_trades: Path = BASE_DIR / "data" / "executed_trades.csv"
+    output_json: Path = BASE_DIR / "data" / "ranker_eval" / "latest.json"
+    output_history: Path | None = BASE_DIR / "data" / "ranker_eval" / "history.csv"
+    min_samples: int = 50
+    min_per_decile: int = 5
 
 
-@dataclass
-class EvalOutputs:
-    summary_path: Path
-    deciles_path: Path
+def _coerce_datetime(series: pd.Series) -> pd.Series:
+    return pd.to_datetime(series, errors="coerce", utc=True)
 
 
-class EvaluationError(RuntimeError):
-    pass
-
-
-def _parse_date(value: str) -> datetime:
-    return datetime.strptime(value, DATE_FORMAT)
-
-
-def _list_label_files(directory: Path) -> list[tuple[datetime, Path]]:
-    files: list[tuple[datetime, Path]] = []
-    for path in sorted(directory.glob("realized_*.csv")):
-        try:
-            date_value = _parse_date(path.stem.replace("realized_", ""))
-        except ValueError:
-            continue
-        files.append((date_value, path))
-    return files
-
-
-def _load_window(cfg: EvalConfig) -> pd.DataFrame:
-    if not cfg.labels_dir.exists():
-        raise EvaluationError(f"Labels directory not found: {cfg.labels_dir}")
-
-    files = _list_label_files(cfg.labels_dir)
-    if not files:
-        raise EvaluationError(f"No realized label files found in {cfg.labels_dir}")
-
-    end_date = cfg.as_of or files[-1][0]
-    start_date = end_date - timedelta(days=cfg.days - 1)
-
-    selected = [(dt, path) for dt, path in files if start_date <= dt <= end_date]
-    if not selected:
-        raise EvaluationError("No realized label files fall within the requested window")
-
+def _load_predictions(predictions_dir: Path) -> pd.DataFrame:
     frames: list[pd.DataFrame] = []
-    for dt, path in selected:
-        frame = pd.read_csv(path)
-        if frame.empty:
+    if not predictions_dir.exists():
+        LOG.warning("Predictions directory missing at %s", predictions_dir)
+        return pd.DataFrame()
+    for path in sorted(predictions_dir.glob("*.csv")):
+        try:
+            df = pd.read_csv(path)
+        except Exception as exc:  # pragma: no cover - defensive I/O
+            LOG.warning("Failed to read predictions %s: %s", path, exc)
             continue
-        frame = frame.copy()
-        frame["as_of"] = dt.date()
-        frames.append(frame)
-
+        if df.empty:
+            continue
+        rename_map = {}
+        if "as_of" in df.columns and "run_date" not in df.columns:
+            rename_map["as_of"] = "run_date"
+        if "Score" in df.columns and "score" not in df.columns:
+            rename_map["Score"] = "score"
+        if rename_map:
+            df = df.rename(columns=rename_map)
+        required = {"symbol", "score", "run_date"}
+        if not required.issubset(df.columns):
+            missing = required - set(df.columns)
+            LOG.warning("Predictions %s missing columns: %s", path, sorted(missing))
+            continue
+        df = df.loc[:, ["symbol", "score", "run_date"]].copy()
+        df["score"] = pd.to_numeric(df["score"], errors="coerce")
+        df["run_date"] = _coerce_datetime(df["run_date"])
+        df = df.dropna(subset=["symbol", "score", "run_date"])
+        if not df.empty:
+            frames.append(df)
     if not frames:
-        raise EvaluationError("Label files are empty for the requested window")
-
+        return pd.DataFrame(columns=["symbol", "score", "run_date"])
     combined = pd.concat(frames, ignore_index=True)
-    combined["nextday_ret"] = pd.to_numeric(combined.get("nextday_ret"), errors="coerce")
-    combined["win_>0"] = pd.to_numeric(combined.get("win_>0"), errors="coerce")
-    combined.dropna(subset=["nextday_ret"], inplace=True)
-
-    if combined.empty:
-        raise EvaluationError("No realized returns available after dropping missing values")
-
-    score_column = None
-    for candidate in [cfg.score_column, "Score", "score"]:
-        if candidate in combined.columns:
-            score_column = candidate
-            break
-    if score_column is None:
-        combined["__score"] = -combined.get("rank", pd.Series([], dtype=float))
-        score_column = "__score"
-    combined["__score_column"] = score_column
-    combined["__score_values"] = pd.to_numeric(combined[score_column], errors="coerce")
-
-    combined = combined.dropna(subset=["__score_values"])
-    if combined.empty:
-        raise EvaluationError("Score column is missing or entirely non-numeric")
-
-    combined.rename(columns={score_column: "score"}, inplace=True)
-    if score_column != "score":
-        combined.drop(columns=[score_column], inplace=True, errors="ignore")
-    return combined
+    combined = combined.sort_values("run_date")
+    return combined.reset_index(drop=True)
 
 
-def _profit_factor(returns: pd.Series) -> float:
-    gains = returns[returns > 0].sum()
-    losses = returns[returns < 0].sum()
-    if losses == 0:
-        return float("inf") if gains > 0 else 0.0
-    return gains / abs(losses)
-
-
-def _max_drawdown(returns: pd.Series, dates: Optional[pd.Series] = None) -> float:
-    series = returns.fillna(0.0)
-    if dates is not None:
-        frame = pd.DataFrame({"ret": series, "as_of": pd.to_datetime(dates, errors="coerce")})
-        frame.dropna(subset=["as_of"], inplace=True)
-        frame.sort_values("as_of", inplace=True)
-        series = frame["ret"].fillna(0.0)
-    equity = (1 + series).cumprod()
-    running_max = equity.cummax()
-    drawdown = (equity / running_max) - 1
-    return float(drawdown.min())
-
-
-def _decile_frame(df: pd.DataFrame) -> pd.DataFrame:
-    deciles = pd.qcut(df["score"], q=10, labels=range(1, 11), duplicates="drop")
-    df = df.assign(decile=deciles)
-    grouped = (
-        df.groupby("decile")
-        .agg(
-            count=("symbol", "size"),
-            avg_return=("nextday_ret", "mean"),
-            hit_rate=("win_>0", "mean"),
-            avg_score=("score", "mean"),
-        )
-        .reset_index()
-    )
-    overall_hit_rate = df["win_>0"].mean() or np.nan
-    if overall_hit_rate and np.isfinite(overall_hit_rate) and overall_hit_rate != 0:
-        grouped["lift"] = grouped["hit_rate"] / overall_hit_rate
-    else:
-        grouped["lift"] = np.nan
-    return grouped
-
-
-def _calibration_points(df: pd.DataFrame, bins: int = 10) -> list[dict[str, float]]:
-    binned = pd.qcut(df["score"], q=min(bins, df["score"].nunique()), duplicates="drop")
-    grouped = (
-        df.groupby(binned)
-        .agg(avg_score=("score", "mean"), hit_rate=("win_>0", "mean"), count=("score", "size"))
-        .reset_index(drop=True)
-    )
-    return grouped.to_dict("records")
-
-
-def _stability(df: pd.DataFrame) -> list[dict[str, float]]:
-    if "as_of" not in df.columns:
-        return []
-    df = df.copy()
-    df["as_of"] = pd.to_datetime(df["as_of"], errors="coerce")
-    df.dropna(subset=["as_of"], inplace=True)
+def _load_trades(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        LOG.warning("Executed trades file missing at %s", path)
+        return pd.DataFrame()
+    try:
+        df = pd.read_csv(path)
+    except Exception as exc:  # pragma: no cover - defensive I/O
+        LOG.warning("Failed to read executed trades %s: %s", path, exc)
+        return pd.DataFrame()
     if df.empty:
-        return []
-    df["month"] = df["as_of"].dt.to_period("M").astype(str)
-    grouped = (
-        df.groupby("month")
-        .agg(
-            samples=("symbol", "size"),
-            hit_rate=("win_>0", "mean"),
-            expectancy=("nextday_ret", "mean"),
+        return df
+    rename_map = {}
+    if "filled_qty" in df.columns and "qty" not in df.columns:
+        rename_map["filled_qty"] = "qty"
+    df = df.rename(columns=rename_map)
+    for col in ("qty", "entry_price", "exit_price", "pnl"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    for col in ("entry_time", "exit_time"):
+        if col in df.columns:
+            df[col] = _coerce_datetime(df[col])
+    if "symbol" in df.columns:
+        df["symbol"] = df["symbol"].astype(str).str.upper()
+    return df
+
+
+def _compute_forward_return(row: Mapping[str, Any]) -> float | None:
+    qty = abs(float(row.get("qty") or 0))
+    entry_price = float(row.get("entry_price") or 0)
+    pnl = row.get("pnl")
+    side = str(row.get("side") or "").lower()
+    exit_price = row.get("exit_price")
+    if entry_price <= 0 or qty <= 0:
+        return None
+    if pd.notna(pnl):
+        return float(pnl) / (entry_price * qty) if entry_price else None
+    if pd.notna(exit_price):
+        sign = 1 if side != "sell" else -1
+        try:
+            return sign * (float(exit_price) - entry_price) / entry_price
+        except Exception:
+            return None
+    return None
+
+
+def _attach_labels(preds: pd.DataFrame, trades: pd.DataFrame, horizon_days: int) -> pd.DataFrame:
+    if preds.empty or trades.empty:
+        return pd.DataFrame(columns=["symbol", "score", "run_date", "forward_return"])
+
+    trades = trades.dropna(subset=["symbol", "entry_time"])
+    if trades.empty:
+        return pd.DataFrame(columns=["symbol", "score", "run_date", "forward_return"])
+    trades = trades.sort_values("entry_time")
+
+    preds = preds.copy()
+    preds["symbol"] = preds["symbol"].astype(str).str.upper()
+    preds = preds.sort_values("run_date")
+
+    joined = pd.merge_asof(
+        preds,
+        trades,
+        left_on="run_date",
+        right_on="entry_time",
+        by="symbol",
+        direction="forward",
+        allow_exact_matches=True,
+    )
+
+    cutoff = joined["run_date"] + pd.to_timedelta(horizon_days, unit="D")
+    joined = joined.loc[(joined["entry_time"] <= cutoff)]
+
+    joined["forward_return"] = joined.apply(_compute_forward_return, axis=1)
+    joined = joined.dropna(subset=["forward_return", "score", "run_date"])
+    return joined.loc[:, ["symbol", "score", "run_date", "forward_return"]]
+
+
+def _compute_deciles(labeled: pd.DataFrame, cfg: EvalConfig) -> tuple[list[dict[str, Any]], str | None]:
+    if labeled.empty:
+        return [], "no labeled samples"
+
+    labeled = labeled.sort_values("score", ascending=False)
+    if len(labeled) < cfg.min_samples:
+        return [], f"insufficient samples (<{cfg.min_samples})"
+
+    try:
+        bins = pd.qcut(labeled["score"], 10, labels=False, duplicates="drop")
+    except ValueError as exc:
+        return [], f"decile split failed: {exc}"
+
+    if bins.isna().all():
+        return [], "decile split failed: insufficient unique scores"
+
+    max_bin = bins.max()
+    labeled["decile"] = (max_bin - bins) + 1
+    labeled["decile"] = labeled["decile"].astype(int)
+
+    results: list[dict[str, Any]] = []
+    for decile in range(1, 11):
+        subset = labeled.loc[labeled["decile"] == decile]
+        if subset.empty or len(subset) < cfg.min_per_decile:
+            results.append(
+                {
+                    "decile": decile,
+                    "count": int(len(subset)),
+                    "avg_return": None,
+                    "median_return": None,
+                    "hit_rate": None,
+                }
+            )
+            continue
+        returns = subset["forward_return"].astype(float)
+        hit_rate = float((returns > 0).mean())
+        results.append(
+            {
+                "decile": decile,
+                "count": int(len(subset)),
+                "avg_return": float(returns.mean()),
+                "median_return": float(returns.median()),
+                "hit_rate": hit_rate,
+            }
         )
-        .reset_index()
-    )
-    grouped["profit_factor"] = df.groupby("month").apply(
-        lambda frame: _profit_factor(frame["nextday_ret"])
-    ).reset_index(drop=True)
-    return grouped.to_dict("records")
+    return results, None
 
 
-def evaluate(cfg: EvalConfig) -> EvalOutputs:
-    combined = _load_window(cfg)
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialised = json.dumps(payload, indent=2, sort_keys=True)
+    path.write_text(serialised, encoding="utf-8")
 
-    deciles = _decile_frame(combined)
-    deciles_output = deciles.copy()
-    deciles_output["hit_rate"] = deciles_output["hit_rate"].round(4)
-    deciles_output["avg_return"] = deciles_output["avg_return"].round(6)
 
-    returns = combined["nextday_ret"].astype(float)
-    hits = combined["win_>0"].astype(float)
+def _append_history(path: Path, run_date: datetime, cfg: EvalConfig, deciles: Iterable[Mapping[str, Any]]) -> None:
+    if path is None:
+        return
+    rows = []
+    for dec in deciles:
+        rows.append(
+            {
+                "run_date": run_date.date().isoformat(),
+                "label_horizon_days": cfg.label_horizon,
+                "decile": dec.get("decile"),
+                "count": dec.get("count"),
+                "avg_return": dec.get("avg_return"),
+                "median_return": dec.get("median_return"),
+                "hit_rate": dec.get("hit_rate"),
+            }
+        )
+    if not rows:
+        return
+    frame = pd.DataFrame(rows)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        try:
+            existing = pd.read_csv(path)
+        except Exception:  # pragma: no cover - defensive read
+            existing = pd.DataFrame()
+        if not existing.empty:
+            frame = pd.concat([existing, frame], ignore_index=True)
+    write_csv_atomic(str(path), frame)
 
-    expectancy = float(returns.mean())
-    hit_rate = float(hits.mean())
-    pf = float(_profit_factor(returns))
-    sharpe = float("nan")
-    std = returns.std(ddof=0)
-    drawdown = float(_max_drawdown(returns, combined["as_of"]))
-    if std and std > 0:
-        sharpe = float(expectancy / std * np.sqrt(252))
 
-    as_of_date = cfg.as_of or max(pd.to_datetime(combined["as_of"]))
-    decile_path = cfg.output_dir / f"deciles_{as_of_date.strftime(DATE_FORMAT)}.csv"
-    summary_path = cfg.output_dir / "summary.json"
-    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+def evaluate(cfg: EvalConfig) -> dict[str, Any]:
+    preds = _load_predictions(cfg.predictions_dir)
+    trades = _load_trades(cfg.executed_trades)
+    labeled = _attach_labels(preds, trades, cfg.label_horizon)
+    deciles, reason = _compute_deciles(labeled, cfg)
 
-    decile_bytes = deciles_output.to_csv(index=False).encode("utf-8")
-    atomic_write_bytes(decile_path, decile_bytes)
-
-    summary_payload = {
-        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "as_of": as_of_date.strftime(DATE_FORMAT),
-        "window_days": cfg.days,
-        "sample_size": int(len(combined)),
-        "metrics": {
-            "hit_rate": hit_rate,
-            "expectancy": expectancy,
-            "profit_factor": pf,
-            "sharpe": sharpe,
-            "max_drawdown": drawdown,
-            "expectancy_std": float(std) if np.isfinite(std) else None,
-        },
-        "calibration": _calibration_points(combined),
-        "stability": _stability(combined),
+    payload: dict[str, Any] = {
+        "run_utc": datetime.now(timezone.utc).isoformat(),
+        "label_horizon_days": cfg.label_horizon,
+        "sample_size": int(len(labeled)),
+        "deciles": deciles,
     }
-    summary_bytes = json.dumps(summary_payload, indent=2).encode("utf-8")
-    atomic_write_bytes(summary_path, summary_bytes)
-
-    latest_path = cfg.output_dir / "latest.json"
-    try:
-        tmp_link = cfg.output_dir / ".latest.json.tmp"
-        if tmp_link.exists() or tmp_link.is_symlink():
-            tmp_link.unlink()
-        relative = os.path.relpath(summary_path, cfg.output_dir)
-        tmp_link.symlink_to(relative)
-        tmp_link.replace(latest_path)
-    except OSError:
-        atomic_write_bytes(latest_path, summary_bytes)
-
-    latest_deciles = cfg.output_dir / "latest_deciles.csv"
-    try:
-        tmp_deciles = cfg.output_dir / ".latest_deciles.csv.tmp"
-        if tmp_deciles.exists() or tmp_deciles.is_symlink():
-            tmp_deciles.unlink()
-        relative_csv = os.path.relpath(decile_path, cfg.output_dir)
-        tmp_deciles.symlink_to(relative_csv)
-        tmp_deciles.replace(latest_deciles)
-    except OSError:
-        atomic_write_bytes(latest_deciles, decile_bytes)
-
-    return EvalOutputs(summary_path=summary_path, deciles_path=decile_path)
+    if reason:
+        payload["reason"] = reason
+    return payload
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Evaluate nightly ranker performance.")
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate ranker decile performance")
+    parser.add_argument("--label-horizon", type=int, default=5, help="Forward return horizon in days")
     parser.add_argument(
-        "--labels-dir",
+        "--predictions-dir",
         type=Path,
-        default=Path("data") / "labels",
-        help="Directory containing realized label CSV files.",
+        default=BASE_DIR / "data" / "predictions",
+        help="Directory containing prediction CSV snapshots",
     )
     parser.add_argument(
-        "--output-dir",
+        "--executed-trades",
         type=Path,
-        default=Path("data") / "ranker_eval",
-        help="Directory for evaluation artefacts.",
+        default=BASE_DIR / "data" / "executed_trades.csv",
+        help="CSV of executed trades with entry/exit info",
     )
     parser.add_argument(
-        "--days",
+        "--output-json",
+        type=Path,
+        default=BASE_DIR / "data" / "ranker_eval" / "latest.json",
+        help="Path to write JSON summary",
+    )
+    parser.add_argument(
+        "--output-history",
+        type=Path,
+        default=BASE_DIR / "data" / "ranker_eval" / "history.csv",
+        help="Path to append decile history (CSV)",
+    )
+    parser.add_argument("--min-samples", type=int, default=50, help="Minimum rows required to compute deciles")
+    parser.add_argument(
+        "--min-per-decile",
         type=int,
-        default=60,
-        help="Number of days to include in the rolling evaluation window.",
+        default=5,
+        help="Minimum rows required per decile; deciles below this threshold emit nulls",
     )
-    parser.add_argument(
-        "--score-column",
-        type=str,
-        default="Score",
-        help="Column containing the model score (defaults to 'Score').",
-    )
-    parser.add_argument(
-        "--as-of",
-        type=_parse_date,
-        help="Evaluate up to this date (inclusive). Defaults to the latest available label.",
-    )
-    return parser
+    return parser.parse_args(argv)
 
 
-def main(argv: Optional[Iterable[str]] = None) -> EvalOutputs:
-    parser = build_parser()
-    args = parser.parse_args(argv)
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
     cfg = EvalConfig(
-        labels_dir=args.labels_dir,
-        output_dir=args.output_dir,
-        days=args.days,
-        score_column=args.score_column,
-        as_of=args.as_of,
+        label_horizon=int(args.label_horizon),
+        predictions_dir=Path(args.predictions_dir),
+        executed_trades=Path(args.executed_trades),
+        output_json=Path(args.output_json),
+        output_history=Path(args.output_history) if args.output_history else None,
+        min_samples=int(args.min_samples),
+        min_per_decile=int(args.min_per_decile),
     )
-    return evaluate(cfg)
+
+    LOG.info(
+        "[INFO] RANKER_EVAL start horizon=%s preds=%s trades=%s",
+        cfg.label_horizon,
+        cfg.predictions_dir,
+        cfg.executed_trades,
+    )
+    payload = evaluate(cfg)
+    try:
+        _write_json(cfg.output_json, payload)
+        LOG.info(
+            "[INFO] RANKER_EVAL samples=%d deciles=%d output=%s",
+            payload.get("sample_size", 0),
+            len(payload.get("deciles") or []),
+            cfg.output_json,
+        )
+    except Exception as exc:  # pragma: no cover - defensive write
+        LOG.exception("Failed to write ranker_eval JSON: %s", exc)
+        return 1
+
+    try:
+        _append_history(cfg.output_history, datetime.now(timezone.utc), cfg, payload.get("deciles") or [])
+    except Exception:  # pragma: no cover - defensive history write
+        LOG.warning("Failed to append ranker_eval history at %s", cfg.output_history, exc_info=True)
+
+    return 0
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except EvaluationError as exc:
-        raise SystemExit(str(exc))
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a ranker_eval module that computes decile returns from predictions and executed trades and writes data/ranker_eval/latest.json
- integrate the ranker evaluation step into the nightly pipeline defaults and expose CLI args for forwarding options
- wire the Screener Health decile charts to the ranker_eval artifact and update docs to reflect the new nightly step

## Testing
- python -m scripts.ranker_eval


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a393f38ec83318ff5046b2eb823fc)