### PR TITLE
Ensure `main()` is invoked from metrics module entrypoint

### DIFF
--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -637,7 +637,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
 
 if __name__ == "__main__":
     logger.info("Starting metrics calculation")
-    exit_code = main(sys.argv[1:])
+    exit_code = main()
     logger.info("Metrics calculation complete")
     end_time = datetime.utcnow()
     elapsed_time = end_time - start_time


### PR DESCRIPTION
### Motivation
- Ensure the `main()` function in `scripts/metrics.py` is actually executed when the module is run so the logging, ranking, and DB write logic inside `main()` runs (avoid mismatch from passing `sys.argv[1:]`).

### Description
- Update the module entrypoint to call `main()` directly (`if __name__ == "__main__": exit_code = main()`) in `scripts/metrics.py` so the script uses its default argument handling and reliably executes the metrics pipeline.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697290b5d8ec8331baef0933ebecb622)