### PR TITLE
Log risk scaling decisions to execute_trades.log

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -238,6 +238,14 @@ PY
 )
 RISK_LOG_LINE=$(printf "%s\n" "$RISK_OUTPUT" | head -n1)
 FINAL_ALLOCATION_PCT=$(printf "%s\n" "$RISK_OUTPUT" | tail -n1)
+
+LOG_TIMESTAMP=$(PYTHONPATH="" python - <<'PY'
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S,%f")[:23])
+PY
+)
+mkdir -p logs
+printf '%s - wrapper - %s\n' "$LOG_TIMESTAMP" "$RISK_LOG_LINE" >> logs/execute_trades.log
 echo "$RISK_LOG_LINE"
 
 python -m scripts.execute_trades \


### PR DESCRIPTION
## Summary
- append the wrapper’s risk scaling line with a timestamp to logs/execute_trades.log so allocations are recorded even when execution skips

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694189d6a00483318da7c4087ab51e7f)