### PR TITLE
Add DB write diagnostic logging to metrics.py

### DIFF
--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -451,6 +451,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             results_df = symbol_metrics
 
     ranked_df = rank_candidates(results_df)
+    logger.info("[DEBUG] Ranked candidates dataframe shape: %s", ranked_df.shape)
+    logger.info("[DEBUG] Ranked candidates columns: %s", list(ranked_df.columns))
     logger.info(
         "Screener Metrics Summary: total_candidates=%s, avg_score=%.2f",
         len(ranked_df),
@@ -488,54 +490,67 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         if "exit_reason" in trades_df.columns:
             logger.info("Exit reason breakdown skipped: DB is source of truth.")
 
-    try:
-        screener_fields = db.fetch_screener_candidates_for_run_date(run_date)
-        if not screener_fields.empty and "symbol" in screener_fields.columns:
-            screener_fields["symbol"] = (
-                screener_fields["symbol"].astype(str).str.upper()
-            )
-            ranked_df["symbol"] = ranked_df["symbol"].astype(str).str.upper()
-            before_rows = int(ranked_df.shape[0])
-            merged = ranked_df.merge(
-                screener_fields,
-                on="symbol",
-                how="inner",
-                suffixes=("", "_sc"),
-            )
-            dropped = before_rows - int(merged.shape[0])
-            if dropped:
-                logger.warning(
-                    "[WARN] METRICS_TOP_CANDIDATES_FILTERED dropped=%s remaining=%s",
-                    dropped,
-                    int(merged.shape[0]),
+    if ranked_df.empty:
+        logger.warning("[WARN] No candidates ranked — skipping DB writes")
+    else:
+        try:
+            screener_fields = db.fetch_screener_candidates_for_run_date(run_date)
+            if not screener_fields.empty and "symbol" in screener_fields.columns:
+                screener_fields["symbol"] = (
+                    screener_fields["symbol"].astype(str).str.upper()
                 )
-            for col in ("entry_price", "adv20", "atrp", "exchange", "source"):
-                sc_col = f"{col}_sc"
-                if sc_col in merged.columns:
-                    merged[col] = merged[sc_col]
-                    merged.drop(columns=[sc_col], inplace=True)
-            ranked_df = merged
-        else:
-            logger.warning(
-                "[WARN] METRICS_TOP_CANDIDATES_FILTERED reason=screener_empty run_date=%s",
-                run_date,
+                ranked_df["symbol"] = ranked_df["symbol"].astype(str).str.upper()
+                before_rows = int(ranked_df.shape[0])
+                merged = ranked_df.merge(
+                    screener_fields,
+                    on="symbol",
+                    how="inner",
+                    suffixes=("", "_sc"),
+                )
+                dropped = before_rows - int(merged.shape[0])
+                if dropped:
+                    logger.warning(
+                        "[WARN] METRICS_TOP_CANDIDATES_FILTERED dropped=%s remaining=%s",
+                        dropped,
+                        int(merged.shape[0]),
+                    )
+                for col in ("entry_price", "adv20", "atrp", "exchange", "source"):
+                    sc_col = f"{col}_sc"
+                    if sc_col in merged.columns:
+                        merged[col] = merged[sc_col]
+                        merged.drop(columns=[sc_col], inplace=True)
+                ranked_df = merged
+            else:
+                logger.warning(
+                    "[WARN] METRICS_TOP_CANDIDATES_FILTERED reason=screener_empty run_date=%s",
+                    run_date,
+                )
+                ranked_df = ranked_df.iloc[0:0].copy()
+            logger.info(
+                "[DEBUG] Writing top candidates to DB: %s rows", len(ranked_df)
             )
-            ranked_df = ranked_df.iloc[0:0].copy()
-        if db.insert_top_candidates(ranked_df, run_date):
-            logger.info("[INFO] DB_TOP_CANDIDATES rows=%s", len(ranked_df.index))
-    except Exception as exc:  # pragma: no cover - defensive guard
-        logger.error("[ERROR] METRICS_DB_WRITE_FAILED table=top_candidates err=%s", exc)
+            if db.insert_top_candidates(ranked_df, run_date):
+                logger.info("[INFO] DB_TOP_CANDIDATES rows=%s", len(ranked_df.index))
+                logger.info(
+                    "[INFO] DB write to top_candidates completed successfully"
+                )
+        except Exception:  # pragma: no cover - defensive guard
+            logger.exception("[ERROR] Failed to write to top_candidates")
 
-    try:
-        db.upsert_metrics_daily(summary_metrics, run_date)
-        logger.info(
-            "[INFO] METRICS_DB_OK run_date=%s total_trades=%s net_pnl=%s",
-            run_date,
-            summary_metrics.get("total_trades"),
-            summary_metrics.get("net_pnl"),
-        )
-    except Exception as exc:  # pragma: no cover - defensive guard
-        logger.error("[ERROR] METRICS_DB_WRITE_FAILED table=metrics_daily err=%s", exc)
+        try:
+            logger.info(
+                "[DEBUG] Writing summary metrics to DB: %s", summary_metrics
+            )
+            db.upsert_metrics_daily(summary_metrics, run_date)
+            logger.info(
+                "[INFO] METRICS_DB_OK run_date=%s total_trades=%s net_pnl=%s",
+                run_date,
+                summary_metrics.get("total_trades"),
+                summary_metrics.get("net_pnl"),
+            )
+            logger.info("[INFO] DB write to metrics_daily completed successfully")
+        except Exception:  # pragma: no cover - defensive guard
+            logger.exception("[ERROR] Failed to write to metrics_daily")
 
     metrics_path = Path(BASE_DIR) / "data" / "screener_metrics.json"
     metrics: dict = {}


### PR DESCRIPTION
### Motivation
- Investigate why `top_candidates` and `metrics_daily` rows were not being written to PostgreSQL despite successful pipeline exit codes.
- Ensure the metrics step emits clear telemetry about the ranked candidates dataframe and DB write attempts.
- Capture exceptions with tracebacks to make DB write failures visible in logs.

### Description
- Log `ranked_df` shape and columns immediately after calling `rank_candidates` using `logger.info` to surface dataframe structure.
- Skip DB writes and emit a warning when `ranked_df` is empty by adding an early `if ranked_df.empty` guard.
- Emit debug logs immediately before calling `db.insert_top_candidates` and `db.upsert_metrics_daily` that show the number of rows and the `summary_metrics` payload respectively.
- Replace prior broad `except` logging with `logger.exception` for `top_candidates` and `metrics_daily` writes and add explicit success `logger.info` messages after successful writes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724eb0b2c883319f5f0d9674df5fc2)