### PR TITLE
Add centralized alerting for critical failures

### DIFF
--- a/scripts/enhanced_screener.py
+++ b/scripts/enhanced_screener.py
@@ -46,6 +46,7 @@ import pandas as pd
 from concurrent.futures import ThreadPoolExecutor
 from dotenv import load_dotenv
 import requests
+from utils.alerts import send_alert
 
 from .indicators import adx, aroon, macd, obv, rsi
 from utils import write_csv_atomic, cache_bars
@@ -76,27 +77,9 @@ logging.basicConfig(
 dotenv_path = os.path.join(BASE_DIR, '.env')
 logging.info("Loading environment variables from %s", dotenv_path)
 load_dotenv(dotenv_path)
-
-ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
 DATA_CACHE_DIR = os.path.join(BASE_DIR, 'data', 'history_cache')
 os.makedirs(DATA_CACHE_DIR, exist_ok=True)
 DB_PATH = os.path.join(BASE_DIR, 'data', 'pipeline.db')
-
-
-def send_alert(message: str) -> None:
-    """Send a simple JSON message to the configured webhook.
-
-    This function is used to surface failures in the screener via
-    Slack/Discord/Teams.  It is intentionally resilient: on any
-    exception it simply logs the error and returns.  See
-    ``ALERT_WEBHOOK_URL`` in the environment.
-    """
-    if not ALERT_WEBHOOK_URL:
-        return
-    try:
-        requests.post(ALERT_WEBHOOK_URL, json={"text": message}, timeout=5)
-    except Exception as exc:
-        logging.error("Failed to send alert: %s", exc)
 
 
 from .ensure_db_indicators import ensure_columns, REQUIRED_COLUMNS

--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -27,12 +27,10 @@ from tempfile import NamedTemporaryFile
 
 from dotenv import load_dotenv
 import pytz
-import requests
+from utils.alerts import send_alert
 
 dotenv_path = os.path.join(BASE_DIR, ".env")
 load_dotenv(dotenv_path)
-
-ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
 
 os.makedirs(os.path.join(BASE_DIR, "logs"), exist_ok=True)
 os.makedirs(os.path.join(BASE_DIR, "data"), exist_ok=True)
@@ -80,16 +78,6 @@ def log_exit_final(status: str, latency_ms: int) -> None:
         "latency_ms": latency_ms,
     }
     logger.info("EXIT_FINAL %s", payload)
-
-
-def send_alert(message: str):
-    """Send alert message to webhook if configured."""
-    if not ALERT_WEBHOOK_URL:
-        return
-    try:
-        requests.post(ALERT_WEBHOOK_URL, json={"text": message}, timeout=5)
-    except Exception as exc:
-        logger.error("Failed to send alert: %s", exc)
 
 
 def log_if_stale(file_path: str, name: str, threshold_minutes: int = 15):

--- a/scripts/run_pipeline_enhanced.py
+++ b/scripts/run_pipeline_enhanced.py
@@ -15,8 +15,9 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
-import requests
 import pandas as pd
+
+from utils.alerts import send_alert
 
 from utils import write_csv_atomic, logger_utils
 
@@ -30,18 +31,6 @@ logger = logger_utils.init_logging(__name__, 'pipeline_enhanced.log')
 error_handler = RotatingFileHandler(error_log_path, maxBytes=2_000_000, backupCount=5)
 error_handler.setLevel(logging.ERROR)
 logger.addHandler(error_handler)
-
-ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
-
-
-def send_alert(msg: str) -> None:
-    if not ALERT_WEBHOOK_URL:
-        return
-    try:
-        requests.post(ALERT_WEBHOOK_URL, json={"text": msg}, timeout=5)
-    except Exception as exc:
-        logger.error("Failed to send alert: %s", exc)
-
 
 def run_step(step_name, command):
     start_time = datetime.utcnow()

