### PR TITLE
Improve ranker eval messaging and strengthen alert/exchange tests

### DIFF
--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -296,7 +296,12 @@ try:  # pragma: no cover - preferred module execution path
     from .utils.calendar import calc_daily_window
     from .utils.http_alpaca import fetch_bars_http
     from .utils.rate import TokenBucket
-    from .utils.models import BarData, classify_exchange, KNOWN_EQUITY
+    from .utils.models import (
+        ALLOWED_EQUITY_EXCHANGES,
+        BarData,
+        classify_exchange,
+        KNOWN_EQUITY,
+    )
     from .utils.env import trading_base_url
     from .utils.frame_guards import ensure_symbol_column
     from .features import (
@@ -321,7 +326,12 @@ except Exception:  # pragma: no cover - fallback for direct script execution
     from scripts.utils.calendar import calc_daily_window  # type: ignore
     from scripts.utils.http_alpaca import fetch_bars_http  # type: ignore
     from scripts.utils.rate import TokenBucket  # type: ignore
-    from scripts.utils.models import BarData, classify_exchange, KNOWN_EQUITY  # type: ignore
+    from scripts.utils.models import (  # type: ignore
+        ALLOWED_EQUITY_EXCHANGES,
+        BarData,
+        classify_exchange,
+        KNOWN_EQUITY,
+    )
     from scripts.utils.env import trading_base_url  # type: ignore
     from scripts.utils.frame_guards import ensure_symbol_column  # type: ignore
     from scripts.features import (  # type: ignore
@@ -4180,7 +4190,7 @@ def run_screener(
     }
 
     if not prefiltered_map and not prepared.empty:
-        allowed_exchanges = {"NASDAQ", "NYSE", "ARCA", "AMEX", "BATS", "IEX"}
+        allowed_exchanges = set(ALLOWED_EQUITY_EXCHANGES)
         auto_prefilter: dict[str, str] = {}
         for sym_raw, exch_raw in prepared[["symbol", "exchange"]].itertuples(index=False):
             sym = str(sym_raw or "").strip().upper()

--- a/scripts/utils/models.py
+++ b/scripts/utils/models.py
@@ -24,6 +24,11 @@ KNOWN_EQUITY = {
     "NYSEARCA",
 }
 
+# Exchanges we consider valid for the equity screener universe. This set is
+# intentionally aligned with ``KNOWN_EQUITY`` with IEX added explicitly to
+# allow its symbols while still filtering out unknown/OTC venues.
+ALLOWED_EQUITY_EXCHANGES = KNOWN_EQUITY | {"IEX"}
+
 
 def classify_exchange(raw: Any) -> str:
     """Classify an arbitrary exchange code into EQUITY/CRYPTO/OTHER."""

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Any
+
+import pytest
+
+from utils import alerts
+
+
+def test_send_alert_disabled(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALERTS_ENABLED", "false")
+    monkeypatch.delenv("ALERT_WEBHOOK", raising=False)
+    monkeypatch.delenv("ALERT_WEBHOOK_URL", raising=False)
+
+    caplog.set_level(logging.INFO, logger="utils.alerts")
+
+    alerts.send_alert("Disabled test", {"foo": "bar"})
+
+    assert "Alerts disabled via ALERTS_ENABLED" in caplog.text
+
+
+def test_send_alert_enabled_missing_webhook(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ALERTS_ENABLED", "true")
+    monkeypatch.delenv("ALERT_WEBHOOK", raising=False)
+    monkeypatch.delenv("ALERT_WEBHOOK_URL", raising=False)
+
+    caplog.set_level(logging.INFO, logger="utils.alerts")
+
+    alerts.send_alert("Missing webhook test")
+
+    assert "ALERT_WEBHOOK not set; would send alert" in caplog.text
+
+
+def test_send_alert_with_webhook_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, Any] = {}
+
+    class DummyResponse:
+        ok = True
+        status_code = 200
+
+    def fake_post(url: str, json: dict[str, Any], timeout: int = 5):  # type: ignore[override]
+        called["url"] = url
+        called["json"] = json
+        called["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setenv("ALERTS_ENABLED", "true")
+    monkeypatch.setenv("ALERT_WEBHOOK", "https://example.com/webhook")
+    monkeypatch.setattr(alerts.requests, "post", fake_post)
+
+    alerts.send_alert("Webhook success", {"alpha": 1})
+
+    assert called["url"] == "https://example.com/webhook"
+    assert "Webhook success" in called["json"].get("text", "")
+    assert called["json"].get("context") == {"alpha": 1}
+    assert called["timeout"] == 5
+

--- a/tests/test_screener_health_layout.py
+++ b/tests/test_screener_health_layout.py
@@ -84,16 +84,13 @@ def test_decile_panels_show_not_computed_when_missing(
     _patch_paths(tmp_path, monkeypatch)
 
     render = _render_callback(monkeypatch, tmp_path)
-    outputs = render({}, [], [], {}, {}, {}, {})
+    outputs = render({}, [], [], None, {}, {}, {})
     hit_fig, ret_fig = outputs[14], outputs[15]
     for fig in (hit_fig, ret_fig):
         assert isinstance(fig, go.Figure)
         annotation_texts = [ann.text for ann in fig.layout.annotations]
         joined = " ".join(annotation_texts)
-        assert any(
-            marker in joined
-            for marker in ("Not computed yet", "No ranker_eval data file yet")
-        )
+        assert "no ranker_eval file present" in joined
 
 
 def test_decile_panels_use_ranker_eval_data_when_present(
@@ -109,3 +106,26 @@ def test_decile_panels_use_ranker_eval_data_when_present(
     assert list(hit_fig.data[0].x) == [1, 2, 3]
     assert list(hit_fig.data[0].y) == [0.1, 0.15, 0.2]
     assert list(ret_fig.data[0].y) == [0.02, 0.03, 0.04]
+
+
+def test_decile_panels_surface_reason_and_sample_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_artifacts(tmp_path)
+    _patch_paths(tmp_path, monkeypatch)
+
+    render = _render_callback(monkeypatch, tmp_path)
+    ev = {
+        "deciles": [],
+        "label_horizon_days": 5,
+        "reason": "no_labeled_samples",
+        "run_utc": "2024-08-01T00:00:00Z",
+        "sample_size": 0,
+    }
+    outputs = render({}, [], [], ev, {}, {}, {})
+    hit_fig, ret_fig = outputs[14], outputs[15]
+    for fig in (hit_fig, ret_fig):
+        annotation_texts = [ann.text for ann in fig.layout.annotations]
+        joined = " ".join(annotation_texts)
+        assert "no_labeled_samples" in joined
+        assert "sample_size=0" in joined


### PR DESCRIPTION
## Summary
- surface ranker evaluation metadata (reason, sample size, horizon) in decile panels and loader handling
- add fast unit tests covering alert sending behavior and decile messaging
- centralize allowed exchanges and align screener/test expectations for unknown exchanges

## Testing
- APCA_API_KEY_ID=foo APCA_API_SECRET_KEY=bar pytest -m "not slow" --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a4f5c3d6c833187661c639e5aa5b5)