### PR TITLE
Align label generator threshold flag name

### DIFF
--- a/scripts/label_generator.py
+++ b/scripts/label_generator.py
@@ -49,6 +49,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--threshold-percent",
+        dest="threshold_pct",
         type=float,
         default=3.0,
         help=(
@@ -139,7 +140,7 @@ def main() -> None:
     bars_df = bars_df.sort_values(["symbol", "timestamp"]).reset_index(drop=True)
 
     with_returns = compute_forward_returns(bars_df, args.horizons)
-    labeled = add_labels(with_returns, args.horizons, args.threshold_percent)
+    labeled = add_labels(with_returns, args.horizons, args.threshold_pct)
 
     as_of_date = determine_as_of_date(labeled)
     output_dir: Path = args.output_dir


### PR DESCRIPTION
## Summary
- align the label generator CLI threshold argument with the `--threshold-percent` flag while keeping the internal threshold configuration unchanged
- ensure help text and argument wiring use the `threshold_pct` attribute behind the `--threshold-percent` flag

## Testing
- python scripts/label_generator.py --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1a0f929c8331a338a38069893681)