### PR TITLE
Add execute source logging to premarket wrapper

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -248,8 +248,18 @@ mkdir -p logs
 printf '%s - wrapper - %s\n' "$LOG_TIMESTAMP" "$RISK_LOG_LINE" >> logs/execute_trades.log
 echo "$RISK_LOG_LINE"
 
+EXEC_SOURCE="data/latest_candidates.csv"
+EXEC_SOURCE_LOG_LINE="[INFO] EXEC_SOURCE path=${EXEC_SOURCE}"
+LOG_TIMESTAMP=$(PYTHONPATH="" python - <<'PY'
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S,%f")[:23])
+PY
+)
+printf '%s - wrapper - %s\n' "$LOG_TIMESTAMP" "$EXEC_SOURCE_LOG_LINE" >> logs/execute_trades.log
+echo "$EXEC_SOURCE_LOG_LINE"
+
 python -m scripts.execute_trades \
-  --source data/latest_candidates.csv \
+  --source "$EXEC_SOURCE" \
   --allocation-pct "$FINAL_ALLOCATION_PCT" --min-order-usd 300 --max-positions 7 \
   --trailing-percent 3 --time-window premarket --extended-hours true \
   --submit-at-ny "07:00" --price-source prevclose \


### PR DESCRIPTION
## Summary
- log the execute_trades source path and append it to execute_trades.log
- explicitly pass the latest candidates CSV path when invoking execute_trades

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a040049483319576d1de08dd7c4d)