### PR TITLE
Document PostgreSQL source of truth

### DIFF
--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -1,3 +1,13 @@
+"""
+DEPRECATED
+
+weekly_summary.py is no longer used.
+All reporting/metrics are derived from PostgreSQL tables:
+- trades
+- order_events
+- metrics_daily
+"""
+
 # weekly_summary.py - Generate weekly trade summary from CSVs and logs
 
 import os


### PR DESCRIPTION
## Summary
- document PostgreSQL as the authoritative source for analytics and clarify CSV parachute policy in the runbook
- add a deprecation note for scripts/weekly_summary.py and direct reporting to PostgreSQL tables
- include an example SQL snippet for weekly metrics rollups

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69555d05b36483319108a56108998504)