### PR TITLE
Add Trade Performance tab content and layout test

### DIFF
--- a/tests/test_dashboard_tabs.py
+++ b/tests/test_dashboard_tabs.py
@@ -1,0 +1,13 @@
+from dashboards import dashboard_app
+
+
+import pytest
+
+
+@pytest.mark.alpaca_optional
+def test_trade_performance_tab_present():
+    tabs = dashboard_app.build_tabs()
+    tab_ids = [tab.tab_id for tab in tabs.children]
+    labels = [tab.label for tab in tabs.children]
+    assert "tab-trade-performance" in tab_ids
+    assert any(str(label).lower().strip() == "trade performance" for label in labels)


### PR DESCRIPTION
## Summary
- add reusable tabs builder so the Trade Performance nav is present in the v2 layout
- enhance the Trade Performance tab to read cached metrics first, surface windowed KPI cards, net P&L chart, and cap the trade table to recent rows with a clearer cache-missing message
- add a unit test that asserts the Trade Performance tab value/label exists

## Testing
- python -m pytest tests/test_dashboard_tabs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d87e0503c8331b3a19cd341970dbc)