### PR TITLE
Handle legacy screener KPI keys

### DIFF
--- a/utils/screener_metrics.py
+++ b/utils/screener_metrics.py
@@ -33,11 +33,13 @@ def ensure_canonical_metrics(payload: Mapping[str, Any] | None) -> dict[str, Any
     metrics = dict(payload) if isinstance(payload, Mapping) else {}
     now_iso = datetime.now(timezone.utc).isoformat()
 
-    last_run = metrics.get("last_run_utc")
-    metrics["timestamp"] = last_run if isinstance(last_run, str) and last_run else now_iso
+    timestamp = metrics.get("timestamp") or metrics.get("last_run_utc")
+    metrics["timestamp"] = timestamp if isinstance(timestamp, str) and timestamp else now_iso
 
-    metrics["rows_out"] = _coerce_int(metrics.get("rows", 0))
-    metrics["with_bars"] = _coerce_int(metrics.get("symbols_with_bars", 0))
+    metrics["rows_out"] = _coerce_int(metrics.get("rows_out") or metrics.get("rows", 0))
+    metrics["with_bars"] = _coerce_int(
+        metrics.get("with_bars") or metrics.get("symbols_with_bars", 0)
+    )
 
     universe_count = metrics.get("universe_count")
     if universe_count is None:


### PR DESCRIPTION
## Summary
- accept both canonical and legacy KPI keys when coercing metrics, including timestamps and row counts
- allow screener health dashboard history and display to fall back to `with_bars`, `rows_out`, and `timestamp` when canonical keys are missing
- preserve canonical fields when writing screener metrics even when only legacy keys are provided

## Testing
- python -m compileall dashboards/utils.py dashboards/screener_health.py utils/screener_metrics.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443d6a74b0833186ed5ae02c20f716)