### PR TITLE
Improve monitor_positions credential validation

### DIFF
--- a/scripts/monitor_positions.py
+++ b/scripts/monitor_positions.py
@@ -260,12 +260,14 @@ def _save_partial_state(state: dict) -> None:
 PARTIAL_EXIT_TAKEN = _load_partial_state()
 RSI_HIGH_MEMORY: dict[str, dict[str, float]] = {}
 
+missing = [k for k in ["APCA_API_KEY_ID", "APCA_API_SECRET_KEY"] if not os.getenv(k)]
+if missing:
+    print(f"[FATAL]: Missing required env vars: {missing}. Did you load .env?")
+    raise SystemExit(1)
+
 API_KEY = os.getenv("APCA_API_KEY_ID")
 API_SECRET = os.getenv("APCA_API_SECRET_KEY")
 BASE_URL = os.getenv("APCA_API_BASE_URL")
-
-if not API_KEY or not API_SECRET:
-    raise ValueError("Missing Alpaca credentials")
 
 # Initialize Alpaca clients
 trading_client = TradingClient(API_KEY, API_SECRET, paper=True)


### PR DESCRIPTION
## Summary
- add early fatal validation for required Alpaca API environment variables
- exit cleanly with a clear fatal message when credentials are missing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc622c9488331a872e74c156afc89)