### PR TITLE
Add overview, pipeline, and ML dashboard tabs

### DIFF
--- a/dashboards/ml_tab.py
+++ b/dashboards/ml_tab.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import dash_bootstrap_components as dbc
+import pandas as pd
+from dash import dash_table, dcc, html
+
+from dashboards.utils import list_recent_files, safe_read_json
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_DIR = BASE_DIR / "data"
+
+
+def _ml_status_rows() -> List[Dict[str, Any]]:
+    payload = safe_read_json(DATA_DIR / "nightly_ml_status.json")
+    rows: List[Dict[str, Any]] = []
+    if payload:
+        rows.append({"key": "written_at", "value": payload.get("written_at")})
+        for key in ["bars", "features", "labels", "model", "predictions", "eval"]:
+            rows.append({"key": key, "value": payload.get(key)})
+    return rows
+
+
+def _ranker_eval_rows() -> List[Dict[str, Any]]:
+    latest = DATA_DIR / "ranker_eval" / "latest.json"
+    if not latest.exists():
+        return []
+    payload = safe_read_json(latest)
+    rows = []
+    for key, value in payload.items():
+        rows.append({"key": str(key), "value": json.dumps(value)[:200]})
+    return rows
+
+
+def _prediction_options() -> List[Dict[str, Any]]:
+    files = list_recent_files(DATA_DIR / "predictions", "*.csv", limit=30)
+    return [
+        {"label": f.name, "value": str(f)}
+        for f in files
+    ]
+
+
+def _prediction_preview(path_str: str | None) -> List[Dict[str, Any]]:
+    if not path_str:
+        return []
+    path = Path(path_str)
+    if not path.exists():
+        return []
+    try:
+        df = pd.read_csv(path)
+        if "score" in df.columns:
+            df = df.sort_values("score", ascending=False)
+        return df.head(50).to_dict(orient="records")
+    except Exception:
+        return []
+
+
+def ml_layout(prediction_path: str | None = None):
+    status_table = dash_table.DataTable(
+        columns=[{"name": "key", "id": "key"}, {"name": "value", "id": "value"}],
+        data=_ml_status_rows(),
+        page_size=10,
+        style_table={"overflowX": "auto"},
+    )
+
+    eval_table = dash_table.DataTable(
+        columns=[{"name": "key", "id": "key"}, {"name": "value", "id": "value"}],
+        data=_ranker_eval_rows(),
+        page_size=10,
+        style_table={"overflowX": "auto"},
+    )
+
+    preview = dash_table.DataTable(
+        columns=[],
+        data=_prediction_preview(prediction_path),
+        page_size=50,
+        style_table={"overflowX": "auto", "maxHeight": "500px", "overflowY": "auto"},
+    )
+
+    return html.Div(
+        [
+            html.H5("Nightly ML Status"),
+            status_table,
+            html.Hr(),
+            html.H5("Ranker Eval"),
+            eval_table,
+            html.Hr(),
+            html.H5("Predictions Browser"),
+            dcc.Dropdown(id="predictions-dropdown", options=_prediction_options(), value=prediction_path),
+            html.Div(preview, id="predictions-preview"),
+        ]
+    )
+

