### PR TITLE
Normalize score breakdown JSON serialization

### DIFF
--- a/tests/test_db_score_breakdown.py
+++ b/tests/test_db_score_breakdown.py
@@ -1,0 +1,30 @@
+import json
+import logging
+
+import pytest
+
+from scripts.db import normalize_score_breakdown
+
+pytestmark = pytest.mark.alpaca_optional
+
+
+def test_normalize_score_breakdown_accepts_dict():
+    payload = {"factor": 1, "reasons": ["alpha", "beta"]}
+
+    serialized = normalize_score_breakdown(payload, symbol="abc")
+
+    assert json.loads(serialized) == payload
+
+
+def test_normalize_score_breakdown_raw_string_wrapped():
+    serialized = normalize_score_breakdown("not-json", symbol="abc")
+
+    assert json.loads(serialized) == {"raw": "not-json"}
+
+
+def test_normalize_score_breakdown_logs_and_returns_none_on_failure(caplog):
+    with caplog.at_level(logging.WARNING):
+        serialized = normalize_score_breakdown({"bad": {1, 2}}, symbol="abc")
+
+    assert serialized is None
+    assert any("SCORE_BREAKDOWN_JSON_FAIL" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add score_breakdown normalization to serialize dict/list/string inputs and log failures without blocking inserts
- reuse the normalization during pipeline artifact ingestion so invalid rows are nulled instead of aborting
- add tests covering normalization of JSON payloads and logging on serialization failures

## Testing
- python -m pytest tests/test_db_score_breakdown.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541d5ba61c8331b34a80d11892680c)