### PR TITLE
Ensure WSGI loads env config

### DIFF
--- a/raspatrick_pythonanywhere_com_wsgi.py
+++ b/raspatrick_pythonanywhere_com_wsgi.py
@@ -7,16 +7,38 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
-
 
 ROOT = Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-env_path = ROOT / ".env"
+PROJECT_HOME = Path("/home/RasPatrick/jbravo_screener")
+os.environ.setdefault("PROJECT_HOME", str(PROJECT_HOME))
+if str(PROJECT_HOME) not in sys.path:
+    sys.path.insert(0, str(PROJECT_HOME))
+
+env_path = Path.home() / ".config" / "jbravo" / ".env"
 if env_path.exists():
-    load_dotenv(env_path)
+    try:
+        with env_path.open("r", encoding="utf-8") as env_file:
+            for raw_line in env_file:
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                if key and key not in os.environ:
+                    os.environ.setdefault(key, value)
+    except OSError:
+        pass
+
+print(
+    "WSGI_ENV_LOADED",
+    str(env_path),
+    "DATABASE_URL_SET",
+    bool(os.getenv("DATABASE_URL")),
+)
 
 os.environ.setdefault("JBRAVO_HOME", str(ROOT))
 


### PR DESCRIPTION
## Summary
- load ~/.config/jbravo/.env into the WSGI environment before initializing the Dash app
- set PROJECT_HOME and sys.path for the deployed project root
- add a debug-safe print confirming environment loading and database URL presence

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958573a26808331853768182ef82619)