### PR TITLE
Harden trade performance summary generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__/
 *.pyc
 .env
 trades.db
- pipeline.log
+pipeline.log
 assets_backup/
 
 # Ignore runtime data and logs
@@ -11,5 +11,10 @@ logs/*.log*
 data/open_positions.csv
 data/trades_log.csv
 data/trade_performance_cache.json
+data/trade_performance_cache.json.*
 data/*.json
 data/predictions/
+data/predictions/*
+.pytest_cache/
+.coverage
+htmlcov/

--- a/tests/test_trade_performance.py
+++ b/tests/test_trade_performance.py
@@ -93,7 +93,8 @@ def test_summarize_by_window_counts_recent_trades():
     assert summary["7D"]["trades"] == 1
     assert summary["7D"]["sold_too_soon"] == 1
     assert summary["7D"]["net_pnl"] == pytest.approx(15.0)
-    assert summary["7D"]["win_rate"] == pytest.approx(100.0)
+    assert summary["7D"]["win_rate"] == pytest.approx(1.0)
+    assert summary["7D"]["win_rate_pct"] == pytest.approx(100.0)
 
 
 def test_summary_always_includes_windows_and_numbers():
@@ -142,7 +143,7 @@ def test_summary_computes_pnl_and_win_rate_when_missing_column():
     summary = summarize_by_window(frame)
     window = summary["ALL"]
     assert window["net_pnl"] == pytest.approx((7 - 5) * 10 + (8 - 10) * 5)
-    assert window["win_rate"] == pytest.approx(50.0)
+    assert window["win_rate"] == pytest.approx(0.5)
 
 
 def test_refresh_best_effort_when_excursions_fail(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- normalize trade performance inputs and compute summaries directly from trades logs with reliable defaults
- keep excursion enrichment best-effort with backoff and cache schema stability while ignoring generated artifacts
- update trade performance tests to expect numeric win-rate/net P&L outputs

## Testing
- python -m pytest tests/test_trade_performance.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c567b4b488331b1367c1272fbd0a1)