### PR TITLE
Refactor metrics to persist to DB only (remove CSV outputs)

### DIFF
--- a/scripts/db.py
+++ b/scripts/db.py
@@ -1354,7 +1354,12 @@ def fetch_latest_backtest_results(
             pass
 
 
-def upsert_metrics_daily(run_date: Any, summary_metrics_dict: Mapping[str, Any] | None) -> None:
+def upsert_metrics_daily(
+    run_date: Any | Mapping[str, Any],
+    summary_metrics_dict: Mapping[str, Any] | Any | None = None,
+) -> None:
+    if isinstance(run_date, Mapping) and summary_metrics_dict is not None:
+        run_date, summary_metrics_dict = summary_metrics_dict, run_date
     if not summary_metrics_dict:
         return
     conn = _conn_or_none()
@@ -1405,6 +1410,10 @@ def upsert_metrics_daily(run_date: Any, summary_metrics_dict: Mapping[str, Any] 
             conn.close()
         except Exception:
             pass
+
+
+def insert_top_candidates(df_candidates: pd.DataFrame | None, run_date: Any) -> bool:
+    return upsert_top_candidates(run_date, df_candidates, replace_for_run_date=True)
 
 
 def ensure_top_candidates_table() -> None:


### PR DESCRIPTION
### Motivation
- Remove local CSV artifacts and persist screener top candidates and daily metrics exclusively to PostgreSQL using existing DB helpers.
- Ensure pipeline exits or logs clearly when the DB is not enabled and surface DB write failures without crashing the pipeline.

### Description
- In `scripts/metrics.py` removed CSV output logic and related helpers and imports, and replaced CSV writes with DB calls to `db.insert_top_candidates(ranked_df, run_date)` and `db.upsert_metrics_daily(summary_metrics, run_date)` while updating logs to report rows written (e.g. `[INFO] DB_TOP_CANDIDATES rows=N`).
- Added guards to check `db.db_enabled()` early and return gracefully when the DB is disabled, and changed behavior to log DB write failures as `[ERROR] METRICS_DB_WRITE_FAILED ...` instead of crashing or falling back to file I/O.
- In `scripts/db.py` updated `upsert_metrics_daily` to accept either argument order and added a convenience `insert_top_candidates` wrapper that calls `upsert_top_candidates(..., replace_for_run_date=True)` to support the new call pattern from `metrics.py`.
- Tightened defensive error handling around DB operations so exceptions are logged and the metrics step continues or exits gracefully as appropriate.

### Testing
- No automated tests were executed for this change (no test run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69723c9c86a88331abbbd244fdf541ba)