### PR TITLE
Fix trade performance tab routing and pnl normalization

### DIFF
--- a/tests/test_dashboard_load_csv.py
+++ b/tests/test_dashboard_load_csv.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+
+from dashboards.dashboard_app import load_csv
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_load_csv_promotes_net_pnl_to_pnl(tmp_path):
+    csv_path = tmp_path / "trades_log.csv"
+    pd.DataFrame(
+        [
+            {
+                "symbol": "ABC",
+                "net_pnl": 5.0,
+                "entry_time": "2024-01-01T00:00:00Z",
+                "exit_time": "2024-01-02T00:00:00Z",
+            }
+        ]
+    ).to_csv(csv_path, index=False)
+
+    df, alert = load_csv(csv_path, required_columns=["pnl"])
+
+    assert alert is None
+    assert "pnl" in df.columns
+    assert "net_pnl" in df.columns
+    assert df.loc[0, "pnl"] == df.loc[0, "net_pnl"] == 5.0


### PR DESCRIPTION
## Summary
- normalize pnl/net_pnl handling in the dashboard CSV loader and add a regression test for net_pnl-only inputs
- make trade performance cache rendering resilient with friendlier empty-state messaging
- wire hash routing to tab selection so the Trade Performance tab can be opened directly via URL anchors

## Testing
- pytest tests/test_dashboard_load_csv.py tests/test_trade_performance.py::test_load_trades_log_handles_missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d7fa72b108331929b26679b7bc932)