### PR TITLE
Add sentiment client support and stream pipeline logs

### DIFF
--- a/tests/test_sentiment_feature.py
+++ b/tests/test_sentiment_feature.py
@@ -1,35 +1,71 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 import json
 from pathlib import Path
 
 import pandas as pd
 import pytest
+import requests
 
 from scripts import screener
-from utils.features.sentiment import JsonHttpSentimentProvider, load_sentiment_cache, persist_sentiment_cache
+from utils.sentiment import JsonHttpSentimentClient, load_sentiment_cache, persist_sentiment_cache
 
 pytestmark = pytest.mark.alpaca_optional
 
 
 def test_sentiment_cache_roundtrip(tmp_path: Path) -> None:
     cache_dir = tmp_path / "data" / "cache" / "sentiment"
-    run_date = datetime(2024, 1, 2, tzinfo=timezone.utc).date()
+    run_date = date(2024, 1, 2)
 
-    persist_sentiment_cache(cache_dir, run_date, {"AAPL": 0.4, "tsla": -0.2, "skip": float("nan")})
+    persist_sentiment_cache(cache_dir, run_date, {"AAPL": 0.4, "tsla": -1.5, "skip": float("nan")})
     cached = load_sentiment_cache(cache_dir, run_date)
 
-    assert cached == {"AAPL": 0.4, "TSLA": -0.2}
+    assert cached == {"AAPL": 0.4, "TSLA": -1.0}
 
 
-def test_json_provider_fail_soft() -> None:
-    class FailingSession:
-        def get(self, *args, **kwargs):
-            raise RuntimeError("boom")
+def test_json_client_enabled_and_clamps(tmp_path: Path) -> None:
+    class StubResponse:
+        def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+            self._payload = payload
+            self.status_code = status_code
 
-    provider = JsonHttpSentimentProvider("http://sentiment.test", session=FailingSession())
-    result = provider.get_symbol_sentiment("AAPL", datetime(2024, 1, 1, tzinfo=timezone.utc))
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise requests.HTTPError(self.status_code)
 
-    assert result is None
+        def json(self):
+            return self._payload
+
+    class RecordingSession:
+        def __init__(self, payload: dict[str, object]):
+            self.calls: list[tuple[str, dict[str, object], dict[str, str]]] = []
+            self.payload = payload
+
+        def get(self, url, params=None, headers=None, timeout=None):
+            self.calls.append((url, params or {}, headers or {}))
+            return StubResponse(self.payload)
+
+    env = {
+        "USE_SENTIMENT": "true",
+        "SENTIMENT_API_URL": "http://sentiment.test/api",
+        "SENTIMENT_API_KEY": "token-123",
+    }
+    session = RecordingSession({"sentiment": 4})
+    client = JsonHttpSentimentClient(env=env, session=session)
+
+    assert client.enabled() is True
+    score = client.get_score("tsla", "2024-02-03")
+
+    assert score == 1.0
+    assert session.calls, "expected outbound request to sentiment endpoint"
+    url, params, headers = session.calls[0]
+    assert url == env["SENTIMENT_API_URL"]
+    assert params == {"symbol": "TSLA", "date": "2024-02-03"}
+    assert headers["Authorization"].endswith(env["SENTIMENT_API_KEY"])
+    assert headers["X-API-Key"] == env["SENTIMENT_API_KEY"]
+
+    disabled_client = JsonHttpSentimentClient(env={"USE_SENTIMENT": "false"})
+    assert disabled_client.enabled() is False
+    assert disabled_client.get_score("AAPL", "2024-02-03") is None
 
 
 def test_apply_sentiment_scores_injects_breakdown_and_gates(tmp_path: Path) -> None:
@@ -51,7 +87,7 @@ def test_apply_sentiment_scores_injects_breakdown_and_gates(tmp_path: Path) -> N
         run_ts=run_ts,
         settings=settings,
         cache_dir=cache_dir,
-        provider_factory=lambda *_: None,
+        client_factory=lambda *_: None,
     )
 
     assert summary["sentiment_gated"] == 1
@@ -60,6 +96,8 @@ def test_apply_sentiment_scores_injects_breakdown_and_gates(tmp_path: Path) -> N
     assert updated["Score"].tolist() == pytest.approx([2.3])
     breakdown = json.loads(updated["score_breakdown"].iat[0])
     assert breakdown["sentiment"] == pytest.approx(0.3)
