### PR TITLE
Fix account tab table format usage

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -5,7 +5,7 @@ from dash import Dash, html, dash_table, dcc
 import dash_bootstrap_components as dbc
 from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
-from dash.dash_table import Format
+from dash.dash_table.Format import Format, Scheme
 from datetime import datetime, timezone, timedelta
 import subprocess
 import json
@@ -807,13 +807,17 @@ def _account_drawdown_fig(df: pd.DataFrame) -> dcc.Graph:
 
 
 def _account_table(df: pd.DataFrame) -> dash_table.DataTable:
+    required = {"taken_at", "equity", "cash", "buying_power", "status"}
+    if df is None or df.empty or not required.issubset(df.columns):
+        return dbc.Alert("No recent account snapshots to display.", color="info", className="mb-3")
+
     display_df = df.copy()
     display_df["taken_at"] = display_df["taken_at"].dt.strftime("%Y-%m-%d %H:%M:%S")
     columns = [
         {"name": "Taken At (UTC)", "id": "taken_at"},
-        {"name": "Equity", "id": "equity", "type": "numeric", "format": Format(precision=2, scheme=Format.Scheme.fixed)},
-        {"name": "Cash", "id": "cash", "type": "numeric", "format": Format(precision=2, scheme=Format.Scheme.fixed)},
-        {"name": "Buying Power", "id": "buying_power", "type": "numeric", "format": Format(precision=2, scheme=Format.Scheme.fixed)},
+        {"name": "Equity", "id": "equity", "type": "numeric", "format": Format(precision=2, scheme=Scheme.fixed)},
+        {"name": "Cash", "id": "cash", "type": "numeric", "format": Format(precision=2, scheme=Scheme.fixed)},
+        {"name": "Buying Power", "id": "buying_power", "type": "numeric", "format": Format(precision=2, scheme=Scheme.fixed)},
         {"name": "Status", "id": "status"},
     ]
     return dash_table.DataTable(
@@ -1444,23 +1448,23 @@ def render_trade_performance_panel() -> html.Div:
         {"name": "Symbol", "id": "symbol"},
         {"name": "Entry Time", "id": "entry_time"},
         {"name": "Exit Time", "id": "exit_time"},
-        {"name": "Qty", "id": "qty", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Entry Price", "id": "entry_price", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Exit Price", "id": "exit_price", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "Qty", "id": "qty", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Entry Price", "id": "entry_price", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Exit Price", "id": "exit_price", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format(precision=2, scheme="f")},
         {"name": "Exit Reason", "id": "exit_reason"},
-        {"name": "MFE %", "id": "mfe_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "MAE %", "id": "mae_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Peak Price", "id": "peak_price", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Trough Price", "id": "trough_price", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Missed Profit %", "id": "missed_profit_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Exit Efficiency %", "id": "exit_efficiency_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "MFE %", "id": "mfe_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "MAE %", "id": "mae_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Peak Price", "id": "peak_price", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Trough Price", "id": "trough_price", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Missed Profit %", "id": "missed_profit_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Exit Efficiency %", "id": "exit_efficiency_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
         {"name": "Trailing Stop Exit", "id": "is_trailing_stop_exit"},
-        {"name": "Rebound Window (days)", "id": "rebound_window_days", "type": "numeric", "format": Format.Format(precision=0, scheme="f")},
-        {"name": "Post-exit High", "id": "post_exit_high", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Rebound %", "id": "rebound_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "Rebound Window (days)", "id": "rebound_window_days", "type": "numeric", "format": Format(precision=0, scheme="f")},
+        {"name": "Post-exit High", "id": "post_exit_high", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Rebound %", "id": "rebound_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
         {"name": "Rebounded", "id": "rebounded"},
     ]
 
@@ -1468,14 +1472,14 @@ def render_trade_performance_panel() -> html.Div:
         {"name": "Exit Time", "id": "exit_time"},
         {"name": "Symbol", "id": "symbol"},
         {"name": "Side", "id": "side"},
-        {"name": "Qty", "id": "qty", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Entry Price", "id": "entry_price", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Exit Price", "id": "exit_price", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Entry Value", "id": "entry_value", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Exit Value", "id": "exit_value", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "Qty", "id": "qty", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Entry Price", "id": "entry_price", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Exit Price", "id": "exit_price", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Entry Value", "id": "entry_value", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Exit Value", "id": "exit_value", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format(precision=2, scheme="f")},
         {"name": "Order Type", "id": "order_type"},
         {"name": "Exit Reason", "id": "exit_reason"},
     ]
@@ -1485,25 +1489,25 @@ def render_trade_performance_panel() -> html.Div:
         {"name": "Exit Time", "id": "exit_time"},
         {"name": "Symbol", "id": "symbol"},
         {"name": "Order Type", "id": "order_type"},
-        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Exit Efficiency %", "id": "exit_efficiency_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Missed Profit %", "id": "missed_profit_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Rebound %", "id": "rebound_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Exit Efficiency %", "id": "exit_efficiency_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Missed Profit %", "id": "missed_profit_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Rebound %", "id": "rebound_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
         {"name": "Rebounded", "id": "rebounded"},
-        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format(precision=2, scheme="f")},
     ]
     sold_too_columns = [
         {"name": "Exit Time", "id": "exit_time"},
         {"name": "Symbol", "id": "symbol"},
         {"name": "Order Type", "id": "order_type"},
-        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Exit Efficiency %", "id": "exit_efficiency_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Missed Profit %", "id": "missed_profit_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "Rebound %", "id": "rebound_pct", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Exit Efficiency %", "id": "exit_efficiency_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Missed Profit %", "id": "missed_profit_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "Rebound %", "id": "rebound_pct", "type": "numeric", "format": Format(precision=2, scheme="f")},
         {"name": "Rebounded", "id": "rebounded"},
-        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
-        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format.Format(precision=2, scheme="f")},
+        {"name": "Hold Days", "id": "hold_days", "type": "numeric", "format": Format(precision=2, scheme="f")},
+        {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format(precision=2, scheme="f")},
     ]
 
     return html.Div(
@@ -3385,7 +3389,7 @@ def _render_tab(tab, n_intervals, n_log_intervals, refresh_clicks):
                                 "name": "Avg Exit Efficiency",
                                 "id": "avg_exit_efficiency",
                                 "type": "numeric",
-                                "format": Format.Format(precision=2, scheme=Format.Scheme.percentage),
+                                "format": Format(precision=2, scheme=Scheme.percentage),
                             },
                         ],
                         style_table={"overflowX": "auto"},
@@ -3435,8 +3439,7 @@ def _render_tab(tab, n_intervals, n_log_intervals, refresh_clicks):
                 col_def: dict[str, Any] = {"name": col.replace("_", " ").title(), "id": col}
                 if col in {"exit_efficiency", "exit_pct", "mfe_pct"}:
                     col_def["type"] = "numeric"
-                    col_def["format"] = Format.Format(precision=2, scheme=Format.Scheme.percentage
-                    )
+                    col_def["format"] = Format(precision=2, scheme=Scheme.percentage)
                 column_defs.append(col_def)
 
             table = dash_table.DataTable(


### PR DESCRIPTION
## Summary
- correct Dash DataTable format import to use the Format and Scheme classes
- update account table formatting to prevent crashes when rendering recent snapshots
- add a guard to show a friendly empty state when recent snapshot data is unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69559a3379388331805c027ec55c2d29)