### PR TITLE
feat: harden screener_health callback returns and add guard+metrics

### DIFF
--- a/dashboards/screener_health.py
+++ b/dashboards/screener_health.py
@@ -1288,9 +1288,14 @@ def register_callbacks(app):
     )
     def _render(m, top_rows, hist_rows, ev, health, summary, premarket):
         empty_fig = _placeholder_figure("Unavailable", "No data available")
+        try:
+            paper_badge_default = _paper_badge_component()
+        except Exception:  # pragma: no cover - defensive badge guard
+            LOGGER.exception("Failed to render paper/live badge")
+            paper_badge_default = html.Span("env unavailable")
         default_outputs = (
             None,
-            _paper_badge_component(),
+            paper_badge_default,
             html.Div(),
             "(no data)",
             "(no data)",
@@ -1332,7 +1337,11 @@ def register_callbacks(app):
 
             fallback_active = bool(m.get("_fallback_active"))
             env_paper, env_feed = _environment_state()
-            paper_badge = _paper_badge_component()
+            paper_badge = paper_badge_default
+            try:
+                paper_badge = _paper_badge_component()
+            except Exception:  # pragma: no cover - defensive badge guard
+                LOGGER.exception("Failed to render paper/live badge")
             latest_zero = bool(m.get("_latest_zero_rows"))
             top_empty_message: Any = ""
             if latest_zero:


### PR DESCRIPTION
## Summary
- guard Screener Health callback defaults and paper badge rendering so multi-output responses remain valid even when environment state fails
- add regression coverage to ensure the screener_health callback returns its full output shape with empty inputs and recovers with an error banner when exceptions occur

## Testing
- pytest tests/test_screener_health_layout.py -k "callback"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694afaf699c08331aeeeb06a856a6cff)