### PR TITLE
Log trade submit events and poll timeout

### DIFF
--- a/tests/test_db_normalize_ts.py
+++ b/tests/test_db_normalize_ts.py
@@ -80,7 +80,7 @@ def test_insert_executed_trade_normalizes_and_logs(monkeypatch, caplog):
         (
             record
             for record in caplog.records
-            if "DB_WRITE_OK table=executed_trades symbol=XYZ" in record.message
+            if "DB_WRITE_OK table=executed_trades" in record.message
         ),
         None,
     )


### PR DESCRIPTION
## Summary
- log executed_trades rows for buy submissions, fills, and trailing stops with event metadata
- add database logging helper and richer executed_trades payloads
- introduce configurable max poll timeout to stop long-running order checks

## Testing
- python -m pytest tests/test_db_normalize_ts.py tests/test_db_dual_write_noop.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542f1f6f708331bc819c2284eb74ed)