### PR TITLE
Fix activity views ordering and filters

### DIFF
--- a/scripts/sql/activity_views.sql
+++ b/scripts/sql/activity_views.sql
@@ -1,21 +1,24 @@
 CREATE OR REPLACE VIEW v_activities_recent AS
 SELECT *
 FROM alpaca_activities
-ORDER BY transaction_time DESC NULLS LAST, id DESC
+ORDER BY (transaction_time IS NULL), transaction_time DESC, activity_pk DESC
 LIMIT 200;
 
 CREATE OR REPLACE VIEW v_fills_recent AS
 SELECT *
 FROM alpaca_activities
 WHERE activity_type ILIKE '%FILL%'
-ORDER BY transaction_time DESC NULLS LAST, id DESC
+ORDER BY (transaction_time IS NULL), transaction_time DESC, activity_pk DESC
 LIMIT 200;
 
 CREATE OR REPLACE VIEW v_cash_activity_recent AS
 SELECT *
 FROM alpaca_activities
-WHERE activity_type ILIKE '%FEE%'
-   OR activity_type ILIKE '%DIV%'
-   OR activity_type ILIKE '%TRANS%'
-ORDER BY transaction_time DESC NULLS LAST, id DESC
+WHERE activity_type NOT ILIKE '%FILL%'
+  AND (
+    activity_type ILIKE '%FEE%'
+    OR activity_type ILIKE '%DIV%'
+    OR activity_type ILIKE '%TRANS%'
+  )
+ORDER BY (transaction_time IS NULL), transaction_time DESC, activity_pk DESC
 LIMIT 200;


### PR DESCRIPTION
## Summary
- update activity views to order by transaction_time with activity_pk fallback and remove id references
- adjust cash activity view to exclude fills while focusing on fee/dividend/transfer activity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ad1b41888331b7028d601bf56573)