### PR TITLE
Fix order metadata and exit efficiency calculations

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -904,6 +904,7 @@ def _build_trade_perf_kpis(metrics: Mapping[str, Any]) -> list[Any]:
         _card("Win Rate", f"{win_rate:.1f}%", "warning"),
         _card("Avg Hold (days)", f"{hold_days:.2f}", "secondary"),
         _card("Exit Efficiency", f"{exit_eff:.1f}%", "success"),
+        _card("TrailingStop exits", f"{stop_exits}", "info"),
         _card("Trailing-Stop Rebound Rate (5D ≥3%)", rebound_value, "info"),
     ]
     return cards
@@ -3236,6 +3237,8 @@ def _prepare_trade_perf_frame(store_data: Mapping[str, Any], window: str) -> pd.
     for col in numeric_cols:
         if col in frame.columns:
             frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    if "exit_efficiency_pct" not in frame.columns:
+        frame["exit_efficiency_pct"] = np.nan
     if "rebounded" in frame.columns:
         frame["rebounded"] = frame["rebounded"].fillna(False)
     if "is_trailing_stop_exit" in frame.columns:

--- a/scripts/trade_performance.py
+++ b/scripts/trade_performance.py
@@ -447,11 +447,11 @@ def compute_exit_quality_columns(
         np.nan,
     )
 
-    valid_peak_mask = (peak_price.notna()) & (entry_price.notna()) & (peak_price > entry_price)
+    valid_peak_mask = (peak_price.notna()) & (peak_price > 0) & (exit_price.notna())
     exit_eff = np.where(
         valid_peak_mask,
         (exit_price / peak_price) * 100,
-        0.0,
+        np.nan,
     )
     frame["exit_efficiency_pct"] = np.clip(exit_eff, 0, 100)
     frame["missed_profit_pct"] = np.where(


### PR DESCRIPTION
## Summary
- capture Alpaca order status and type separately during backfills, preferring exit order types and marking trailing-stop exits
- compute daily-bar peaks to derive exit efficiency (with NaN when bars missing), and surface trailing-stop exit counts/exit efficiency in the dashboard cache and UI
- expand tests to cover trailing-stop backfills and cached exit efficiency calculations

## Testing
- python -m pytest tests/test_backfill_trades_log.py tests/test_trade_performance.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7072e7f08331a24726bbf768f5da)