### PR TITLE
Harmonize screener metrics semantics and dashboard fallback

### DIFF
--- a/dashboards/data_io.py
+++ b/dashboards/data_io.py
@@ -285,9 +285,15 @@ def load_screener_metrics(base_dir: Optional[Path] = None) -> Dict[str, Any]:
     symbols_with_any_bars = _coerce_int(
         payload.get("symbols_with_any_bars") or payload.get("symbols_with_bars_any")
     )
-    symbols_with_bars_fetch = _coerce_int(
-        payload.get("symbols_with_bars_fetch")
-    ) or _coerce_int(payload.get("symbols_with_required_bars")) or _coerce_int(payload.get("symbols_with_bars"))
+    symbols_with_bars_fetch = _coerce_int(payload.get("symbols_with_bars_fetch"))
+    symbols_attempted_fetch = _coerce_int(payload.get("symbols_attempted_fetch"))
+    if symbols_with_any_bars is not None:
+        symbols_with_bars_fetch = symbols_with_any_bars
+    elif symbols_with_bars_fetch is None:
+        symbols_with_bars_fetch = _coerce_int(payload.get("symbols_with_required_bars")) or _coerce_int(
+            payload.get("symbols_with_bars")
+        )
+    attempted_fetch = symbols_attempted_fetch or symbols_with_bars_fetch
     symbols_with_required_bars = _coerce_int(
         payload.get("symbols_with_required_bars")
     ) or symbols_with_bars_fetch
@@ -313,6 +319,7 @@ def load_screener_metrics(base_dir: Optional[Path] = None) -> Dict[str, Any]:
         "last_run_utc": payload.get("last_run_utc") or payload.get("last_run"),
         "symbols_in": _coerce_int(payload.get("symbols_in")),
         "symbols_with_bars_fetch": symbols_with_bars_fetch,
+        "symbols_attempted_fetch": attempted_fetch,
         "symbols_with_any_bars": symbols_with_any_bars,
         "symbols_with_required_bars": symbols_with_required_bars,
         "symbols_with_bars_post": _coerce_int(payload.get("symbols_with_bars_post")),

--- a/tests/test_dashboard_consistency_check.py
+++ b/tests/test_dashboard_consistency_check.py
@@ -79,3 +79,22 @@ def test_dashboard_consistency_detects_missing_metrics(
     assert findings_path.exists()
     report_json = json.loads((reports_dir / "dashboard_consistency.json").read_text())
     assert report_json["inputs"]["screener_metrics"]["present"] is False
+
+
+def test_dashboard_consistency_allows_fetch_superset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_alert(monkeypatch)
+    _build_test_layout(tmp_path)
+    data_dir = tmp_path / "data"
+    metrics = {
+        "symbols_in": 57,
+        "symbols_with_required_bars": 57,
+        "symbols_with_any_bars": 100,
+        "symbols_with_bars_fetch": 419,
+        "bars_rows_total_fetch": 1000,
+        "rows": 2,
+    }
+    (data_dir / "screener_metrics.json").write_text(json.dumps(metrics), encoding="utf-8")
+
+    errors = checker.run_assertions(tmp_path)
+
+    assert errors == []

--- a/tests/test_screener_metrics_versioning.py
+++ b/tests/test_screener_metrics_versioning.py
@@ -1,0 +1,39 @@
+import pytest
+from utils.screener_metrics import ensure_canonical_metrics
+
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_legacy_fetch_counts_are_mapped_to_attempted() -> None:
+    payload = {
+        "symbols_in": 57,
+        "symbols_with_any_bars": 57,
+        "symbols_with_required_bars": 57,
+        "symbols_with_bars_fetch": 419,
+        "rows": 2,
+    }
+
+    canonical = ensure_canonical_metrics(payload)
+
+    assert canonical["symbols_attempted_fetch"] == 419
+    assert canonical["symbols_with_any_bars"] == 57
+    assert canonical["with_bars"] == 57
+    assert canonical["metrics_version"] == 2
+
+
+def test_required_bars_and_with_bars_are_canonicalised() -> None:
+    payload = {
+        "symbols_in": 10,
+        "symbols_with_bars": 8,
+        "rows": 1,
+        "required_bars": 250,
+    }
+
+    canonical = ensure_canonical_metrics(payload)
+
+    assert canonical["symbols_with_required_bars"] == 8
+    assert canonical["with_bars_required"] == 8
+    assert canonical["with_bars"] == 8
+    assert canonical["required_bars"] == 250
+    assert canonical["metrics_version"] == 2


### PR DESCRIPTION
## Summary
- Canonicalized screener metrics to emit required bar counts, symbols_attempted_fetch, and metrics_version 2 while keeping legacy aliases consistent.
- Updated screener outputs and pipeline summary to source counts from canonical screener_metrics, aligning dashboard/KPI semantics and mapping fetch coverage to Screener Health.
- Relaxed dashboard fallback checks to focus on empty candidate outputs and added regression tests for legacy mapping and dashboard consistency.

## Testing
- pytest tests/test_screener_metrics_versioning.py tests/test_dashboard_consistency_check.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952dc5738388331bc5315664f114366)