### PR TITLE
Preserve allocation weights in execute trades pipeline

### DIFF
--- a/scripts/fallback_candidates.py
+++ b/scripts/fallback_candidates.py
@@ -295,7 +295,20 @@ def _canonical_frame(df: Optional[pd.DataFrame], now_ts: Optional[str] = None) -
 
     mask_symbol = out["symbol"].astype("string").str.len() > 0
     out = out.loc[mask_symbol]
+    source_frame = source_frame.loc[mask_symbol] if not source_frame.empty else source_frame
+
     out = out.reset_index(drop=True)
+    source_frame = source_frame.reset_index(drop=True)
+
+    out = out[list(CANONICAL_COLUMNS)]
+
+    extra_columns = [column for column in source_frame.columns if column not in out.columns]
+    for column in extra_columns:
+        try:
+            out[column] = source_frame[column]
+        except Exception:
+            out[column] = source_frame.get(column)
+
     return out
 
 


### PR DESCRIPTION
## Summary
- preserve appended columns such as alloc_weight and model scores when canonicalizing candidate data
- ensure allocation logging and weighting use the ranked top candidates and report available columns

## Testing
- python -m compileall scripts/execute_trades.py scripts/fallback_candidates.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942f8479ef88331a564d41a86226e75)