### PR TITLE
Handle closed trade pairing with FIFO lot matching

### DIFF
--- a/tests/test_backfill_trades_log.py
+++ b/tests/test_backfill_trades_log.py
@@ -42,6 +42,7 @@ def test_build_trades_from_events_pairs_buys_and_sells(dummy_events):
     assert trade["exit_price"] == 110
     assert trade["net_pnl"] == 10
     assert trade["side"] == "buy"
+    assert trade["order_status"] == "closed"
 
 
 def test_merge_trades_deduplicates_on_key(dummy_events, tmp_path):
@@ -74,6 +75,54 @@ def test_gather_fill_events_falls_back_to_orders(monkeypatch, dummy_events, null
 
     assert events == dummy_events
     assert calls == {"activities": 1, "orders": 1}
+
+
+def test_build_trades_supports_multi_fill_entry_and_exit():
+    events = [
+        {"symbol": "AAPL", "side": "buy", "qty": 5, "price": 10, "timestamp": "2024-01-01T00:00:00Z"},
+        {"symbol": "AAPL", "side": "buy", "qty": 5, "price": 11, "timestamp": "2024-01-01T00:01:00Z"},
+        {"symbol": "AAPL", "side": "sell", "qty": 6, "price": 12, "timestamp": "2024-01-01T01:00:00Z", "order_type": "trailing_stop"},
+        {"symbol": "AAPL", "side": "sell", "qty": 4, "price": 13, "timestamp": "2024-01-01T01:30:00Z", "order_type": "limit"},
+    ]
+
+    trades = build_trades_from_events(events)
+
+    assert len(trades) == 2
+
+    first, second = trades
+    assert first["qty"] == 5
+    assert first["entry_price"] == 10
+    assert first["exit_price"] == 12
+    assert first["exit_time"] == "2024-01-01T01:00:00+00:00"
+    assert first["order_type"] == "trailing_stop"
+    assert first["exit_reason"] == "trailing_stop"
+
+    assert second["qty"] == 5
+    assert second["entry_price"] == 11
+    assert pytest.approx(second["exit_price"], rel=1e-6) == 12.8
+    assert second["exit_time"] == "2024-01-01T01:30:00+00:00"
+    assert all(trade["order_status"] == "closed" for trade in trades)
+    assert all(trade["entry_time"] for trade in trades)
+
+
+def test_partial_exit_accumulates_and_sets_exit_price():
+    events = [
+        {"symbol": "TSLA", "side": "buy", "qty": 10, "price": 20, "timestamp": "2024-02-01T00:00:00Z"},
+        {"symbol": "TSLA", "side": "sell", "qty": 4, "price": 21, "timestamp": "2024-02-01T01:00:00Z"},
+        {"symbol": "TSLA", "side": "sell", "qty": 6, "price": 22, "timestamp": "2024-02-01T02:00:00Z"},
+    ]
+
+    trades = build_trades_from_events(events)
+
+    assert len(trades) == 1
+    trade = trades[0]
+    assert trade["qty"] == 10
+    assert trade["entry_price"] == 20
+    assert pytest.approx(trade["exit_price"], rel=1e-6) == 21.6
+    assert trade["exit_time"] == "2024-02-01T02:00:00+00:00"
+    assert trade["order_status"] == "closed"
+    assert trade["exit_price"] != 0
+    assert trade["entry_time"] != ""
 
 
 def test_backfill_writes_atomic(tmp_path, monkeypatch, dummy_events):


### PR DESCRIPTION
## Summary
- implement FIFO buy-lot matching that accumulates sell fills into closed trade rows with VWAP entry/exit prices, UTC timestamps, and closed status
- ensure backfill output only contains fully-valued trades and preserve merge deduplication using entry/exit times plus quantity
- expand trade backfill tests to cover multi-fill entries/exits and partial exits while guarding against missing exit data

## Testing
- python -m pytest tests/test_backfill_trades_log.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6a9c70c48331b927f60f245994bd)