### PR TITLE
Normalize executed trade timestamps

### DIFF
--- a/tests/test_db_normalize_ts.py
+++ b/tests/test_db_normalize_ts.py
@@ -1,0 +1,87 @@
+import logging
+from datetime import date, datetime, timezone
+
+import pytest
+
+from scripts import db
+
+
+def test_normalize_ts_parses_and_attaches_timezone():
+    parsed = db.normalize_ts("2024-05-01T12:34:56", field="entry_time")
+    assert parsed == datetime(2024, 5, 1, 12, 34, 56, tzinfo=timezone.utc)
+
+
+def test_normalize_ts_handles_dates_and_naive_datetimes():
+    naive = datetime(2024, 5, 1, 12, 0, 0)
+    normalized = db.normalize_ts(naive, field="exit_time")
+    assert normalized.tzinfo == timezone.utc
+    as_date = db.normalize_ts(date(2024, 5, 1), field="exit_time")
+    assert as_date == datetime(2024, 5, 1, tzinfo=timezone.utc)
+
+
+def test_insert_executed_trade_normalizes_and_logs(monkeypatch, caplog):
+    executed: list[dict] = []
+
+    class DummyConnection:
+        def __init__(self, bucket: list[dict]):
+            self.bucket = bucket
+
+        def execute(self, stmt, payload):
+            self.bucket.append(payload)
+
+    class DummyBegin:
+        def __init__(self, bucket: list[dict]):
+            self.bucket = bucket
+
+        def __enter__(self):
+            return DummyConnection(self.bucket)
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyEngine:
+        def __init__(self, bucket: list[dict]):
+            self.bucket = bucket
+
+        def begin(self):
+            return DummyBegin(self.bucket)
+
+    monkeypatch.setattr(db, "_engine_or_none", lambda: DummyEngine(executed))
+
+    caplog.set_level(logging.INFO)
+    db.insert_executed_trade(
+        {
+            "symbol": "xyz",
+            "qty": 1,
+            "entry_time": "2024-05-01T12:00:00",
+            "entry_price": 1.0,
+            "exit_time": "bad-ts",
+            "exit_price": 2.0,
+            "pnl": 1.0,
+            "net_pnl": 1.0,
+            "order_id": "1",
+            "status": "filled",
+        }
+    )
+
+    assert len(executed) == 1
+    payload = executed[0]
+    assert payload["symbol"] == "XYZ"
+    assert isinstance(payload["entry_time"], datetime)
+    assert payload["entry_time"].tzinfo == timezone.utc
+    assert payload["exit_time"] is None
+
+    warning = next(
+        (record for record in caplog.records if "EXECUTED_TRADES_TS_PARSE_FAIL" in record.message),
+        None,
+    )
+    assert warning is not None
+    info = next(
+        (
+            record
+            for record in caplog.records
+            if "DB_WRITE_OK table=executed_trades symbol=XYZ" in record.message
+        ),
+        None,
+    )
+    assert info is not None


### PR DESCRIPTION
## Summary
- add a normalize_ts helper to parse executed trade timestamps and ensure they are timezone-aware
- normalize entry/exit timestamps during executed_trades ingestion with logging for parse failures and successful writes
- cover normalization and ingestion logging with new unit tests

## Testing
- pytest tests/test_db_normalize_ts.py tests/test_db_dual_write_noop.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542c2115e4833181b0710e24e61a85)