### PR TITLE
Set Vite base to root so assets are served from /assets

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>JBRAVO Dashboard</title>
-    <script type="module" crossorigin src="/ui-assets/assets/index-AZtr3CFs.js"></script>
-    <link rel="stylesheet" crossorigin href="/ui-assets/assets/index-DdjcmU9U.css">
+    <script type="module" crossorigin src="/assets/index-AZtr3CFs.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DdjcmU9U.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 export default defineConfig({
-    base: "/ui-assets/",
+    base: "/",
     plugins: [react()],
     build: {
         outDir: "dist",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  base: "/ui-assets/",
+  base: "/",
   plugins: [react()],
   build: {
     outDir: "dist",


### PR DESCRIPTION
### Motivation
- The frontend was built with a `base` of `/ui-assets/` so `index.html` referenced `/ui-assets/assets/*`, which prevents assets from loading at the site root.
- The goal is to serve all JS/CSS from `/assets/*` and deploy the app at the domain root without WSGI routing workarounds.

### Description
- Toolchain detected: Vite (checked `frontend/package.json` scripts using `vite`).
- Changed Vite config `base` from `"/ui-assets/"` → `"/"` in `frontend/vite.config.ts` and `frontend/vite.config.js` so built asset URLs are root-based.
- Rebuilt the frontend so `frontend/dist/index.html` now references assets as `/assets/...` and the build output is placed in `frontend/dist` with an `assets/` subdirectory.

### Testing
- Ran `npm install` in `frontend/` which completed successfully.
- Ran `npm run build` in `frontend/` which initially errored with a permission problem but after making the local `vite` binary executable the build completed successfully and produced `frontend/dist/index.html` referencing `/assets/*`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69718f3c00f083318426d3e3cb026e89)