### PR TITLE
Standardize sold-too IDs and tests

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -5,7 +5,7 @@ from dash import Dash, html, dash_table, dcc
 import dash_bootstrap_components as dbc
 from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
-from dash.dash_table import Format
+from dash.dash_table.Format import Format
 from datetime import datetime, timezone, timedelta
 import subprocess
 import json
@@ -1203,9 +1203,9 @@ def render_trade_performance_panel() -> html.Div:
                     dbc.CardHeader("Sold Too Soon (Flagged Trades)", className="fw-bold"),
                     dbc.CardBody(
                         [
-                            html.Div(id="sold-too-soon-summary", className="mb-2 d-flex flex-wrap gap-2"),
+                            html.Div(id="sold-too-summary-chips", className="mb-2 d-flex flex-wrap gap-2"),
                             dash_table.DataTable(
-                                id="sold-too-soon-table",
+                                id="sold-too-table",
                                 columns=sold_too_columns,
                                 data=[],
                                 sort_action="native",
@@ -3735,8 +3735,8 @@ def _format_chip(label: str, value: str | float) -> dbc.Badge:
 
 @app.callback(
     [
-        Output("sold-too-soon-table", "data"),
-        Output("sold-too-soon-summary", "children"),
+        Output("sold-too-table", "data"),
+        Output("sold-too-summary-chips", "children"),
     ],
     [
         Input("active-tab-store", "data"),

--- a/tests/test_trade_performance.py
+++ b/tests/test_trade_performance.py
@@ -1,8 +1,10 @@
+import json
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 import pytest
 
+from dashboards import dashboard_app
 from scripts.trade_performance import (
     cache_refresh_summary_token,
     read_cache,
@@ -31,6 +33,24 @@ def test_cache_refresh_summary_token_includes_counts():
     assert "lookback_days=400" in token
     assert "windows=7D,ALL" in token
     assert token.endswith("rc=0")
+
+
+def test_sold_too_layout_ids_are_kebab_case():
+    layout = dashboard_app.render_trade_performance_panel()
+
+    def _jsonify(node):
+        if hasattr(node, "to_plotly_json"):
+            return _jsonify(node.to_plotly_json())
+        if isinstance(node, dict):
+            return {key: _jsonify(value) for key, value in node.items()}
+        if isinstance(node, (list, tuple)):
+            return [_jsonify(item) for item in node]
+        return node
+
+    layout_json = json.dumps(_jsonify(layout))
+    assert "sold-too-mode" in layout_json
+    assert "sold-too-table" in layout_json
+    assert "soldtoo-mode" not in layout_json
 
 
 def test_trade_excursions_and_exit_quality_bounds():


### PR DESCRIPTION
## Summary
- update sold-too layout components to use consistent kebab-case IDs and align callback outputs
- import the dash table Format class directly to avoid runtime errors when building layouts
- add a regression test to ensure the trade performance layout JSON includes the standardized sold-too IDs and rejects legacy ones

## Testing
- python -m py_compile dashboards/dashboard_app.py
- pytest tests/test_trade_performance.py -k sold_too_layout_ids_are_kebab_case

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529ea6d57c83319f75a9bd9ad8a07c)