### PR TITLE
Handle NaNs when reranking candidates

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -938,10 +938,15 @@ def _rerank_latest_candidates(
             )
             return False
 
+        primary_numeric = pd.to_numeric(frame[primary], errors="coerce")
+        nan_scores = int(primary_numeric.isna().sum())
+        frame[primary] = primary_numeric
+
         try:
             sorted_frame = frame.sort_values(
                 by=[primary, secondary],
                 ascending=[False, False],
+                na_position="last",
                 kind="mergesort",
             )
             write_csv_atomic(str(candidates_path), sorted_frame)
@@ -955,9 +960,10 @@ def _rerank_latest_candidates(
             return False
 
         LOG.info(
-            "[INFO] CANDIDATES_RERANKED primary=%s secondary=%s rows=%s",
+            "[INFO] CANDIDATES_RERANKED primary=%s secondary=%s nan_scores=%s rows=%s",
             primary,
             secondary,
+            nan_scores,
             len(sorted_frame.index),
         )
         return True


### PR DESCRIPTION
## Summary
- coerce model_score_5d to numeric before reranking and count NaN scores
- sort candidates with model scores descending, placing NaNs last and falling back to screener scores for NaN rows
- log NaN score counts when reranking candidates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402c2c71f88331b43f37b47d200828)