--- a/dashboards/overview.py
+++ b/dashboards/overview.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+import dash_bootstrap_components as dbc
+import pandas as pd
+from dash import html
+
+from dashboards.utils import safe_read_json, parse_pipeline_summary, safe_tail_text
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_DIR = BASE_DIR / "data"
+LOG_DIR = BASE_DIR / "logs"
+
+
+def _read_screener_metrics() -> Dict[str, Any]:
+    path = DATA_DIR / "screener_metrics.json"
+    payload = safe_read_json(path)
+    if payload:
+        payload.setdefault("timestamp", payload.get("last_run_utc"))
+    else:
+        payload = parse_pipeline_summary(LOG_DIR / "pipeline.log")
+    return payload
+
+
+def _read_execute_metrics() -> Dict[str, Any]:
+    path = DATA_DIR / "execute_metrics.json"
+    return safe_read_json(path)
+
+
+def _read_candidates() -> tuple[int | None, List[Dict[str, Any]]]:
+    path = DATA_DIR / "latest_candidates.csv"
+    if not path.exists():
+        return None, []
+    try:
+        df = pd.read_csv(path)
+        rows = len(df)
+        top_cols = [col for col in ("symbol", "score", "model_score_5d") if col in df.columns]
+        return rows, df[top_cols].head(5).to_dict(orient="records") if top_cols else []
+    except Exception:
+        return None, []
+
+
+def _read_nightly_ml_status() -> Dict[str, Any]:
+    return safe_read_json(DATA_DIR / "nightly_ml_status.json")
+
+
+def _read_ranker_eval_path() -> Path | None:
+    path = DATA_DIR / "ranker_eval" / "latest.json"
+    return path if path.exists() else None
+
+
+def _build_card(title: str, items: List[str]) -> dbc.Card:
+    return dbc.Card(
+        dbc.CardBody([html.H5(title, className="card-title"), html.Ul([html.Li(i) for i in items])]),
+        className="mb-3",
+    )
+
+
+def _format_time(ts: str | None) -> str:
+    if not ts:
+        return "(missing)"
+    try:
+        return datetime.fromisoformat(str(ts)).strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return str(ts)
+
+
+def _compute_alerts(metrics: Dict[str, Any], exec_metrics: Dict[str, Any], candidates_rows: int | None) -> List[dbc.Badge]:
+    alerts: List[dbc.Badge] = []
+    now = datetime.now(timezone.utc)
+    ts_raw = metrics.get("timestamp") or metrics.get("last_run_utc")
+    try:
+        dt = datetime.fromisoformat(str(ts_raw)) if ts_raw else None
+    except Exception:
+        dt = None
+    if dt and now - dt > timedelta(hours=6):
+        alerts.append(dbc.Badge("Pipeline stale", color="danger", className="me-2"))
+    auth_ok = exec_metrics.get("auth_ok")
+    if auth_ok is False:
+        alerts.append(dbc.Badge("Auth failed", color="danger", className="me-2"))
+    finished = exec_metrics.get("run_finished_utc") or exec_metrics.get("timestamp")
+    if finished:
+        try:
+            finished_dt = datetime.fromisoformat(str(finished))
+            if finished_dt.date() != now.date():
+                alerts.append(dbc.Badge("Execute stale", color="warning", className="me-2"))
+        except Exception:
+            pass
+    else:
+        alerts.append(dbc.Badge("Execute stale", color="warning", className="me-2"))
+
+    skips = exec_metrics.get("skips") or exec_metrics.get("skip_reasons") or {}
+    if isinstance(skips, dict) and any("OPEN ORDER" in k for k in skips):
+        alerts.append(dbc.Badge("Open order skip", color="warning", className="me-2"))
+
+    duration_sec = exec_metrics.get("duration_sec")
+    started = exec_metrics.get("run_started_utc")
+    if duration_sec and started and finished:
+        try:
+            s_dt = datetime.fromisoformat(str(started))
+            f_dt = datetime.fromisoformat(str(finished))
+            actual = (f_dt - s_dt).total_seconds()
+            if abs(actual - float(duration_sec)) > 10:
+                alerts.append(dbc.Badge("Duration mismatch", color="warning", className="me-2"))
+        except Exception:
+            pass
+
+    if not candidates_rows:
+        alerts.append(dbc.Badge("Candidates missing", color="danger", className="me-2"))
+
+    rows_out = metrics.get("rows_out")
+    rows = metrics.get("rows")
+    try:
+        if rows_out and rows and float(rows_out) > float(rows) * 50:
+            alerts.append(dbc.Badge("rows_out mismatch", color="warning", className="me-2"))
+    except Exception:
+        pass
+
+    return alerts
+
+
+def overview_layout():
+    metrics = _read_screener_metrics()
+    exec_metrics = _read_execute_metrics()
+    candidates_rows, top_candidates = _read_candidates()
+    ml_status = _read_nightly_ml_status()
+    ranker_eval_path = _read_ranker_eval_path()
+
+    pipeline_items = [
+        f"Last run: {_format_time(metrics.get('timestamp') or metrics.get('last_run_utc'))}",
+        f"RC: {metrics.get('rc', 'N/A')}",
+        f"Symbols in: {metrics.get('symbols_in', 'N/A')}",
+        f"With bars: {metrics.get('with_bars', metrics.get('symbols_with_bars', 'N/A'))}",
+        f"Rows: {metrics.get('rows', 'N/A')}",
+        f"Bars rows total: {metrics.get('bars_rows_total', 'N/A')}",
+        f"Source: {metrics.get('source', 'screener')}",
+    ]
+
+    candidates_items = [f"Rows: {candidates_rows if candidates_rows is not None else '(missing)'}"]
+    if top_candidates:
+        for row in top_candidates:
+            symbol = row.get("symbol")
+            score = row.get("score")
+            bonus = row.get("model_score_5d")
+            suffix = f" (model_5d={bonus})" if bonus is not None else ""
+            candidates_items.append(f"{symbol}: {score}{suffix}")
+
+    execute_items = [
+        f"Last execute: {_format_time(exec_metrics.get('run_finished_utc') or exec_metrics.get('timestamp'))}",
+        f"Auth OK: {exec_metrics.get('auth_ok')}",
+        f"Orders submitted: {exec_metrics.get('orders_submitted')}",
+        f"Fills: {exec_metrics.get('fills')}",
+        f"Trails: {exec_metrics.get('trails')}",
+        f"Duration: {exec_metrics.get('duration_sec')}",
+    ]
+    skips = exec_metrics.get("skips") or exec_metrics.get("skip_reasons") or {}
+    if isinstance(skips, dict):
+        sorted_skips = sorted(skips.items(), key=lambda kv: kv[1], reverse=True)
+        for reason, count in sorted_skips[:3]:
+            execute_items.append(f"Skip {reason}: {count}")
+
+    ml_items = [
+        f"Written at: {_format_time(ml_status.get('written_at'))}",
+    ]
+    for key in ["bars", "features", "labels", "model", "predictions", "eval"]:
+        if key in ml_status:
+            ml_items.append(f"{key}: {_format_time(ml_status.get(key))}")
+    if ranker_eval_path:
+        ml_items.append(f"Ranker eval: {ranker_eval_path.name}")
+
+    alerts = _compute_alerts(metrics, exec_metrics, candidates_rows)
+
+    alerts_block = html.Div(
+        alerts if alerts else [dbc.Badge("Healthy", color="success")],
+        className="mb-3",
+    )
+
+    return html.Div(
+        [
+            alerts_block,
+            dbc.Row(
+                [
+                    dbc.Col(_build_card("Pipeline", pipeline_items), md=6),
+                    dbc.Col(_build_card("Candidates", candidates_items), md=6),
+                ]
+            ),
+            dbc.Row(
+                [
+                    dbc.Col(_build_card("Execution", execute_items), md=6),
+                    dbc.Col(_build_card("ML", ml_items), md=6),
+                ]
+            ),
+            html.H5("Recent Token Events"),
+            html.Pre(
+                safe_tail_text(LOG_DIR / "pipeline.log", 50),
+                style={"maxHeight": "300px", "overflow": "auto"},
+            ),
+        ]
+    )
+

