### PR TITLE
Add safe CSV line counter for labels step

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -622,6 +622,17 @@ def _count_csv_rows(path: Path) -> int:
         return 0
 
 
+def _count_csv_lines(path: Path | None) -> int:
+    """
+    Safe wrapper used by the labels step:
+    - returns 0 on missing file or None
+    - counts data rows (excluding header) otherwise.
+    """
+    if path is None:
+        return 0
+    return _count_csv_rows(path)
+
+
 def _sync_top_candidates_to_latest(base_dir: Path | None = None) -> None:
     base = _resolve_base_dir(base_dir)
     data_dir = base / "data"


### PR DESCRIPTION
## Summary
- add a `_count_csv_lines` helper to safely count label CSV rows, handling missing files or None
- ensure labels pipeline logging can call the new helper without errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a2ebc64d083319e7bb77eaf2b25b9)