### PR TITLE
Ensure monitor_positions works in module and script modes

### DIFF
--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -21,7 +21,7 @@ from alpaca.trading.requests import (
 if __package__ in {None, ""}:
     PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if PROJECT_ROOT not in sys.path:
-        sys.path.append(PROJECT_ROOT)
+        sys.path.insert(0, PROJECT_ROOT)
     from scripts.utils import fetch_bars_with_cutoff
 else:
     from .utils import fetch_bars_with_cutoff


### PR DESCRIPTION
## Summary
- adjust monitor_positions import guard to insert the project root when run as a script
- preserve relative imports when invoked as a module so both entry styles remain functional

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dade6bae8833181cdd89618e0ddf1)