### PR TITLE
Add canonical KPI fields to screener metrics output

### DIFF
--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -16,6 +16,7 @@ from collections import Counter
 import numpy as np
 import pandas as pd
 from utils import write_csv_atomic
+from utils.screener_metrics import ensure_canonical_metrics, write_screener_metrics_json
 from utils.env import load_env
 
 load_env()
@@ -422,10 +423,8 @@ def main():
         metrics["universe_prefix_counts"] = {}
 
     try:
-        metrics_path.parent.mkdir(parents=True, exist_ok=True)
-        metrics_path.write_text(
-            json.dumps(metrics, indent=2, sort_keys=True), encoding="utf-8"
-        )
+        metrics = ensure_canonical_metrics(metrics)
+        write_screener_metrics_json(metrics_path, metrics)
     except Exception as exc:  # pragma: no cover - defensive I/O guard
         logger.warning("Failed to update %s: %s", metrics_path, exc)
 

--- a/scripts/screener.py
+++ b/scripts/screener.py
@@ -357,6 +357,7 @@ from utils.env import (
     write_auth_error_artifacts,
 )
 from utils.io_utils import atomic_write_bytes
+from utils.screener_metrics import ensure_canonical_metrics
 
 DEFAULT_FEED = (os.getenv("ALPACA_DATA_FEED") or "iex").strip().lower() or "iex"
 
@@ -3131,8 +3132,10 @@ def _write_shortlist_csv(path: Path, shortlist: Optional[pd.DataFrame]) -> Path:
 
 
 def _write_json_atomic(path: Path, payload: dict) -> None:
-    data = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
-    atomic_write_bytes(path, data)
+    target = Path(path)
+    enriched = ensure_canonical_metrics(payload) if target.name == "screener_metrics.json" else payload
+    data = json.dumps(enriched, indent=2, sort_keys=True).encode("utf-8")
+    atomic_write_bytes(target, data)
 
 
 def _load_coverage_table(path: Path) -> dict[str, dict[str, object]]:

--- a/utils/screener_metrics.py
+++ b/utils/screener_metrics.py
@@ -1,0 +1,67 @@
+"""Helpers for writing ``screener_metrics.json`` consistently.
+
+This module centralises the logic for adding canonical KPI fields required by the
+dashboard and ensures atomic writes so readers never observe partial output.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from . import atomic_write_bytes
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return 0
+
+
+def ensure_canonical_metrics(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a copy of ``payload`` with canonical KPI fields populated.
+
+    The dashboard expects the following keys to always be present and non-null:
+    ``timestamp``, ``rows_out``, ``with_bars``, ``universe_count``, and
+    ``gate_breakdown``. Existing keys are preserved.
+    """
+
+    metrics = dict(payload) if isinstance(payload, Mapping) else {}
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    last_run = metrics.get("last_run_utc")
+    metrics["timestamp"] = last_run if isinstance(last_run, str) and last_run else now_iso
+
+    metrics["rows_out"] = _coerce_int(metrics.get("rows", 0))
+    metrics["with_bars"] = _coerce_int(metrics.get("symbols_with_bars", 0))
+
+    universe_count = metrics.get("universe_count")
+    if universe_count is None:
+        universe_count = metrics.get("symbols_in")
+        if universe_count is None:
+            universe_count = metrics.get("symbols_with_bars")
+    metrics["universe_count"] = _coerce_int(universe_count)
+
+    gate_breakdown = metrics.get("gate_breakdown")
+    metrics["gate_breakdown"] = dict(gate_breakdown) if isinstance(gate_breakdown, Mapping) else {}
+
+    return metrics
+
+
+def write_screener_metrics_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Write screener metrics atomically with canonical KPI fields.
+
+    The payload is enriched via :func:`ensure_canonical_metrics` before being
+    written to ``path``.
+    """
+
+    enriched = ensure_canonical_metrics(payload)
+    serialised = json.dumps(enriched, indent=2, sort_keys=True).encode("utf-8")
+    atomic_write_bytes(path, serialised)
+
+
+__all__ = ["ensure_canonical_metrics", "write_screener_metrics_json"]


### PR DESCRIPTION
## Summary
- add a shared helper to enrich screener metrics with canonical KPI fields and write atomically
- update pipeline, screener, and metrics writers to include dashboard keys such as timestamp, rows_out, with_bars, and universe_count
- ensure refresh and annotation paths produce atomic screener_metrics.json outputs with no missing canonical fields

## Testing
- python -m pytest tests/test_pipeline_metrics_sync.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944393037b88331b0abb3027a686ac7)