### PR TITLE
Ensure unknown exchanges are always prefiltered

### DIFF
--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -4189,7 +4189,7 @@ def run_screener(
         for sym, reason in (prefiltered_skips or {}).items()
     }
 
-    if not prefiltered_map and not prepared.empty:
+    if not prepared.empty:
         allowed_exchanges = set(ALLOWED_EQUITY_EXCHANGES)
         auto_prefilter: dict[str, str] = {}
         for sym_raw, exch_raw in prepared[["symbol", "exchange"]].itertuples(index=False):
@@ -4213,7 +4213,8 @@ def run_screener(
             if reason:
                 auto_prefilter.setdefault(sym, reason)
         if auto_prefilter:
-            prefiltered_map.update(auto_prefilter)
+            for sym, reason in auto_prefilter.items():
+                prefiltered_map.setdefault(sym, reason)
 
     initial_rejects: list[dict[str, str]] = []
     for sym, reason in prefiltered_map.items():


### PR DESCRIPTION
## Summary
- always apply the screener's auto-prefilter for unsupported exchanges so unknown and non-equity symbols are skipped consistently
- preserve existing skip reasons while merging automatically detected exchange issues

## Testing
- APCA_API_KEY_ID=dummy APCA_API_SECRET_KEY=dummy pytest tests/test_screener_unknown_exchange.py -q --maxfail=1
- APCA_API_KEY_ID=dummy APCA_API_SECRET_KEY=dummy pytest -m "not slow" --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a553fe6c8833196d698ae0e8df945)