### PR TITLE
Add consistent bar coverage metrics to screener and pipeline

### DIFF
--- a/dashboards/utils.py
+++ b/dashboards/utils.py
@@ -434,7 +434,7 @@ def parse_pipeline_summary(path: Path) -> Dict[str, Any]:
         if "PIPELINE_SUMMARY" not in line:
             continue
         match = re.search(
-            r"symbols_in=(\d+)\s+with_bars=(\d+)\s+rows=(\d+)(?:[^\n\r]*?(?:\sbar_rows|\sbars_rows_total)=(\d+))?",
+            r"symbols_in=(\d+)\s+with_bars=(\d+)(?:\s+with_bars_any=(\d+))?(?:\s+with_bars_required=(\d+))?\s+rows=(\d+)(?:[^\n\r]*?(?:\sbar_rows|\sbars_rows_total)=(\d+))?",
             line,
         )
         if match:
@@ -442,10 +442,14 @@ def parse_pipeline_summary(path: Path) -> Dict[str, Any]:
                 "last_run_utc": None,
                 "symbols_in": int(match.group(1)),
                 "symbols_with_bars": int(match.group(2)),
-                "rows": int(match.group(3)),
+                "rows": int(match.group(5)),
             }
+            if match.group(3):
+                payload["symbols_with_any_bars"] = int(match.group(3))
             if match.group(4):
-                payload["bars_rows_total"] = int(match.group(4))
+                payload["symbols_with_required_bars"] = int(match.group(4))
+            if match.group(6):
+                payload["bars_rows_total"] = int(match.group(6))
             return payload
         break
     return {}
@@ -462,6 +466,8 @@ def coerce_kpi_types(metrics: Dict[str, Any]) -> Dict[str, Any]:
     int_fields = {
         "symbols_in": ("symbols_in",),
         "symbols_with_bars": ("symbols_with_bars", "with_bars"),
+        "symbols_with_any_bars": ("symbols_with_any_bars", "with_bars_any", "symbols_with_bars_any"),
+        "symbols_with_required_bars": ("symbols_with_required_bars", "with_bars_required"),
         "bars_rows_total": ("bars_rows_total",),
         "rows": ("rows", "rows_out"),
     }

--- a/tests/data/screener_metrics_bad.json
+++ b/tests/data/screener_metrics_bad.json
@@ -1,6 +1,8 @@
 {
   "symbols_in": 10,
   "symbols_with_bars": 20,
+  "symbols_with_any_bars": 20,
+  "symbols_with_required_bars": 20,
   "bars_rows_total": -1,
   "rows": -5
 }

--- a/tests/data/screener_metrics_ok.json
+++ b/tests/data/screener_metrics_ok.json
@@ -1,6 +1,8 @@
 {
   "symbols_in": 10,
   "symbols_with_bars": 8,
+  "symbols_with_any_bars": 8,
+  "symbols_with_required_bars": 8,
   "bars_rows_total": 200,
   "rows": 2,
   "symbols_with_bars_fetch": 8,

--- a/tests/test_bar_history_counts.py
+++ b/tests/test_bar_history_counts.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from scripts.screener import summarize_bar_history_counts, BARS_REQUIRED_FOR_INDICATORS
+
+
+def test_summarize_bar_history_counts_respects_threshold_and_any_count():
+    history = pd.DataFrame(
+        {
+            "symbol": ["A", "A", "B", "C", "C", "C", "D"],
+            "n": [BARS_REQUIRED_FOR_INDICATORS, 0, BARS_REQUIRED_FOR_INDICATORS + 10, 100, 100, 100, 1],
+        }
+    )
+
+    summary = summarize_bar_history_counts(history, required_bars=BARS_REQUIRED_FOR_INDICATORS)
+
+    assert summary["any"] == 4
+    assert summary["required"] == 3

--- a/tests/test_dashboard_consistency.py
+++ b/tests/test_dashboard_consistency.py
@@ -31,6 +31,8 @@ def test_dashboard_consistency_report_generation(tmp_path: Path) -> None:
                 "last_run_utc": "2024-01-01T09:05:00Z",
                 "symbols_in": 12,
                 "symbols_with_bars": 10,
+                "symbols_with_any_bars": 10,
+                "symbols_with_required_bars": 10,
                 "rows": 2,
                 "source": "screener",
                 "gate_fail_total": 1,

--- a/utils/screener_metrics.py
+++ b/utils/screener_metrics.py
@@ -37,9 +37,22 @@ def ensure_canonical_metrics(payload: Mapping[str, Any] | None) -> dict[str, Any
     metrics["timestamp"] = timestamp if isinstance(timestamp, str) and timestamp else now_iso
 
     metrics["rows_out"] = _coerce_int(metrics.get("rows_out") or metrics.get("rows", 0))
-    metrics["with_bars"] = _coerce_int(
-        metrics.get("with_bars") or metrics.get("symbols_with_bars", 0)
-    )
+    any_bars = metrics.get("symbols_with_any_bars")
+    required_bars = metrics.get("symbols_with_required_bars")
+    if required_bars is None:
+        required_bars = metrics.get("symbols_with_bars")
+    if any_bars is None:
+        any_bars = metrics.get("symbols_with_bars_any") or metrics.get("symbols_with_bars")
+
+    metrics["with_bars_required"] = _coerce_int(required_bars)
+    metrics["with_bars_any"] = _coerce_int(any_bars)
+    metrics["with_bars"] = metrics["with_bars_required"]
+    metrics["symbols_with_required_bars"] = metrics["with_bars_required"]
+    metrics["symbols_with_any_bars"] = metrics["with_bars_any"]
+    if "symbols_with_bars" not in metrics or metrics.get("symbols_with_bars") in (None, ""):
+        metrics["symbols_with_bars"] = metrics["with_bars_required"]
+    metrics.setdefault("symbols_with_bars_required", metrics["with_bars_required"])
+    metrics.setdefault("symbols_with_bars_any", metrics["with_bars_any"])
 
     universe_count = metrics.get("universe_count")
     if universe_count is None:


### PR DESCRIPTION
## Summary
- compute explicit "any" vs "required" bar coverage counts in the screener, propagate them into screener metrics, stage snapshots, and pipeline summary logs
- update dashboard health loaders and consistency checks to use the new counts for coverage and indicator-readiness without recomputing in the pipeline orchestrator
- add unit/integration tests for bar count summarization and pipeline metric ingestion, and refresh fixtures for the new fields

## Testing
- python -m pytest tests/test_bar_history_counts.py tests/test_pipeline_metrics_sync.py tests/test_dashboard_consistency_check.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d7e9da8083318ed2a777bb853e3f)