--- a/dashboards/pipeline_tab.py
+++ b/dashboards/pipeline_tab.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import dash_bootstrap_components as dbc
+import pandas as pd
+from dash import dash_table, html
+
+from dashboards.utils import file_stat, parse_pipeline_tokens, safe_tail_text
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_DIR = BASE_DIR / "data"
+LOG_DIR = BASE_DIR / "logs"
+
+
+def _artifact_rows() -> list[Dict[str, Any]]:
+    targets = [
+        DATA_DIR / "latest_candidates.csv",
+        DATA_DIR / "screener_metrics.json",
+        DATA_DIR / "execute_metrics.json",
+        DATA_DIR / "nightly_ml_status.json",
+        DATA_DIR / "ranker_eval" / "latest.json",
+    ]
+    preds_dir = DATA_DIR / "predictions"
+    if preds_dir.exists():
+        newest = sorted(preds_dir.glob("*.csv"), key=lambda p: p.stat().st_mtime, reverse=True)
+        if newest:
+            targets.append(newest[0])
+    targets.extend([LOG_DIR / "pipeline.log", LOG_DIR / "execute_trades.log"])
+    rows: list[Dict[str, Any]] = []
+    for path in targets:
+        stat = file_stat(path)
+        rows.append(
+            {
+                "path": str(path.relative_to(BASE_DIR)),
+                "exists": stat.get("exists"),
+                "mtime": stat.get("mtime_iso"),
+                "size_bytes": stat.get("size_bytes"),
+            }
+        )
+    return rows
+
+
+def pipeline_layout():
+    tokens = parse_pipeline_tokens(LOG_DIR / "pipeline.log")
+    token_table = dash_table.DataTable(
+        columns=[{"name": col, "id": col} for col in [
+            "start_time",
+            "end_time",
+            "rc",
+            "duration",
+            "symbols_in",
+            "with_bars",
+            "rows",
+            "bars_rows_total",
+            "source",
+        ]],
+        data=tokens,
+        style_table={"overflowX": "auto"},
+        page_size=10,
+    )
+
+    artifacts = dash_table.DataTable(
+        columns=[{"name": col, "id": col} for col in ["path", "exists", "mtime", "size_bytes"]],
+        data=_artifact_rows(),
+        style_table={"overflowX": "auto"},
+        page_size=10,
+    )
+
+    log_tail = safe_tail_text(LOG_DIR / "pipeline.log", 200)
+
+    return html.Div(
+        [
+            html.H5("Pipeline tokens"),
+            token_table,
+            html.Hr(),
+            html.H5("Artifact freshness"),
+            artifacts,
+            html.Hr(),
+            html.H5("pipeline.log tail"),
+            html.Pre(log_tail or "(no log)", style={"maxHeight": "400px", "overflow": "auto"}),
+        ]
+    )
+

