### PR TITLE
Simplify premarket wrapper pipeline gate to only check PIPELINE_END rc=0

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -24,7 +24,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 PIPELINE_LOG="logs/pipeline.log"
-if ! [ -f "$PIPELINE_LOG" ] || ! grep -q "PIPELINE_END rc=0" "$PIPELINE_LOG"; then
+if ! grep -q "PIPELINE_END rc=0" "$PIPELINE_LOG"; then
   echo "[WARN] PIPELINE_MISSING — executor skipped"
   python - <<'PY'
 import json


### PR DESCRIPTION
### Motivation
- Ensure the premarket wrapper no longer gates execution on the presence of the pipeline log file and instead only verifies the canonical success marker `PIPELINE_END rc=0`.

### Description
- Replace the conditional that checked file existence and grepped the log with a single `grep -q "PIPELINE_END rc=0"` check so the wrapper only looks for the success marker while preserving the existing skip behavior that writes `data/last_premarket_run.json` and touches the WSGI file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fde1bdbd48331b9f0b89de633ea36)