### PR TITLE
Add decile lift reporting to ranker evaluation

### DIFF
--- a/data/ranker_eval/latest.json
+++ b/data/ranker_eval/latest.json
@@ -3,5 +3,14 @@
   "label_horizon_days": 5,
   "reason": "no labeled samples",
   "run_utc": "2025-11-29T00:10:19.795253+00:00",
-  "sample_size": 0
+  "sample_size": 0,
+  "label_column": "label_5d_pos_300bp",
+  "score_column": "score_5d",
+  "decile_convention": "10=top",
+  "top_decile_index": 10,
+  "bottom_decile_index": 1,
+  "top_avg_label": null,
+  "bottom_avg_label": null,
+  "decile_lift": null,
+  "signal_quality": null
 }


### PR DESCRIPTION
## Summary
- compute top/bottom decile averages, decile lift, and signal quality when running the ranker evaluation script
- propagate new decile lift metrics into the dashboard ranker health summary while keeping backward-compatible parsing
- refresh the sample ranker evaluation output with the new metadata fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69417900680c8331b47e5805514f7325)