### PR TITLE
Update premarket wrapper env setup and enforce alloc-weight-key

### DIFF
--- a/bin/run_premarket_once.sh
+++ b/bin/run_premarket_once.sh
@@ -5,8 +5,26 @@ export TZ="America/New_York"
 PROJECT="${PROJECT:-/home/RasPatrick/jbravo_screener}"
 VENV="${VENV:-/home/RasPatrick/.virtualenvs/jbravo-env}"
 cd "$PROJECT"
+
+unset \
+  APCA_API_KEY_ID \
+  APCA_API_SECRET_KEY \
+  APCA_API_BASE_URL \
+  APCA_DATA_API_BASE_URL \
+  APCA_API_DATA_URL \
+  ALPACA_API_KEY_ID \
+  ALPACA_API_SECRET_KEY \
+  ALPACA_API_BASE_URL \
+  ALPACA_API_DATA_URL
+
+set -a; . "$PROJECT/.env"; set +a
+
+export APCA_API_KEY_ID="${APCA_API_KEY_ID:-${ALPACA_API_KEY_ID:-}}"
+export APCA_API_SECRET_KEY="${APCA_API_SECRET_KEY:-${ALPACA_API_SECRET_KEY:-}}"
+export APCA_API_BASE_URL="${APCA_API_BASE_URL:-https://paper-api.alpaca.markets}"
+export APCA_DATA_API_BASE_URL="${APCA_DATA_API_BASE_URL:-https://data.alpaca.markets}"
+
 source "$VENV/bin/activate"
-set -a; . ~/.config/jbravo/.env; set +a
 
 DRY_RUN="${JBRAVO_DRY_RUN:-false}"
 


### PR DESCRIPTION
### Motivation
- Ensure the executor always runs against paper Alpaca credentials loaded from the project `.env` and that previous Alpaca/Alpaca-compatible env vars are cleared to avoid accidental use of wrong credentials.
- Make the wrapper export stable `APCA_*` variables (falling back to any `ALPACA_*` aliases) and set sane defaults for paper endpoints so the executor runs consistently.
- Guarantee the executor invocation uses allocation by `score` every run while preserving the existing execution flags and behavior.

### Description
- Reset a set of Alpaca-related environment variables with `unset` at the top of `bin/run_premarket_once.sh` and then load the project `.env` via `set -a; . "$PROJECT/.env"; set +a`.
- Export `APCA_API_KEY_ID`, `APCA_API_SECRET_KEY`, `APCA_API_BASE_URL`, and `APCA_DATA_API_BASE_URL` with fallbacks to `ALPACA_*` aliases and defaults for paper/data endpoints.
- Moved `.env` loading and explicit `APCA_*` exports to occur before activating the Python virtualenv and kept the `python -m scripts.execute_trades` invocation unchanged but confirmed inclusion of `--alloc-weight-key score` and the other specified flags.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697120507ee083319e91a6b3b429a0ec)