--- a/dashboards/utils.py
+++ b/dashboards/utils.py
@@ -7,6 +7,122 @@ import re
 from pathlib import Path
 from typing import Any, Dict
 
+
+def safe_tail_text(path: Path, max_lines: int = 200) -> str:
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            lines = handle.readlines()
+    except FileNotFoundError:
+        logger.warning("TAIL_FAIL path=%s err=missing", path)
+        return ""
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("TAIL_FAIL path=%s err=%s", path, exc)
+        return ""
+    trimmed = [line.rstrip("\n") for line in lines[-max_lines:]]
+    return "\n".join(trimmed)
+
+
+def file_stat(path: Path) -> Dict[str, Any]:
+    try:
+        stat = path.stat()
+        mtime_iso = None
+        try:
+            from datetime import datetime
+
+            mtime_iso = datetime.utcfromtimestamp(stat.st_mtime).isoformat()
+        except Exception:
+            mtime_iso = None
+        return {"exists": True, "mtime_iso": mtime_iso, "size_bytes": stat.st_size}
+    except FileNotFoundError:
+        return {"exists": False, "mtime_iso": None, "size_bytes": None}
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("FILE_STAT_FAIL path=%s err=%s", path, exc)
+        return {"exists": False, "mtime_iso": None, "size_bytes": None}
+
+
+def list_recent_files(dir_path: Path, pattern: str, limit: int = 30) -> list[Path]:
+    if not dir_path.exists():
+        return []
+    try:
+        files = sorted(
+            dir_path.glob(pattern),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except Exception:  # pragma: no cover - defensive logging
+        return []
+    return files[:limit]
+
+
+def parse_pipeline_tokens(path: Path, limit_runs: int = 10) -> list[Dict[str, Any]]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except FileNotFoundError:
+        logger.warning("PIPELINE_TOKEN_PARSE_FAIL path=%s err=%s", path, "missing")
+        return []
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("PIPELINE_TOKEN_PARSE_FAIL path=%s err=%s", path, exc)
+        return []
+
+    runs: list[Dict[str, Any]] = []
+    current: Dict[str, Any] | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if "PIPELINE START" in line:
+            if current:
+                runs.append(current)
+            current = {"start": line}
+        elif "PIPELINE END" in line and current is not None:
+            current["end"] = line
+            runs.append(current)
+            current = None
+        elif "PIPELINE SUMMARY" in line and current is not None:
+            current["summary"] = line
+        elif "FALLBACK_CHECK" in line and current is not None:
+            current.setdefault("tokens", []).append(line)
+
+    if current:
+        runs.append(current)
+
+    parsed: list[Dict[str, Any]] = []
+    for run in runs[::-1][:limit_runs]:
+        start_match = re.search(r"(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})", run.get("start", ""))
+        end_match = re.search(r"(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})", run.get("end", ""))
+        summary = run.get("summary", "")
+        summary_match = re.search(
+            r"symbols_in=(?P<symbols_in>\d+)\s+with_bars=(?P<with_bars>\d+)\s+rows=(?P<rows>\d+)(?:[^\n\r]*?(?:\sbar_rows|\sbars_rows_total)=(?P<bars_rows_total>\d+))?",
+            summary,
+        )
+        rc_match = re.search(r"rc=(?P<rc>-?\d+)", run.get("end", ""))
+        start_ts = start_match.group("ts") if start_match else None
+        end_ts = end_match.group("ts") if end_match else None
+        duration = None
+        if start_ts and end_ts:
+            try:
+                from datetime import datetime
+
+                dt_start = datetime.fromisoformat(start_ts)
+                dt_end = datetime.fromisoformat(end_ts)
+                duration = (dt_end - dt_start).total_seconds()
+            except Exception:
+                duration = None
+
+        parsed.append(
+            {
+                "start_time": start_ts,
+                "end_time": end_ts,
+                "rc": int(rc_match.group("rc")) if rc_match else None,
+                "duration": duration,
+                "symbols_in": int(summary_match.group("symbols_in")) if summary_match else None,
+                "with_bars": int(summary_match.group("with_bars")) if summary_match else None,
+                "rows": int(summary_match.group("rows")) if summary_match else None,
+                "bars_rows_total": int(summary_match.group("bars_rows_total")) if summary_match and summary_match.group("bars_rows_total") else None,
+                "source": "fallback" if any("FALLBACK_CHECK" in t for t in run.get("tokens", [])) else "screener",
+            }
+        )
+
+    return parsed
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- add new Overview, Pipeline, and ML tabs with supporting layouts
- include utility helpers for reading logs and artifacts safely
- wire refresh store and suppress callback exceptions for dynamic content

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694452d58f308331a7e8a70b475a5559)