### PR TITLE
Enhance exit management with dynamic signals

### DIFF
--- a/data/trades_log.csv
+++ b/data/trades_log.csv
@@ -1,0 +1,3 @@
+symbol,qty,entry_price,exit_price,entry_time,exit_time,order_status,net_pnl,order_type,exit_reason,side
+ABC,100,10.0,10.5,2024-01-02T09:30:00Z,2024-01-05T15:50:00Z,filled,50.0,limit,Partial 5% Gain,sell
+XYZ,50,20.0,21.5,2024-02-01T09:30:00Z,2024-02-03T10:15:00Z,filled,75.0,limit,MACD cross; Shooting star,sell

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -379,6 +379,17 @@ def main():
             summary_metrics.get("sortino", 0.0),
         )
 
+        if "exit_reason" in trades_df.columns:
+            pnl_column = "net_pnl" if "net_pnl" in trades_df.columns else "pnl"
+            breakdown = trades_df.groupby("exit_reason")[pnl_column].agg(
+                trades="count", total_pnl="sum", avg_pnl="mean"
+            )
+            breakdown_path = Path(BASE_DIR) / "data" / "exit_reason_summary.csv"
+            write_csv_atomic(str(breakdown_path), breakdown.reset_index())
+            logger.info(
+                "Exit reason breakdown saved to %s", breakdown_path
+            )
+
     try:
         write_csv_atomic(str(metrics_summary_file), metrics_summary)
         logger.info(


### PR DESCRIPTION
## Summary
- add tiered trailing-stop tightening, partial scale-outs, and new sell triggers (MACD, RSI divergence, shooting star) to real-time monitoring
- extend backtester with matching exit options, partial scale-outs, and pattern detection controls
- capture exit-reason breakdowns and provide a sample trades_log.csv showcasing the new reasons

## Testing
- python -m compileall scripts/monitor_positions.py scripts/backtest.py scripts/metrics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dbf9f197c83319b929b78148c7082)