### PR TITLE
Decorate closed trades with latest sell fills

### DIFF
--- a/tests/test_reconcile_trades.py
+++ b/tests/test_reconcile_trades.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -11,7 +11,7 @@ from scripts.execute_trades import ExecutionMetrics, ExecutorConfig, TradeExecut
 def test_reconcile_closes_open_trades(monkeypatch):
     fake_engine = object()
     closed_calls: list[dict] = []
-    update_calls: list[dict] = []
+    decorate_calls: list[dict] = []
     event_calls: list[dict] = []
 
     monkeypatch.setattr(db, "db_enabled", lambda: True)
@@ -43,13 +43,27 @@ def test_reconcile_closes_open_trades(monkeypatch):
         event_calls.append(kwargs)
         return True
 
-    def fake_update_trade_exit_fields(engine, trade_id, **kwargs):
-        update_calls.append({"trade_id": trade_id, **kwargs})
+    def fake_get_closed_trades_missing_exit(engine, updated_after, limit=200):
+        return [
+            {
+                "trade_id": open_trade["trade_id"],
+                "symbol": open_trade["symbol"],
+                "qty": open_trade["qty"],
+                "entry_price": open_trade["entry_price"],
+                "exit_price": None,
+                "exit_order_id": None,
+                "realized_pnl": None,
+            }
+        ]
+
+    def fake_decorate_trade_exit(engine, trade_id, **kwargs):
+        decorate_calls.append({"trade_id": trade_id, **kwargs})
         return True
 
     monkeypatch.setattr(db, "close_trade", fake_close_trade)
     monkeypatch.setattr(db, "insert_order_event", fake_insert_order_event)
-    monkeypatch.setattr(db, "update_trade_exit_fields", fake_update_trade_exit_fields)
+    monkeypatch.setattr(db, "get_closed_trades_missing_exit", fake_get_closed_trades_missing_exit)
+    monkeypatch.setattr(db, "decorate_trade_exit", fake_decorate_trade_exit)
 
     filled_order = SimpleNamespace(
         id="sell-1",
@@ -58,7 +72,7 @@ def test_reconcile_closes_open_trades(monkeypatch):
         status="filled",
         filled_qty=5,
         filled_avg_price="11.25",
-        filled_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        filled_at=datetime.now(timezone.utc) - timedelta(minutes=5),
         type="trailing_stop",
         order_class="trailing_stop",
     )
@@ -84,5 +98,75 @@ def test_reconcile_closes_open_trades(monkeypatch):
     assert closed_calls[0]["exit_order_id"] is None
     assert closed_calls[0]["exit_reason"] == "POSITION_CLOSED"
     assert closed_calls[0]["exit_price"] is None
-    assert any(call.get("exit_order_id") == "sell-1" and call.get("exit_reason") == "TRAIL_STOP" for call in update_calls)
+    assert any(call.get("exit_order_id") == "sell-1" and call.get("exit_reason") == "TRAIL_STOP" for call in decorate_calls)
+    assert any(call.get("event_type") == "SELL_FILL" for call in event_calls)
+
+
+@pytest.mark.alpaca_optional
+def test_reconcile_decorates_without_open_trades(monkeypatch):
+    fake_engine = object()
+    event_calls: list[dict] = []
+    decorate_calls: list[dict] = []
+
+    monkeypatch.setattr(db, "db_enabled", lambda: True)
+    monkeypatch.setattr(db, "get_engine", lambda: fake_engine)
+    monkeypatch.setattr(db, "get_open_trades", lambda engine, limit=200: [])
+    monkeypatch.setattr(db, "close_trade", lambda *_, **__: pytest.fail("close_trade should not be called"))
+
+    missing_trade = {
+        "trade_id": 2,
+        "symbol": "TSLA",
+        "qty": 1,
+        "entry_price": 100.0,
+        "exit_price": None,
+        "exit_order_id": None,
+        "realized_pnl": None,
+    }
+
+    monkeypatch.setattr(
+        db,
+        "get_closed_trades_missing_exit",
+        lambda engine, updated_after, limit=200: [missing_trade],
+    )
+
+    def fake_insert_order_event(**kwargs):
+        event_calls.append(kwargs)
+        return True
+
+    def fake_decorate_trade_exit(engine, trade_id, **kwargs):
+        decorate_calls.append({"trade_id": trade_id, **kwargs})
+        return True
+
+    monkeypatch.setattr(db, "insert_order_event", fake_insert_order_event)
+    monkeypatch.setattr(db, "decorate_trade_exit", fake_decorate_trade_exit)
+
+    filled_order = SimpleNamespace(
+        id="sell-2",
+        symbol="TSLA",
+        side="sell",
+        status="filled",
+        filled_qty=1,
+        filled_avg_price="105.50",
+        filled_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+        type="market",
+        order_class="simple",
+    )
+
+    class FakeClient:
+        def __init__(self, orders):
+            self.orders = orders
+
+        def get_orders(self, request):
+            self.request = request
+            return self.orders
+
+    client = FakeClient([filled_order])
+    config = ExecutorConfig(reconcile_lookback_days=2)
+    executor = TradeExecutor(config, client, ExecutionMetrics())
+
+    executor.reconcile_closed_trades()
+
+    assert len(decorate_calls) == 1
+    assert decorate_calls[0]["exit_order_id"] == "sell-2"
+    assert decorate_calls[0]["exit_price"] == 105.50
     assert any(call.get("event_type") == "SELL_FILL" for call in event_calls)


### PR DESCRIPTION
## Summary
- add helpers to fetch closed trades missing exit details and decorate them with sell fills
- update reconcile_closed_trades to look back for filled sell orders and patch CLOSED trades with exit fields and realized PnL
- cover decoration logic for trades closed by position and when no open trades remain

## Testing
- pytest tests/test_reconcile_trades.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695445b423ac8331aa400733bb6332e6)