### PR TITLE
Isolate ML predictions dropdown updates

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -40,7 +40,7 @@ from dashboards.data_io import (
 from dashboards.utils import coerce_kpi_types, parse_pipeline_summary
 from dashboards.overview import overview_layout, render_timeline_table
 from dashboards.pipeline_tab import pipeline_layout
-from dashboards.ml_tab import ml_layout
+from dashboards.ml_tab import build_predictions_table, ml_layout
 from scripts.run_pipeline import write_complete_screener_metrics
 from scripts.indicators import macd as _macd, rsi as _rsi, adx as _adx, obv as _obv
 
@@ -2970,10 +2970,18 @@ def _refresh_ts(n_clicks):
 
 
 @app.callback(
-    Output("tabs-content", "children"),
-    [Input("tabs", "active_tab"), Input("refresh-ts", "data"), Input("predictions-dropdown", "value")],
+    Output("ml-predictions-table", "children"),
+    [Input("predictions-dropdown", "value"), Input("refresh-ts", "data")],
 )
-def render_tab(tab, refresh_ts=None, prediction_path=None):
+def update_ml_predictions_table(prediction_path, refresh_ts=None):
+    return build_predictions_table(prediction_path)
+
+
+@app.callback(
+    Output("tabs-content", "children"),
+    [Input("tabs", "active_tab"), Input("refresh-ts", "data")],
+)
+def render_tab(tab, refresh_ts=None):
     if tab == "tab-overview":
         logger.info("Rendering content for tab: %s", tab)
         return overview_layout()
@@ -2982,7 +2990,7 @@ def render_tab(tab, refresh_ts=None, prediction_path=None):
         return pipeline_layout()
     if tab == "tab-ml":
         logger.info("Rendering content for tab: %s", tab)
-        return ml_layout(prediction_path)
+        return ml_layout()
     if tab == "tab-screener-health":
         logger.info("Rendering content for tab: %s", tab)
         return build_screener_health()

--- a/dashboards/ml_tab.py
+++ b/dashboards/ml_tab.py
@@ -58,7 +58,26 @@ def _prediction_preview(path_str: str | None) -> List[Dict[str, Any]]:
         return []
 
 
+def build_predictions_table(path_str: str | None) -> dash_table.DataTable:
+    rows = _prediction_preview(path_str)
+    columns = (
+        [{"name": str(col), "id": str(col)} for col in rows[0].keys()]
+        if rows
+        else []
+    )
+
+    return dash_table.DataTable(
+        columns=columns,
+        data=rows,
+        page_size=50,
+        style_table={"overflowX": "auto", "maxHeight": "500px", "overflowY": "auto"},
+    )
+
+
 def ml_layout(prediction_path: str | None = None):
+    options = _prediction_options()
+    selected_prediction = prediction_path or (options[0]["value"] if options else None)
+
     status_table = dash_table.DataTable(
         columns=[{"name": "key", "id": "key"}, {"name": "value", "id": "value"}],
         data=_ml_status_rows(),
@@ -73,13 +92,6 @@ def ml_layout(prediction_path: str | None = None):
         style_table={"overflowX": "auto"},
     )
 
-    preview = dash_table.DataTable(
-        columns=[],
-        data=_prediction_preview(prediction_path),
-        page_size=50,
-        style_table={"overflowX": "auto", "maxHeight": "500px", "overflowY": "auto"},
-    )
-
     return html.Div(
         [
             html.H5("Nightly ML Status"),
@@ -89,8 +101,10 @@ def ml_layout(prediction_path: str | None = None):
             eval_table,
             html.Hr(),
             html.H5("Predictions Browser"),
-            dcc.Dropdown(id="predictions-dropdown", options=_prediction_options(), value=prediction_path),
-            html.Div(preview, id="predictions-preview"),
+            dcc.Dropdown(
+                id="predictions-dropdown", options=options, value=selected_prediction
+            ),
+            html.Div(build_predictions_table(selected_prediction), id="ml-predictions-table"),
         ]
     )
 


### PR DESCRIPTION
## Summary
- keep the ML predictions dropdown within the tab layout and preselect the latest option
- add a dedicated predictions table builder and callback driven by dropdown and refresh timestamp
- simplify the tabs content callback so ML updates stay isolated

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694476c69e74833194e91992f4c20aae)