### PR TITLE
Set alloc-weight-key=score in premarket wrapper

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -204,13 +204,15 @@ fi
 
 python -m scripts.execute_trades \
   --source db \
+  --time-window auto \
+  --extended-hours true \
+  --alloc-weight-key score \
   --allocation-pct 0.06 \
   --min-order-usd 300 \
   --max-positions 4 \
   --trailing-percent 3 \
   --limit-buffer-pct 1.0 \
-  --extended-hours true \
-  --time-window premarket
+  --cancel-after-min 35
 
 PREMARKET_FINISHED_UTC=$(python - <<'PY'
 from datetime import datetime, timezone


### PR DESCRIPTION
### Motivation
- Ensure the executor invocation always uses the screener `score` column as the allocation weight when running trade execution. 
- Make the wrapper consistently run the executor with `--source db`, `--time-window auto`, and `--extended-hours true` by default.

### Description
- Updated `bin/run_premarket_once.sh` to add `--time-window auto`, `--extended-hours true`, and `--alloc-weight-key score` to the `python -m scripts.execute_trades` invocation. 
- Added `--cancel-after-min 35` to the invocation and preserved existing flags including `--source db`, `--allocation-pct 0.06`, `--min-order-usd 300`, `--max-positions 4`, `--trailing-percent 3`, and `--limit-buffer-pct 1.0`. 
- Retained all environment loading, virtualenv activation, Alpaca probe, logging, and snapshotting behavior present in the wrapper.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711cc6334c8331ad6c623e58b5a744)