+    assert breakdown["sentiment_weight"] == pytest.approx(1.0)
+    assert breakdown["min_sentiment"] == pytest.approx(-0.1)
 
     candidates_df = updated.assign(
         close=10.0,
@@ -85,7 +123,7 @@ def test_sentiment_missing_does_not_gate(tmp_path: Path) -> None:
         run_ts=run_ts,
         settings=settings,
         cache_dir=tmp_path / "data" / "cache" / "sentiment",
-        provider_factory=lambda *_: None,
+        client_factory=lambda *_: None,
     )
 
     assert summary["sentiment_gated"] == 0
@@ -93,4 +131,56 @@ def test_sentiment_missing_does_not_gate(tmp_path: Path) -> None:
     assert updated.shape[0] == 1
     breakdown = json.loads(updated["score_breakdown"].iat[0])
     assert breakdown.get("sentiment") is None
+    assert breakdown["sentiment_weight"] == pytest.approx(2.0)
+    assert breakdown["min_sentiment"] == pytest.approx(0.5)
     assert updated["Score"].iat[0] == pytest.approx(1.5)
+
+
+def test_screener_metrics_include_sentiment_keys(tmp_path: Path) -> None:
+    base_dir = tmp_path / "enabled"
+    base_dir.mkdir()
+    top_df = pd.DataFrame(columns=screener.TOP_CANDIDATE_COLUMNS)
+    scored_df = pd.DataFrame({"symbol": ["AAPL"], "sentiment": [0.2], "Score": [1.0]})
+    stats_common = {
+        "candidates_out": 0,
+        "shortlist_requested": 0,
+        "shortlist_candidates": 0,
+        "coarse_ranked": 0,
+        "shortlist_path": "",
+        "backtest_target": 0,
+        "backtest_evaluated": 0,
+        "backtest_lookback": 0,
+        "backtest_expectancy_mean": 0.0,
+        "backtest_win_rate_mean": 0.0,
+    }
+    skip_reasons = {key: 0 for key in screener.SKIP_KEYS}
+
+    stats_enabled = {
+        **stats_common,
+        "sentiment_enabled": True,
+        "sentiment_missing_count": 0,
+        "sentiment_avg": 0.2,
+        "sentiment_gated": 0,
+    }
+    screener.write_outputs(base_dir, top_df, scored_df, stats_enabled, skip_reasons)
+    metrics_path = base_dir / "data" / "screener_metrics.json"
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["sentiment_enabled"] is True
+    assert metrics["sentiment_missing_count"] == 0
+    assert metrics["sentiment_avg"] == pytest.approx(0.2)
+    assert metrics["metrics_version"] == 2
+
+    disabled_dir = tmp_path / "disabled"
+    disabled_stats = {
+        **stats_common,
+        "sentiment_enabled": False,
+        "sentiment_missing_count": 5,
+        "sentiment_avg": None,
+        "sentiment_gated": 0,
+    }
+    screener.write_outputs(disabled_dir, top_df, scored_df, disabled_stats, skip_reasons)
+    disabled_metrics = json.loads((disabled_dir / "data" / "screener_metrics.json").read_text(encoding="utf-8"))
+    assert disabled_metrics["sentiment_enabled"] is False
+    assert disabled_metrics["sentiment_missing_count"] == 0
+    assert disabled_metrics["sentiment_avg"] is None
+    assert disabled_metrics["metrics_version"] == 2

