### PR TITLE
Call metrics main unconditionally

### DIFF
--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -635,11 +635,4 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     logger.info("[INFO] metrics.py completed successfully")
     return exit_code
 
-if __name__ == "__main__":
-    logger.info("Starting metrics calculation")
-    exit_code = main()
-    logger.info("Metrics calculation complete")
-    end_time = datetime.utcnow()
-    elapsed_time = end_time - start_time
-    logger.info("Script finished in %s", elapsed_time)
-    sys.exit(exit_code)
+main()


### PR DESCRIPTION
### Motivation
- Ensure the `main()` function in `scripts/metrics.py` always executes when the module is invoked (for example via `python -m scripts.metrics --run-date YYYY-MM-DD`) so pipeline diagnostics and metric writes occur as expected.

### Description
- Remove the `if __name__ == "__main__":` guard and call `main()` unconditionally at the end of `scripts/metrics.py`, keeping all `print(...)` and `logger.info(...)` diagnostics inside `main()` unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729925a0c48331a8b99502abdfbd8f)