### PR TITLE
Add non-fatal Postgres dual writes for pipeline

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -19,6 +19,7 @@ import json
 import numpy as np
 import pandas as pd
 
+from scripts import db
 from utils import logger_utils
 from utils.env import load_env, get_alpaca_creds
 
@@ -919,6 +920,10 @@ def run_backtest(
         write_csv_atomic(trades_path, trades_df)
         write_csv_atomic(equity_path, equity_df.reset_index())
         write_csv_atomic(metrics_path, summary_df)
+        try:
+            db.insert_backtest_results(datetime.now(timezone.utc).date(), summary_df)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.warning("[WARN] DB_WRITE_FAILED table=backtest_results err=%s", exc)
         logger.info(f"Trades log successfully updated with net_pnl at {trades_path}.")
 
     except Exception as e:
@@ -1019,4 +1024,3 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/db.py
+++ b/scripts/db.py
@@ -1,7 +1,10 @@
+import json
 import logging
 import os
-from typing import Optional
+from datetime import date, datetime
+from typing import Any, Mapping, Optional
 
+import pandas as pd
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
@@ -48,3 +51,303 @@ def safe_connect_test() -> bool:
         return False
 
     return True
+
+
+def _engine_or_none() -> Optional[Engine]:
+    if not db_enabled():
+        return None
+    return get_engine()
+
+
+def _coerce_date(run_date: Any) -> str:
+    if isinstance(run_date, datetime):
+        return run_date.date().isoformat()
+    if isinstance(run_date, date):
+        return run_date.isoformat()
+    try:
+        return date.fromisoformat(str(run_date)).isoformat()
+    except Exception:
+        return str(run_date)
+
+
+def _coerce_json(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {"raw": value}
+        return parsed
+    if isinstance(value, (Mapping, list)):
+        return value
+    return value
+
+
+def _json_dumps_or_none(payload: Any) -> Optional[str]:
+    if payload is None:
+        return None
+    try:
+        return json.dumps(payload)
+    except Exception:
+        try:
+            return json.dumps({"raw": str(payload)})
+        except Exception:
+            return None
+
+
+def _log_write_result(ok: bool, table: str, rows: int, err: Exception | None = None) -> None:
+    if ok:
+        logger.info("[INFO] DB_WRITE_OK table=%s rows=%s", table, rows)
+    else:
+        logger.warning("[WARN] DB_WRITE_FAILED table=%s err=%s", table, err)
+
+
+def upsert_pipeline_run(
+    run_date: Any,
+    started_at: datetime | None,
+    ended_at: datetime | None,
+    rc: int,
+    summary_dict: Mapping[str, Any] | None,
+) -> None:
+    engine = _engine_or_none()
+    if engine is None:
+        return
+
+    payload = {
+        "run_date": _coerce_date(run_date),
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "rc": int(rc),
+        "summary": _json_dumps_or_none(summary_dict or {}),
+    }
+    stmt = text(
+        """
+        INSERT INTO pipeline_runs (run_date, started_at, ended_at, rc, summary)
+        VALUES (:run_date, :started_at, :ended_at, :rc, CAST(:summary AS JSONB))
+        ON CONFLICT (run_date) DO UPDATE
+        SET started_at=EXCLUDED.started_at,
+            ended_at=EXCLUDED.ended_at,
+            rc=EXCLUDED.rc,
+            summary=EXCLUDED.summary
+        """
+    )
+    try:
+        with engine.begin() as connection:
+            connection.execute(stmt, payload)
+        _log_write_result(True, "pipeline_runs", 1)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        _log_write_result(False, "pipeline_runs", 0, exc)
+
+
+def insert_screener_candidates(run_date: Any, df_candidates: pd.DataFrame | None) -> None:
+    if df_candidates is None or df_candidates.empty:
+        return
+    engine = _engine_or_none()
+    if engine is None:
+        return
+
+    normalized = df_candidates.copy()
+    columns = {
+        "timestamp": None,
+        "symbol": None,
+        "score": None,
+        "exchange": None,
+        "close": None,
+        "volume": None,
+        "universe_count": None,
+        "score_breakdown": None,
+        "entry_price": None,
+        "adv20": None,
+        "atrp": None,
+        "source": None,
+    }
+    rows: list[dict[str, Any]] = []
+    for _, row in normalized.iterrows():
+        record = {}
+        for key in columns:
+            record[key] = row.get(key) if isinstance(row, Mapping) else row[key] if key in row else None
+        payload = {
+            "run_date": _coerce_date(run_date),
+            "timestamp": record.get("timestamp"),
+            "symbol": (record.get("symbol") or "").upper(),
+            "score": record.get("score"),
+            "exchange": record.get("exchange"),
+            "close": record.get("close"),
+            "volume": record.get("volume"),
+            "universe_count": record.get("universe_count"),
+            "score_breakdown": _json_dumps_or_none(_coerce_json(record.get("score_breakdown"))),
+            "entry_price": record.get("entry_price"),
+            "adv20": record.get("adv20"),
+            "atrp": record.get("atrp"),
+            "source": record.get("source"),
+        }
+        rows.append(payload)
+
+    stmt = text(
+        """
+        INSERT INTO screener_candidates (
+            run_date, timestamp, symbol, score, exchange, close, volume,
+            universe_count, score_breakdown, entry_price, adv20, atrp, source
+        )
+        VALUES (
+            :run_date, :timestamp, :symbol, :score, :exchange, :close, :volume,
+            :universe_count, CAST(:score_breakdown AS JSONB), :entry_price, :adv20, :atrp, :source
+        )
+        ON CONFLICT (run_date, symbol) DO UPDATE SET
+            timestamp=EXCLUDED.timestamp,
+            score=EXCLUDED.score,
+            exchange=EXCLUDED.exchange,
+            close=EXCLUDED.close,
+            volume=EXCLUDED.volume,
+            universe_count=EXCLUDED.universe_count,
+            score_breakdown=EXCLUDED.score_breakdown,
+            entry_price=EXCLUDED.entry_price,
+            adv20=EXCLUDED.adv20,
+            atrp=EXCLUDED.atrp,
+            source=EXCLUDED.source
+        """
+    )
+    try:
+        with engine.begin() as connection:
+            connection.execute(stmt, rows)
+        _log_write_result(True, "screener_candidates", len(rows))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        _log_write_result(False, "screener_candidates", 0, exc)
+
+
+def insert_backtest_results(run_date: Any, df_results: pd.DataFrame | None) -> None:
+    if df_results is None or df_results.empty:
+        return
+    engine = _engine_or_none()
+    if engine is None:
+        return
+
+    rows: list[dict[str, Any]] = []
+    for _, row in df_results.iterrows():
+        payload = {
+            "run_date": _coerce_date(run_date),
+            "symbol": (row.get("symbol") or "").upper(),
+            "trades": row.get("trades"),
+            "win_rate": row.get("win_rate"),
+            "net_pnl": row.get("net_pnl"),
+            "expectancy": row.get("expectancy"),
+            "profit_factor": row.get("profit_factor"),
+            "max_drawdown": row.get("max_drawdown"),
+            "sharpe": row.get("sharpe"),
+            "sortino": row.get("sortino"),
+        }
+        rows.append(payload)
+
+    stmt = text(
+        """
+        INSERT INTO backtest_results (
+            run_date, symbol, trades, win_rate, net_pnl, expectancy,
+            profit_factor, max_drawdown, sharpe, sortino
+        )
+        VALUES (
+            :run_date, :symbol, :trades, :win_rate, :net_pnl, :expectancy,
+            :profit_factor, :max_drawdown, :sharpe, :sortino
+        )
+        ON CONFLICT (run_date, symbol) DO UPDATE SET
+            trades=EXCLUDED.trades,
+            win_rate=EXCLUDED.win_rate,
+            net_pnl=EXCLUDED.net_pnl,
+            expectancy=EXCLUDED.expectancy,
+            profit_factor=EXCLUDED.profit_factor,
+            max_drawdown=EXCLUDED.max_drawdown,
+            sharpe=EXCLUDED.sharpe,
+            sortino=EXCLUDED.sortino
+        """
+    )
+    try:
+        with engine.begin() as connection:
+            connection.execute(stmt, rows)
+        _log_write_result(True, "backtest_results", len(rows))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        _log_write_result(False, "backtest_results", 0, exc)
+
+
+def upsert_metrics_daily(run_date: Any, summary_metrics_dict: Mapping[str, Any] | None) -> None:
+    if not summary_metrics_dict:
+        return
+    engine = _engine_or_none()
+    if engine is None:
+        return
+
+    payload = {
+        "run_date": _coerce_date(run_date),
+        "total_trades": summary_metrics_dict.get("total_trades"),
+        "win_rate": summary_metrics_dict.get("win_rate"),
+        "net_pnl": summary_metrics_dict.get("net_pnl"),
+        "expectancy": summary_metrics_dict.get("expectancy"),
+        "profit_factor": summary_metrics_dict.get("profit_factor"),
+        "max_drawdown": summary_metrics_dict.get("max_drawdown"),
+        "sharpe": summary_metrics_dict.get("sharpe"),
+        "sortino": summary_metrics_dict.get("sortino"),
+    }
+    stmt = text(
+        """
+        INSERT INTO metrics_daily (
+            run_date, total_trades, win_rate, net_pnl, expectancy,
+            profit_factor, max_drawdown, sharpe, sortino
+        )
+        VALUES (
+            :run_date, :total_trades, :win_rate, :net_pnl, :expectancy,
+            :profit_factor, :max_drawdown, :sharpe, :sortino
+        )
+        ON CONFLICT (run_date) DO UPDATE SET
+            total_trades=EXCLUDED.total_trades,
+            win_rate=EXCLUDED.win_rate,
+            net_pnl=EXCLUDED.net_pnl,
+            expectancy=EXCLUDED.expectancy,
+            profit_factor=EXCLUDED.profit_factor,
+            max_drawdown=EXCLUDED.max_drawdown,
+            sharpe=EXCLUDED.sharpe,
+            sortino=EXCLUDED.sortino
+        """
+    )
+    try:
+        with engine.begin() as connection:
+            connection.execute(stmt, payload)
+        _log_write_result(True, "metrics_daily", 1)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        _log_write_result(False, "metrics_daily", 0, exc)
+
+
+def insert_executed_trade(row_dict: Mapping[str, Any] | None) -> None:
+    if not row_dict:
+        return
+    engine = _engine_or_none()
+    if engine is None:
+        return
+
+    payload = {
+        "symbol": (row_dict.get("symbol") or "").upper(),
+        "qty": row_dict.get("qty"),
+        "entry_time": row_dict.get("entry_time"),
+        "entry_price": row_dict.get("entry_price"),
+        "exit_time": row_dict.get("exit_time"),
+        "exit_price": row_dict.get("exit_price"),
+        "pnl": row_dict.get("pnl"),
+        "net_pnl": row_dict.get("net_pnl"),
+        "order_id": row_dict.get("order_id"),
+        "status": row_dict.get("order_status") or row_dict.get("status"),
+        "raw": _json_dumps_or_none(row_dict),
+    }
+    stmt = text(
+        """
+        INSERT INTO executed_trades (
+            symbol, qty, entry_time, entry_price, exit_time, exit_price,
+            pnl, net_pnl, order_id, status, raw
+        )
+        VALUES (
+            :symbol, :qty, :entry_time, :entry_price, :exit_time, :exit_price,
+            :pnl, :net_pnl, :order_id, :status, CAST(:raw AS JSONB)
+        )
+        """
+    )
+    try:
+        with engine.begin() as connection:
+            connection.execute(stmt, payload)
+        _log_write_result(True, "executed_trades", 1)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        _log_write_result(False, "executed_trades", 0, exc)

--- a/scripts/db_migrate.py
+++ b/scripts/db_migrate.py
@@ -22,6 +22,7 @@ TABLE_STATEMENTS = [
     """
     CREATE TABLE IF NOT EXISTS screener_candidates (
         run_date DATE NOT NULL,
+        timestamp TIMESTAMPTZ,
         symbol TEXT NOT NULL,
         score NUMERIC,
         exchange TEXT,

--- a/scripts/execute_trades.py
+++ b/scripts/execute_trades.py
@@ -26,6 +26,7 @@ NY = ZoneInfo("America/New_York")
 import pandas as pd
 import requests
 
+from scripts import db
 from scripts.fallback_candidates import CANONICAL_COLUMNS, normalize_candidate_df
 from scripts.utils.env import load_env
 from utils import atomic_write_bytes, write_csv_atomic
@@ -408,6 +409,10 @@ def record_executed_trade(
             symbol,
             EXECUTED_TRADES_PATH,
         )
+    try:
+        db.insert_executed_trade(row)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        LOGGER.warning("[WARN] DB_WRITE_FAILED table=executed_trades err=%s", exc)
 
 
 

--- a/tests/test_db_dual_write_noop.py
+++ b/tests/test_db_dual_write_noop.py
@@ -1,0 +1,77 @@
+from datetime import date, datetime, timezone
+
+import pandas as pd
+import pytest
+
+from scripts import db
+
+
+@pytest.mark.alpaca_optional
+def test_dual_write_noop_without_database(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    assert db.db_enabled() is False
+
+    today = date(2024, 1, 1)
+    candidates = pd.DataFrame(
+        [
+            {
+                "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+                "symbol": "ABC",
+                "score": 1.23,
+                "exchange": "NASDAQ",
+                "close": 10.5,
+                "volume": 1_000,
+                "universe_count": 200,
+                "score_breakdown": '{"factor": 1}',
+                "entry_price": 10.0,
+                "adv20": 2_000,
+                "atrp": 0.02,
+                "source": "screener",
+            }
+        ]
+    )
+    backtest_results = pd.DataFrame(
+        [
+            {
+                "symbol": "ABC",
+                "trades": 5,
+                "win_rate": 60.0,
+                "net_pnl": 12.5,
+                "expectancy": 2.5,
+                "profit_factor": 1.4,
+                "max_drawdown": -0.03,
+                "sharpe": 1.1,
+                "sortino": 1.5,
+            }
+        ]
+    )
+    metrics_summary = {
+        "total_trades": 5,
+        "net_pnl": 12.5,
+        "win_rate": 60.0,
+        "expectancy": 2.5,
+        "profit_factor": 1.4,
+        "max_drawdown": -0.03,
+        "sharpe": 1.1,
+        "sortino": 1.5,
+    }
+
+    db.upsert_pipeline_run(today, datetime.now(timezone.utc), datetime.now(timezone.utc), 0, {"rows": 1})
+    db.insert_screener_candidates(today, candidates)
+    db.insert_backtest_results(today, backtest_results)
+    db.upsert_metrics_daily(today, metrics_summary)
+    db.insert_executed_trade(
+        {
+            "symbol": "ABC",
+            "qty": 10,
+            "entry_time": datetime.now(timezone.utc).isoformat(),
+            "entry_price": 10.0,
+            "exit_time": None,
+            "exit_price": None,
+            "pnl": 0.0,
+            "net_pnl": 0.0,
+            "order_id": "test-1",
+            "order_status": "filled",
+            "side": "buy",
+        }
+    )


### PR DESCRIPTION
## Summary
- add SQLAlchemy helper methods for dual-writing pipeline, screener, backtest, metrics, and executor data into Postgres while keeping CSV artifacts authoritative
- wire nightly scripts to call the Postgres writers after CSV outputs and log warnings on failures; extend migration schema for screener timestamps
- add a safety test to ensure scripts no-op cleanly when DATABASE_URL is missing

## Testing
- pytest tests/test_db_dual_write_noop.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540b8952488331960c52673fabb53e)