### PR TITLE
Add cash P&L per trade view to trade performance tab

### DIFF
--- a/tests/test_trade_performance.py
+++ b/tests/test_trade_performance.py
@@ -50,6 +50,8 @@ def test_sold_too_layout_ids_are_kebab_case():
     layout_json = json.dumps(_jsonify(layout))
     assert "sold-too-mode" in layout_json
     assert "sold-too-table" in layout_json
+    assert "trade-pnl-table" in layout_json
+    assert "trade-pnl-summary-chips" in layout_json
     assert "soldtoo-mode" not in layout_json
 
 


### PR DESCRIPTION
## Summary
- add a cash P&L per-trade table and summary chips to the Trade Performance tab
- compute per-trade cash metrics and windowed summaries from the trade performance cache, reusing the active range selector
- expand the trade performance range options and tests to cover the new elements

## Testing
- python -m pytest tests/test_trade_performance.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952bf914a4883318a5fd34abde6141d)