### PR TITLE
Improve reconcile decoration for filled sells

### DIFF
--- a/tests/test_reconcile_trades.py
+++ b/tests/test_reconcile_trades.py
@@ -81,7 +81,7 @@ def test_reconcile_closes_open_trades(monkeypatch):
         def __init__(self, orders):
             self.orders = orders
 
-        def get_orders(self, request):
+        def get_orders(self, **request):
             self.request = request
             return self.orders
 
@@ -156,7 +156,7 @@ def test_reconcile_decorates_without_open_trades(monkeypatch):
         def __init__(self, orders):
             self.orders = orders
 
-        def get_orders(self, request):
+        def get_orders(self, **request):
             self.request = request
             return self.orders
 


### PR DESCRIPTION
## Summary
- fetch Alpaca orders with status=all and perform Python-side filtering to select the latest filled sell for decoration
- log detailed reconcile decoration misses and update exit metadata/pnl from filled order timestamps
- update reconcile tests to align with the new order retrieval signature

## Testing
- pytest tests/test_reconcile_trades.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544ad80b5c8331bac04d3a0339545f)