### PR TITLE
Fix indentation for symbol performance tab

### DIFF
--- a/dashboards/dashboard_app.py
+++ b/dashboards/dashboard_app.py
@@ -4059,11 +4059,11 @@ def _render_tab(tab, n_intervals, n_log_intervals, refresh_clicks):
                 className="m-2",
             )
 
-    app.logger.info(
-        "Loaded %d trades for symbol performance from %s",
-        len(trades_df),
-        symbol_source_path,
-    )
+        app.logger.info(
+            "Loaded %d trades for symbol performance from %s",
+            len(trades_df),
+            symbol_source_path,
+        )
 
         grouped = trades_df.groupby("symbol")["net_pnl"]
         avg_pnl = grouped.mean()


### PR DESCRIPTION
## Summary
- correct the indentation of the symbol performance block in the trade dashboard
- keep existing trade P/L aggregation and visualization intact

## Testing
- python -m py_compile dashboards/dashboard_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ef20de1c8331ba7be1b474ecfdcc)