### PR TITLE
Handle monitor_positions import guard for script execution

### DIFF
--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -17,7 +17,14 @@ from alpaca.trading.requests import (
     LimitOrderRequest,
 )
 
-from .utils import fetch_bars_with_cutoff
+# Support both ``python -m scripts.monitor_positions`` (preferred) and direct invocation.
+if __package__ in {None, ""}:
+    PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if PROJECT_ROOT not in sys.path:
+        sys.path.append(PROJECT_ROOT)
+    from scripts.utils import fetch_bars_with_cutoff
+else:
+    from .utils import fetch_bars_with_cutoff
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 import logging


### PR DESCRIPTION
## Summary
- add an import guard so monitor_positions works when executed directly or as a module
- retain existing logging configuration for logs/monitor.log

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da9c0a34c8331b819db889bbc10d4)