### PR TITLE
Add trade performance dashboard and cache refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ data/*.csv
 logs/*.log*
 data/open_positions.csv
 data/trades_log.csv
-
+data/trade_performance_cache.json

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1893,6 +1893,21 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             if rc_metrics:
                 logger.warning("[WARN] METRICS_STEP rc=%s (continuing)", rc_metrics)
             _sync_top_candidates_to_latest(base_dir)
+            try:
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "scripts.trade_performance_refresh",
+                        "--lookback-days",
+                        "400",
+                    ],
+                    cwd=PROJECT_ROOT,
+                    check=True,
+                )
+                LOG.info("[INFO] TRADE_PERFORMANCE_CACHE_REFRESHED")
+            except Exception:
+                LOG.warning("TRADE_PERFORMANCE_CACHE_REFRESH_FAILED", exc_info=True)
         if "labels" in steps:
             current_step = "labels"
             bars_path = _resolve_labels_bars_path(args.labels_bars_path, base_dir)

--- a/scripts/trade_performance_refresh.py
+++ b/scripts/trade_performance_refresh.py
@@ -1,0 +1,85 @@
+"""CLI utility to refresh trade performance cache."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable, Optional
+
+from utils.env import load_env
+
+from scripts.trade_performance import (
+    BASE_DIR,
+    CACHE_PATH,
+    DEFAULT_LOOKBACK_DAYS,
+    build_data_client,
+    cache_refresh_summary_token,
+    refresh_trade_performance_cache,
+)
+
+LOG = logging.getLogger("trade_performance_refresh")
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        level=logging.INFO,
+    )
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Refresh trade performance cache.")
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help="Lookback horizon for trade performance calculations (default: 400).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force cache rebuild even if the cache looks fresh.",
+    )
+    parser.add_argument(
+        "--base-dir",
+        default=None,
+        help="Override base directory (defaults to JBRAVO_HOME or repository root).",
+    )
+    parser.add_argument(
+        "--cache-path",
+        default=str(CACHE_PATH),
+        help="Path to write the trade performance cache.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    _configure_logging()
+    load_env()
+    args = parse_args(argv)
+    base_dir = Path(args.base_dir) if args.base_dir else BASE_DIR
+    cache_path = Path(args.cache_path) if args.cache_path else CACHE_PATH
+
+    data_client = build_data_client()
+    rc = 0
+    try:
+        df, summary = refresh_trade_performance_cache(
+            base_dir=base_dir,
+            data_client=data_client,
+            lookback_days=int(args.lookback_days),
+            force=bool(args.force),
+            cache_path=cache_path,
+        )
+        token = cache_refresh_summary_token(len(df.index), summary, rc)
+    except Exception:
+        LOG.exception("TRADE_PERFORMANCE_REFRESH_FAILED")
+        rc = 1
+        token = cache_refresh_summary_token(0, {}, rc)
+
+    print(token)
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_trade_performance.py
+++ b/tests/test_trade_performance.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+
+from scripts.trade_performance import (
+    compute_exit_quality_columns,
+    compute_trade_excursions,
+    load_trades_log,
+    summarize_by_window,
+)
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_load_trades_log_handles_missing(tmp_path):
+    df = load_trades_log(tmp_path)
+    assert df.empty
+
+
+def test_trade_excursions_and_exit_quality_bounds():
+    start = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    end = start + timedelta(days=2)
+    trades = pd.DataFrame(
+        [
+            {
+                "symbol": "ABC",
+                "entry_time": start,
+                "exit_time": end,
+                "qty": 10,
+                "entry_price": 10.0,
+                "exit_price": 12.0,
+                "pnl": 20.0,
+            }
+        ]
+    )
+
+    def fake_fetch(symbol, fetch_start, fetch_end, timeframe):
+        return pd.DataFrame(
+            {
+                "timestamp": [
+                    fetch_start + timedelta(hours=1),
+                    fetch_start + timedelta(hours=5),
+                    fetch_end - timedelta(hours=2),
+                ],
+                "high": [11.0, 13.0, 12.5],
+                "low": [9.5, 9.8, 10.2],
+                "close": [10.8, 12.8, 12.2],
+            }
+        )
+
+    excursions = compute_trade_excursions(trades, data_client=None, bar_fetcher=fake_fetch)
+    enriched = compute_exit_quality_columns(excursions)
+    for column in (
+        "mfe_pct",
+        "mae_pct",
+        "missed_profit_pct",
+        "exit_efficiency_pct",
+        "hold_days",
+    ):
+        assert column in enriched.columns
+    eff = enriched.loc[0, "exit_efficiency_pct"]
+    assert 0 <= eff <= 100
+
+
+def test_summarize_by_window_counts_recent_trades():
+    now = datetime.now(timezone.utc)
+    frame = pd.DataFrame(
+        [
+            {
+                "symbol": "XYZ",
+                "entry_time": now - timedelta(days=3),
+                "exit_time": now - timedelta(days=1),
+                "pnl": 15.0,
+                "return_pct": 5.0,
+                "hold_days": 2.0,
+                "exit_efficiency_pct": 80.0,
+                "missed_profit_pct": 4.0,
+                "mfe_pct": 6.0,
+                "mae_pct": -2.0,
+                "peak_price": 11.0,
+                "trough_price": 9.5,
+                "exit_price": 10.5,
+                "entry_price": 10.0,
+                "sold_too_soon": True,
+            }
+        ]
+    )
+    summary = summarize_by_window(frame)
+    assert {"7D", "30D", "365D", "ALL"}.issubset(summary.keys())
+    assert summary["7D"]["trades"] == 1
+    assert summary["7D"]["sold_too_soon"] == 1


### PR DESCRIPTION
## Summary
- add a trade_performance module to compute excursions, exit quality metrics, caching, and summaries for trades_log
- integrate a CLI refresh utility and pipeline hook so the trade performance cache is rebuilt automatically
- surface a new Trade Performance dashboard tab with KPIs, charts, and a sortable trades table, plus tests for the new computations

## Testing
- python -m pytest tests/test_trade_performance.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3b27a0748331914f0b6635327482)