### PR TITLE
Improve trade pairing, order types, and exit efficiency

### DIFF
--- a/scripts/trade_performance.py
+++ b/scripts/trade_performance.py
@@ -447,11 +447,16 @@ def compute_exit_quality_columns(
         np.nan,
     )
 
-    valid_peak_mask = (peak_price.notna()) & (peak_price > 0) & (exit_price.notna())
-    exit_eff = np.where(
+    valid_peak_mask = (peak_price.notna()) & (entry_price.notna()) & (exit_price.notna()) & (peak_price > entry_price)
+    exit_eff_raw = np.where(
         valid_peak_mask,
-        (exit_price / peak_price) * 100,
+        (exit_price - entry_price) / (peak_price - entry_price) * 100,
         np.nan,
+    )
+    exit_eff = np.where(
+        (peak_price.notna()) & (entry_price.notna()) & (exit_price.notna()) & (peak_price <= entry_price),
+        0.0,
+        exit_eff_raw,
     )
     frame["exit_efficiency_pct"] = np.clip(exit_eff, 0, 100)
     frame["missed_profit_pct"] = np.where(

--- a/tests/test_backfill_trades_log.py
+++ b/tests/test_backfill_trades_log.py
@@ -163,6 +163,27 @@ def test_trailing_stop_exit_sets_type_and_reason():
     assert trade["order_status"] == "filled"
 
 
+def test_order_type_uses_alpaca_type_not_status():
+    events = [
+        {"symbol": "AMD", "side": "buy", "qty": 1, "price": 50, "timestamp": "2024-04-01T00:00:00Z"},
+        {
+            "symbol": "AMD",
+            "side": "sell",
+            "qty": 1,
+            "price": 55,
+            "timestamp": "2024-04-01T01:00:00Z",
+            "order_type": "limit",
+            "order_status": "partial_fill",
+        },
+    ]
+
+    trades = build_trades_from_events(events)
+    assert len(trades) == 1
+    trade = trades[0]
+    assert trade["order_type"] == "limit"
+    assert trade["order_status"] == "partial_fill"
+
+
 def test_backfill_writes_atomic(tmp_path, monkeypatch, dummy_events):
     dest = tmp_path / "trades_log.csv"
 

--- a/tests/test_trade_performance.py
+++ b/tests/test_trade_performance.py
@@ -230,7 +230,7 @@ def test_refresh_populates_exit_efficiency_with_daily_peak(tmp_path):
         cache_path=cache_path,
         bar_fetcher=fake_fetch,
     )
-    expected_eff = (11.0 / 12.0) * 100
+    expected_eff = ((11.0 - 10.0) / (12.0 - 10.0)) * 100
     assert pytest.approx(df.loc[0, "peak_price"], rel=1e-6) == 12.0
     assert pytest.approx(df.loc[0, "exit_efficiency_pct"], rel=1e-6) == expected_eff
 
@@ -366,7 +366,7 @@ def test_exit_efficiency_nan_when_peak_missing_or_clamped():
     )
     enriched = compute_exit_quality_columns(trades)
     assert pd.isna(enriched.loc[0, "exit_efficiency_pct"])
-    assert enriched.loc[1, "exit_efficiency_pct"] == pytest.approx(100.0)
+    assert enriched.loc[1, "exit_efficiency_pct"] == pytest.approx(0.0)
 
 
 def test_rebound_columns_exist():


### PR DESCRIPTION
## Summary
- implement deterministic FIFO multi-fill lot pairing with VWAP prices and trailing-stop exit classification
- keep order_type aligned to Alpaca order type while tracking fill status separately in built trades
- compute exit_efficiency_pct from enriched peak prices and update trade performance cache plus tests

## Testing
- pytest tests/test_backfill_trades_log.py tests/test_trade_performance.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c749becec83319b3e0733fce54830)