### PR TITLE
Add optional sentiment scoring with caching support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ data/trade_performance_cache.json.*
 data/*.json
 data/predictions/
 data/predictions/*
+data/cache/
 .pytest_cache/
 .coverage
 htmlcov/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Pipeline options worth knowing:
 
 The Bollinger-band squeeze component now applies a shape-safe mask so the ranking pass no longer crashes with NumPy shape mismatch errors.
 
+### Sentiment enrichment (optional)
+
+Enable `USE_SENTIMENT=true` to append per-symbol sentiment to screener outputs. The screener reads `SENTIMENT_API_URL` (required) and `SENTIMENT_API_KEY` (optional) for the JSON HTTP provider, using `SENTIMENT_TIMEOUT_SECS` (default `8`) for requests. Scores are cached at `data/cache/sentiment/YYYY-MM-DD.json` so repeated runs only fetch missing symbols for the day. Adjust impact with `SENTIMENT_WEIGHT` (default `0.0`) and optionally gate out strongly negative values with `MIN_SENTIMENT` (default `-999`, which disables gating). When enabled the screener records `sentiment_enabled`, `sentiment_missing_count`, and `sentiment_avg` in `data/screener_metrics.json`.
+
 ### Screener pipeline modes
 
 `scripts/screener.py` now exposes dedicated modes that break the nightly run

--- a/tests/test_sentiment_feature.py
+++ b/tests/test_sentiment_feature.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts import screener
+from utils.features.sentiment import JsonHttpSentimentProvider, load_sentiment_cache, persist_sentiment_cache
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_sentiment_cache_roundtrip(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "data" / "cache" / "sentiment"
+    run_date = datetime(2024, 1, 2, tzinfo=timezone.utc).date()
+
+    persist_sentiment_cache(cache_dir, run_date, {"AAPL": 0.4, "tsla": -0.2, "skip": float("nan")})
+    cached = load_sentiment_cache(cache_dir, run_date)
+
+    assert cached == {"AAPL": 0.4, "TSLA": -0.2}
+
+
+def test_json_provider_fail_soft() -> None:
+    class FailingSession:
+        def get(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    provider = JsonHttpSentimentProvider("http://sentiment.test", session=FailingSession())
+    result = provider.get_symbol_sentiment("AAPL", datetime(2024, 1, 1, tzinfo=timezone.utc))
+
+    assert result is None
+
+
+def test_apply_sentiment_scores_injects_breakdown_and_gates(tmp_path: Path) -> None:
+    run_ts = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    cache_dir = tmp_path / "data" / "cache" / "sentiment"
+    persist_sentiment_cache(cache_dir, run_ts.date(), {"AAA": -0.5, "BBB": 0.3})
+
+    frame = pd.DataFrame(
+        {
+            "symbol": ["AAA", "BBB"],
+            "Score": [1.0, 2.0],
+            "score_breakdown": ["{}", "{}"],
+        }
+    )
+    settings = {"enabled": True, "weight": 1.0, "min": -0.1}
+
+    updated, summary = screener._apply_sentiment_scores(
+        frame,
+        run_ts=run_ts,
+        settings=settings,
+        cache_dir=cache_dir,
+        provider_factory=lambda *_: None,
+    )
+
+    assert summary["sentiment_gated"] == 1
+    assert summary["sentiment_missing_count"] == 0
+    assert summary["sentiment_avg"] == pytest.approx(0.3)
+    assert updated["Score"].tolist() == pytest.approx([2.3])
+    breakdown = json.loads(updated["score_breakdown"].iat[0])
+    assert breakdown["sentiment"] == pytest.approx(0.3)
+
+    candidates_df = updated.assign(
+        close=10.0,
+        volume=1_000_000.0,
+        adv20=2_000_000.0,
+        atrp=0.05,
+        timestamp=pd.Timestamp(run_ts),
+        entry_price=10.0,
+        universe_count=2,
+    )
+    top_df = screener._prepare_top_frame(candidates_df, top_n=1)
+    assert "sentiment" not in top_df.columns
+    assert len(top_df.columns) == len(screener.TOP_CANDIDATE_COLUMNS)
+
+
+def test_sentiment_missing_does_not_gate(tmp_path: Path) -> None:
+    run_ts = datetime(2024, 4, 1, tzinfo=timezone.utc)
+    frame = pd.DataFrame({"symbol": ["ZZZ"], "Score": [1.5], "score_breakdown": ["{}"]})
+    settings = {"enabled": True, "weight": 2.0, "min": 0.5}
+
+    updated, summary = screener._apply_sentiment_scores(
+        frame,
+        run_ts=run_ts,
+        settings=settings,
+        cache_dir=tmp_path / "data" / "cache" / "sentiment",
+        provider_factory=lambda *_: None,
+    )
+
+    assert summary["sentiment_gated"] == 0
+    assert summary["sentiment_missing_count"] == 1
+    assert updated.shape[0] == 1
+    breakdown = json.loads(updated["score_breakdown"].iat[0])
+    assert breakdown.get("sentiment") is None
+    assert updated["Score"].iat[0] == pytest.approx(1.5)

--- a/utils/features/__init__.py
+++ b/utils/features/__init__.py
@@ -1,0 +1,3 @@
+"""Feature-level helpers for optional data sources."""
+
+__all__ = []

--- a/utils/features/sentiment.py
+++ b/utils/features/sentiment.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from pathlib import Path
+from typing import Mapping, Optional, Protocol
+
+import requests
+
+from utils.io_utils import atomic_write_bytes
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SentimentProvider(Protocol):
+    """Interface for loading per-symbol sentiment scores."""
+
+    def get_symbol_sentiment(self, symbol: str, asof_utc: datetime) -> Optional[float]:
+        """Return the sentiment score for ``symbol`` at ``asof_utc`` or ``None`` on error."""
+        raise NotImplementedError
+
+
+def _coerce_sentiment_value(value: object) -> Optional[float]:
+    try:
+        score = float(value)
+    except Exception:
+        return None
+    if not (-1.0 <= score <= 1.0):
+        score = max(min(score, 1.0), -1.0)
+    if score != score:  # NaN check
+        return None
+    return score
+
+
+class JsonHttpSentimentProvider:
+    """HTTP provider that fetches per-symbol sentiment from a JSON endpoint."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+        session: requests.sessions.Session | None = None,
+    ) -> None:
+        self.base_url = base_url
+        self.api_key = api_key
+        self.timeout = timeout if timeout and timeout > 0 else 8.0
+        self.session = session or requests.Session()
+        self._logged_error = False
+
+    def _log_once(self, message: str, *args: object) -> None:
+        if self._logged_error:
+            return
+        try:
+            LOGGER.warning(message, *args)
+        except Exception:
+            LOGGER.warning(message)
+        self._logged_error = True
+
+    def get_symbol_sentiment(self, symbol: str, asof_utc: datetime) -> Optional[float]:
+        params = {
+            "symbol": (symbol or "").strip().upper(),
+            "date": asof_utc.date().isoformat(),
+        }
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+            headers["X-API-Key"] = self.api_key
+        try:
+            response = self.session.get(
+                self.base_url,
+                params=params,
+                headers=headers,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except Exception as exc:
+            self._log_once("Sentiment fetch failed: %s", exc)
+            return None
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            self._log_once("Invalid sentiment payload: %s", exc)
+            return None
+
+        if not isinstance(payload, Mapping):
+            self._log_once("Unexpected sentiment response type: %s", type(payload))
+            return None
+
+        raw = payload.get("sentiment", payload.get("score"))
+        score = _coerce_sentiment_value(raw)
+        if score is None:
+            self._log_once("Sentiment response missing/invalid for %s", params["symbol"])
+            return None
+        return score
+
+
+def load_sentiment_cache(cache_dir: Path, run_date: date) -> dict[str, float]:
+    """Load cached sentiments from ``cache_dir/<date>.json``."""
+
+    cache_path = Path(cache_dir) / f"{run_date.isoformat()}.json"
+    if not cache_path.exists():
+        return {}
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception:
+        LOGGER.warning("Failed to read sentiment cache %s", cache_path)
+        return {}
+
+    cache: dict[str, float] = {}
+    if isinstance(data, Mapping):
+        for sym, value in data.items():
+            score = _coerce_sentiment_value(value)
+            if score is None:
+                continue
+            cache[str(sym).upper()] = score
+    return cache
+
+
+def persist_sentiment_cache(cache_dir: Path, run_date: date, cache: Mapping[str, float]) -> Path:
+    """Persist sentiment cache to ``cache_dir/<date>.json``."""
+
+    path = Path(cache_dir) / f"{run_date.isoformat()}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cleaned: dict[str, float] = {}
+    for sym, value in cache.items():
+        score = _coerce_sentiment_value(value)
+        if score is None:
+            continue
+        cleaned[str(sym).upper()] = score
+    serialized = json.dumps(cleaned, indent=2, sort_keys=True).encode("utf-8")
+    atomic_write_bytes(path, serialized)
+    return path
+
+
+__all__ = [
+    "JsonHttpSentimentProvider",
+    "SentimentProvider",
+    "load_sentiment_cache",
+    "persist_sentiment_cache",
+]


### PR DESCRIPTION
## Summary
- add a reusable sentiment provider with HTTP fail-soft handling and daily JSON cache helpers
- integrate optional sentiment weighting and gating into the screener pipeline, including score_breakdown injection, predictions output, and metrics fields
- document the new sentiment environment variables and add regression tests for caching, provider failures, and top-candidate safety

## Testing
- pytest tests/test_sentiment_feature.py tests/test_screener_predictions.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ede082848331b60258c0ddbfa1df)