--- a/scripts/update_dashboard_data.py
+++ b/scripts/update_dashboard_data.py
@@ -10,7 +10,7 @@ import pandas as pd
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import GetOrdersRequest, GetPortfolioHistoryRequest
 from dotenv import load_dotenv
-import requests
+from utils.alerts import send_alert
 from typing import Optional
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,8 +20,6 @@ os.makedirs(DATA_DIR, exist_ok=True)
 os.makedirs(LOG_DIR, exist_ok=True)
 
 load_dotenv(os.path.join(BASE_DIR, ".env"))
-
-ALERT_WEBHOOK_URL = os.getenv("ALERT_WEBHOOK_URL")
 
 logger = logging.getLogger("update_dashboard_data")
 logger.setLevel(logging.INFO)
@@ -57,16 +55,6 @@ def load_csv_with_pnl(path: str, fallback_col: Optional[str] = None) -> pd.DataF
         else:
             df["pnl"] = 0.0
     return df
-
-
-def send_alert(message: str):
-    """Send alert via webhook if configured."""
-    if not ALERT_WEBHOOK_URL:
-        return
-    try:
-        requests.post(ALERT_WEBHOOK_URL, json={"text": message}, timeout=5)
-    except Exception as exc:
-        logger.error("Failed to send alert: %s", exc)
 
 
 def log_if_stale(file_path: str, name: str, threshold_minutes: int = 15):

--- a/utils/alerts.py
+++ b/utils/alerts.py
@@ -1,0 +1,69 @@
+"""Lightweight alert helper for webhook notifications.
+
+Alerts are best-effort: missing configuration or network failures should never
+crash callers. Set ``ALERTS_ENABLED=false`` to disable alerts locally.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Mapping, Optional
+
+import requests
+
+LOGGER = logging.getLogger("alerts")
+
+
+def _is_enabled() -> bool:
+    value = str(os.getenv("ALERTS_ENABLED", "true")).strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _webhook_url() -> str | None:
+    return os.getenv("ALERT_WEBHOOK") or os.getenv("ALERT_WEBHOOK_URL")
+
+
+def _coerce_context(context: Mapping[str, Any] | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if not isinstance(context, Mapping):
+        return payload
+    for key, value in context.items():
+        if value is None:
+            continue
+        try:
+            json.dumps({"_": value})
+            payload[str(key)] = value
+        except TypeError:
+            payload[str(key)] = str(value)
+    return payload
+
+
+def send_alert(message: str, context: Optional[Mapping[str, Any]] = None) -> None:
+    """Send an alert message to the configured webhook if enabled.
+
+    The payload is Slack-compatible and intentionally compact. Missing
+    configuration or delivery failures are logged as warnings and never raise.
+    """
+
+    if not _is_enabled():
+        LOGGER.debug("Alerts disabled via ALERTS_ENABLED")
+        return
+
+    webhook = _webhook_url()
+    if not webhook:
+        LOGGER.warning("ALERT_WEBHOOK not configured; skipping alert: %s", message)
+        return
+
+    context_payload = _coerce_context(context)
+    summary = ", ".join(f"{k}={v}" for k, v in context_payload.items())
+    text = message if not summary else f"{message} | {summary}"
+    payload = {"text": text}
+    if context_payload:
+        payload["context"] = context_payload
+
+    try:
+        requests.post(webhook, json=payload, timeout=5)
+    except Exception as exc:  # pragma: no cover - defensive network guard
+        LOGGER.warning("Failed to send alert: %s", exc)
+


### PR DESCRIPTION
## Summary
- centralize alert handling in utils/alerts.py and update existing scripts to use the shared helper
- add alerts for pipeline failures, zero-candidate anomalies, executor issues, and dashboard consistency problems
- update the premarket wrapper to rerun stale pipelines and announce auto-runs through the alert channel

## Testing
- python -m compileall utils/alerts.py scripts/run_pipeline.py scripts/execute_trades.py scripts/dashboard_consistency_check.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a3c509624833194b1d54b779f367f)