### PR TITLE
Use lightweight sklearn model for ranker training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ nest-asyncio==1.6.0
 numpy==2.2.6
 packaging==25.0
 pandas==2.3.0
+scikit-learn==1.5.2
 pydantic>=1.10,<3
 plotly==6.2.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Summary
- add scikit-learn dependency so ranker training can load lightweight models
- switch ranker training to prefer a fast LogisticRegression with a small RandomForest fallback and clearer missing-sklearn errors
- log concise training summaries while continuing to save model and metrics artifacts

## Testing
- python -m scripts.ranker_train --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2e5c08f083319f9e1db751bb5b12)