--- a/utils/sentiment.py
+++ b/utils/sentiment.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from datetime import date
+from pathlib import Path
+from typing import Mapping, Optional
+
+import requests
+
+from utils.io_utils import atomic_write_bytes
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_CACHE_DIR = Path("data") / "cache" / "sentiment"
+
+
+def _as_bool(value: object, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _clamp_score(value: object) -> Optional[float]:
+    try:
+        score = float(value)
+    except Exception:
+        return None
+    if math.isnan(score):
+        return None
+    if score < -1.0:
+        score = -1.0
+    elif score > 1.0:
+        score = 1.0
+    return score
+
+
+class JsonHttpSentimentClient:
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        timeout: float | None = None,
+        env: Mapping[str, object] | None = None,
+        session: requests.sessions.Session | None = None,
+    ) -> None:
+        self._env = env or os.environ
+        self.base_url = base_url
+        self.api_key = api_key
+        self.timeout = timeout
+        self.session = session or requests.Session()
+
+    def _config(self) -> dict[str, object]:
+        env = self._env
+        url_env = (env.get("SENTIMENT_API_URL") or "") if isinstance(env, Mapping) else ""
+        key_env = env.get("SENTIMENT_API_KEY") if isinstance(env, Mapping) else None
+        timeout_env = env.get("SENTIMENT_TIMEOUT_SECS") if isinstance(env, Mapping) else None
+        use_flag = env.get("USE_SENTIMENT") if isinstance(env, Mapping) else False
+        timeout_val = self.timeout if self.timeout not in (None, "", 0) else timeout_env
+        try:
+            timeout = float(timeout_val) if timeout_val not in (None, "") else 8.0
+        except Exception:
+            timeout = 8.0
+        if timeout <= 0:
+            timeout = 8.0
+        return {
+            "use_sentiment": _as_bool(use_flag, False),
+            "url": (self.base_url or str(url_env or "")).strip(),
+            "api_key": self.api_key if self.api_key not in (None, "") else key_env,
+            "timeout": float(timeout),
+        }
+
+    def enabled(self) -> bool:
+        cfg = self._config()
+        return bool(cfg["use_sentiment"] and cfg["url"])
+
+    def get_score(self, symbol: str, date_utc: str) -> Optional[float]:
+        cfg = self._config()
+        if not (cfg["use_sentiment"] and cfg["url"]):
+            return None
+
+        params = {
+            "symbol": (symbol or "").strip().upper(),
+            "date": str(date_utc).split("T", 1)[0],
+        }
+        headers: dict[str, str] = {}
+        api_key = cfg.get("api_key")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+            headers["X-API-Key"] = str(api_key)
+
+        try:
+            response = self.session.get(
+                str(cfg["url"]),
+                params=params,
+                headers=headers,
+                timeout=float(cfg.get("timeout", 8.0)),
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception:
+            return None
+
+        if not isinstance(payload, Mapping):
+            return None
+
+        raw = payload.get("sentiment", payload.get("score"))
+        return _clamp_score(raw)
+
+
+def load_sentiment_cache(cache_dir: Path | str = DEFAULT_CACHE_DIR, run_date: date | str = None) -> dict[str, float]:
+    if run_date is None:
+        return {}
+    cache_path = Path(cache_dir) / f"{date.fromisoformat(str(run_date)).isoformat()}.json"
+    if not cache_path.exists():
+        return {}
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception:
+        LOGGER.warning("Failed to read sentiment cache %s", cache_path)
+        return {}
+
+    cache: dict[str, float] = {}
+    if isinstance(data, Mapping):
+        for sym, value in data.items():
+            score = _clamp_score(value)
+            if score is None:
+                continue
+            cache[str(sym).upper()] = score
+    return cache
+
+
+def persist_sentiment_cache(
+    cache_dir: Path | str = DEFAULT_CACHE_DIR, run_date: date | str = None, cache: Mapping[str, float] | None = None
+) -> Path:
+    if run_date is None:
+        raise ValueError("run_date is required to persist the sentiment cache")
+    run_dt = date.fromisoformat(str(run_date))
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cleaned: dict[str, float] = {}
+    for sym, value in (cache or {}).items():
+        score = _clamp_score(value)
+        if score is None:
+            continue
+        cleaned[str(sym).upper()] = score
+
+    serialized = json.dumps(cleaned, indent=2, sort_keys=True).encode("utf-8")
+    target = cache_dir / f"{run_dt.isoformat()}.json"
+    atomic_write_bytes(target, serialized)
+    return target
+
+
+__all__ = [
+    "JsonHttpSentimentClient",
+    "DEFAULT_CACHE_DIR",
+    "load_sentiment_cache",
+    "persist_sentiment_cache",
+]


### PR DESCRIPTION
## Summary
- add a JsonHttpSentimentClient with file-based caching and hook the screener into the new sentiment settings/logging/score breakdowns
- ensure sentiment metrics and scored outputs include the new sentiment fields while keeping latest candidates headers stable
- stream run_pipeline step output to log files with heartbeats to avoid deadlocks and cover the change with tests

## Testing
- pytest tests/test_sentiment_feature.py tests/test_run_pipeline.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953030163208331a1ed8d99762148f1)